### PR TITLE
fix: Handle null descriptions in tree view

### DIFF
--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -702,7 +702,7 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
           prop.name,
           icon,
           'weaviateProperty',
-          description.trim()
+          description?.trim() ?? ''
         );
       });
 

--- a/src/WeaviateTreeDataProvider/__tests__/WeaviateTreeDataProvider.test.ts
+++ b/src/WeaviateTreeDataProvider/__tests__/WeaviateTreeDataProvider.test.ts
@@ -131,6 +131,57 @@ describe('WeaviateTreeDataProvider', () => {
     expect(connected.contextValue).toBe('weaviateConnectionActive');
   });
 
+  describe('getChildren for properties', () => {
+    it('should handle null, undefined, and valid descriptions for properties', async () => {
+      // 1. Setup mock data
+      const connectionId = '2'; // 'Prod' connection is 'connected'
+      const collectionName = 'TestCollection';
+      const mockCollection = {
+        label: collectionName,
+        itemType: 'collection',
+        connectionId: connectionId,
+        collectionName: collectionName,
+        schema: {
+          class: collectionName,
+          properties: [
+            { name: 'propWithDesc', dataType: ['string'], description: 'This is a description.' },
+            { name: 'propWithNullDesc', dataType: ['int'], description: null },
+            { name: 'propWithUndefinedDesc', dataType: ['boolean'] },
+            { name: 'propToTrim', dataType: ['text'], description: '  needs trimming  ' },
+          ],
+        },
+      };
+
+      (provider as any).collections[connectionId] = [mockCollection];
+
+      // 2. Define the parent element for which we want children
+      const propertiesElement = {
+        itemType: 'properties',
+        connectionId: connectionId,
+        collectionName: collectionName,
+        label: 'Properties (4)',
+      };
+
+      // 3. Call getChildren
+      const propertyItems = await provider.getChildren(propertiesElement as any);
+
+      // 4. Assertions
+      expect(propertyItems).toHaveLength(4);
+
+      const desc1 = propertyItems.find((p: any) => p.itemId === 'propWithDesc')?.description;
+      const desc2 = propertyItems.find((p: any) => p.itemId === 'propWithNullDesc')?.description;
+      const desc3 = propertyItems.find(
+        (p: any) => p.itemId === 'propWithUndefinedDesc'
+      )?.description;
+      const desc4 = propertyItems.find((p: any) => p.itemId === 'propToTrim')?.description;
+
+      expect(desc1).toBe('This is a description.');
+      expect(desc2).toBe('');
+      expect(desc3).toBe('');
+      expect(desc4).toBe('needs trimming');
+    });
+  });
+
   describe('deleteAllCollections', () => {
     let provider: WeaviateTreeDataProvider;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -175,7 +175,7 @@ export class WeaviateTreeItem extends vscode.TreeItem {
       }
     }
 
-    if (description) {
+    if (description !== null && description !== undefined) {
       // @ts-ignore - We're setting a read-only property here
       this.description = description;
     }


### PR DESCRIPTION
This commit fixes an issue where properties with null or undefined descriptions would cause a crash or display "undefined" in the tree view.

- The WeaviateTreeDataProvider now correctly handles nullish descriptions, defaulting to an empty string.
- The WeaviateTreeItem constructor is updated to correctly handle empty string descriptions.
- Adds a test case to cover null and undefined descriptions to prevent future regressions.

Fixes #33