### PR TITLE
Fix clone/create schema dataType serialization by normalizing to serv…

### DIFF
--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -1721,12 +1721,19 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
      * @returns The formatted schema ready for API consumption
      */
     private convertSchemaToApiFormat(schema: any): any {
-        const fixed_properties = schema.properties?.map((prop: any) => ({
-            ...prop,
-            dataType: Array.isArray(prop.dataType) ? prop.dataType : [prop.dataType],
-            tokenization: prop.tokenization === 'none' ? undefined : prop.tokenization,
-            indexSearchable: prop.indexInverted,
-        })) || [];
+        const fixed_properties = schema.properties?.map((prop: any) => {
+            // Normalize dataType to the v2 string format (not array)
+            let dt = prop?.dataType;
+            if (Array.isArray(dt)) {
+                dt = dt[0];
+            }
+            return {
+                ...prop,
+                dataType: dt,
+                tokenization: prop.tokenization === 'none' ? undefined : prop.tokenization,
+                indexSearchable: prop.indexInverted,
+            };
+        }) || [];
                 
         const fixed_vectorizers = schema.vectorizers ? Object.fromEntries(
             Object.entries(schema.vectorizers).map(([key, vec]: [string, any]) => {
@@ -2017,11 +2024,27 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
             throw new Error('Collection name is required');
         }
         
+        // Determine server major version to pick schema format (v1 vs v2)
+        const serverVersion = this.clusterMetadataCache[connectionId]?.version || '';
+        const serverMajor = parseInt((serverVersion.split('.')[0] || '0'), 10);
+        const useV2Types = serverMajor >= 2; // v2 uses string dataType; v1 uses string[]
+
         // Build schema object
         const schemaObject = {
             class: schema.class,
             description: schema.description || undefined,
-            properties: schema.properties || []  // Include properties from the form
+            properties: (schema.properties || []).map((p: any) => {
+                // Normalize incoming dataType to canonical string with [] suffix for arrays
+                let dt: any = p?.dataType;
+                if (Array.isArray(dt)) {
+                    dt = dt[0];
+                }
+                // Ensure string
+                dt = String(dt);
+                // For v1, wrap in array; for v2, keep as string
+                const normalizedDt = useV2Types ? dt : [dt];
+                return { ...p, dataType: normalizedDt };
+            })  // Include properties from the form
         } as any;
         
         // Handle vectorConfig (new multi-vectorizer format)
@@ -2983,10 +3006,40 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
                             }
                         }
                         
-                        // Properties
+                        // Properties: normalize incoming schema to editing model
                         if (schema.properties && Array.isArray(schema.properties)) {
-                            properties = [...schema.properties];
-                            propertyCounter = properties.length;
+                            const builtinTypes = new Set(['text', 'string', 'int', 'number', 'boolean', 'date', 'geoCoordinates', 'phoneNumber', 'blob', 'object', 'uuid']);
+                            properties = schema.properties.map((p, idx) => {
+                                let dt = p?.dataType;
+                                if (Array.isArray(dt)) {
+                                    dt = dt[0];
+                                }
+                                dt = dt || '';
+                                let isArray = false;
+                                if (typeof dt === 'string' && dt.endsWith('[]')) {
+                                    isArray = true;
+                                    dt = dt.slice(0, -2);
+                                }
+                                let dataType = dt;
+                                let targetCollection = '';
+                                if (!builtinTypes.has(dt)) {
+                                    // Treat as reference
+                                    targetCollection = dt;
+                                    dataType = 'reference';
+                                }
+                                return {
+                                    id: 'prop_' + (++propertyCounter),
+                                    name: p.name || '',
+                                    dataType: dataType || 'text',
+                                    isArray: !!isArray,
+                                    targetCollection: targetCollection || undefined,
+                                    description: p.description || '',
+                                    tokenization: p.tokenization || '',
+                                    indexFilterable: typeof p.indexFilterable === 'boolean' ? p.indexFilterable : true,
+                                    indexSearchable: typeof p.indexSearchable === 'boolean' ? p.indexSearchable : true,
+                                    indexRangeFilters: typeof p.indexRangeFilters === 'boolean' ? p.indexRangeFilters : false
+                                };
+                            });
                             renderProperties();
                         }
                         
@@ -3682,9 +3735,15 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
                             properties: properties.map(function(prop) {
                                 const propSchema = {
                                     name: prop.name.trim(),
-                                    dataType: prop.dataType === 'reference' && prop.targetCollection
-                                        ? [prop.targetCollection]
-                                        : (prop.isArray ? [prop.dataType + '[]'] : [prop.dataType]),
+                                    dataType: (function () {
+                                        let dt = (prop.dataType === 'reference' && prop.targetCollection)
+                                            ? prop.targetCollection
+                                            : prop.dataType;
+                                        if (prop.isArray) {
+                                            dt = dt + '[]';
+                                        }
+                                        return dt;
+                                    })(),
                                     description: prop.description ? prop.description.trim() : undefined
                                 };
 
@@ -3779,12 +3838,18 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
                             class: collectionName || 'collectionName',
                             description: descriptionVal || undefined,
                             properties: properties.map(function(prop) {
-                                const dataType = prop.dataType === 'reference' && prop.targetCollection
-                                    ? [prop.targetCollection]
-                                    : (prop.isArray ? [prop.dataType + '[]'] : [prop.dataType]);
+                                const dt = (function () {
+                                    let t = (prop.dataType === 'reference' && prop.targetCollection)
+                                        ? prop.targetCollection
+                                        : prop.dataType;
+                                    if (prop.isArray) {
+                                        t = t + '[]';
+                                    }
+                                    return t;
+                                })();
                                 const propObj = {
                                     name: prop.name.trim() || 'propertyName',
-                                    dataType: dataType,
+                                    dataType: dt,
                                     description: prop.description ? prop.description.trim() : undefined
                                 };
 

--- a/src/views/ViewRenderer.ts
+++ b/src/views/ViewRenderer.ts
@@ -948,12 +948,15 @@ client.collections.createFromSchema(schema)`;
     private convertToApiFormat(schema: any): any {
         // Remove internal fields and format for API
         // if tokenization for "none", make undefined
-        const fixed_properties = schema.properties?.map((prop: { dataType: string[]; tokenization?: string, indexInverted?: string }) => ({
-            ...prop,
-            dataType: [prop.dataType],
-            tokenization: prop.tokenization === 'none' ? undefined : prop.tokenization,
-            indexSearchable: prop.indexInverted,
-        })) || [];
+        const fixed_properties = schema.properties?.map((prop: { dataType: string | string[]; tokenization?: string, indexInverted?: string }) => {
+            const dt = Array.isArray(prop.dataType) ? prop.dataType[0] : prop.dataType;
+            return {
+                ...prop,
+                dataType: dt,
+                tokenization: prop.tokenization === 'none' ? undefined : prop.tokenization,
+                indexSearchable: prop.indexInverted,
+            };
+        }) || [];
         const apiSchema = { 
             ...schema, 
             class: schema.name, 


### PR DESCRIPTION
- Normalize dataType to string for v2, array for v1
- Convert cloned schema properties into editable model
- Ensure create path coerces incoming formats
- Update preview/generators to match
- Fixes #19