### PR TITLE
Add 3 Collection Schemas Check, other improvements to Cluster Panel UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 firebase-debug.log
 .env
 .serena
+.claude

--- a/example-local.weaviate
+++ b/example-local.weaviate
@@ -8,6 +8,7 @@
   "grpcPort": 50051,
   "grpcSecure": false,
   "connectionVersion": "2",
+  "readOnly": true,
   "links": [
     {
       "name": "Weaviate Docs",

--- a/package.json
+++ b/package.json
@@ -648,17 +648,17 @@
         },
         {
           "command": "weaviate.refreshCollections",
-          "when": "view == weaviateConnectionsView && (viewItem == weaviateCollectionsGroup || viewItem == weaviateCollectionsGroupMtWarning)",
+          "when": "view == weaviateConnectionsView && viewItem =~ /^weaviateCollectionsGroup/",
           "group": "navigation@1"
         },
         {
           "command": "weaviate.refreshCollections",
-          "when": "view == weaviateConnectionsView && (viewItem == weaviateCollectionsGroup || viewItem == weaviateCollectionsGroupMtWarning)",
+          "when": "view == weaviateConnectionsView && viewItem =~ /^weaviateCollectionsGroup/",
           "group": "inline@2"
         },
         {
           "command": "weaviate.openMtChecks",
-          "when": "view == weaviateConnectionsView && (viewItem == weaviateCollectionsGroup || viewItem == weaviateCollectionsGroupMtWarning)",
+          "when": "view == weaviateConnectionsView && viewItem =~ /^weaviateCollectionsGroup/",
           "group": "navigation@2"
         },
         {
@@ -717,13 +717,13 @@
         },
         {
           "command": "weaviate.addCollection",
-          "when": "view == weaviateConnectionsView && viewItem == weaviateCollectionsGroup",
+          "when": "view == weaviateConnectionsView && viewItem =~ /^weaviateCollectionsGroup/",
           "group": "inline@1",
           "icon": "$(add)"
         },
         {
           "command": "weaviate.deleteAllCollections",
-          "when": "view == weaviateConnectionsView && viewItem == weaviateCollectionsGroup",
+          "when": "view == weaviateConnectionsView && viewItem =~ /^weaviateCollectionsGroup/",
           "group": "3_modification@1"
         },
         {

--- a/package.json
+++ b/package.json
@@ -327,6 +327,12 @@
         "icon": "$(dashboard)"
       },
       {
+        "command": "weaviate.openMtChecks",
+        "title": "Open Checks",
+        "category": "Weaviate",
+        "icon": "$(checklist)"
+      },
+      {
         "command": "weaviate.openRagChat",
         "title": "Generative Search",
         "category": "Weaviate",
@@ -642,13 +648,23 @@
         },
         {
           "command": "weaviate.refreshCollections",
-          "when": "view == weaviateConnectionsView && viewItem == weaviateCollectionsGroup",
+          "when": "view == weaviateConnectionsView && (viewItem == weaviateCollectionsGroup || viewItem == weaviateCollectionsGroupMtWarning)",
           "group": "navigation@1"
         },
         {
           "command": "weaviate.refreshCollections",
-          "when": "view == weaviateConnectionsView && viewItem == weaviateCollectionsGroup",
+          "when": "view == weaviateConnectionsView && (viewItem == weaviateCollectionsGroup || viewItem == weaviateCollectionsGroupMtWarning)",
           "group": "inline@2"
+        },
+        {
+          "command": "weaviate.openMtChecks",
+          "when": "view == weaviateConnectionsView && (viewItem == weaviateCollectionsGroup || viewItem == weaviateCollectionsGroupMtWarning)",
+          "group": "navigation@2"
+        },
+        {
+          "command": "weaviate.openMtChecks",
+          "when": "view == weaviateConnectionsView && viewItem == weaviateCollectionsGroupMtWarning",
+          "group": "inline@1"
         },
         {
           "command": "weaviate.refreshNodes",

--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -418,6 +418,9 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
         mtCount > 0
           ? 'Some collections share identical schemas — they could use Multi-Tenancy'
           : 'Collections in this instance';
+      // Use a distinct contextValue when there's an MT warning so we can show the inline button
+      element.contextValue =
+        mtCount > 0 ? 'weaviateCollectionsGroupMtWarning' : 'weaviateCollectionsGroup';
     } else if (element.itemType === 'backups') {
       if (!element.iconPath) {
         element.iconPath = new vscode.ThemeIcon('archive');
@@ -1254,18 +1257,23 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       }
 
       // Add cluster nodes section
+      const cachedNodes = this.clusterNodesCache[element.connectionId];
+      const nodesLoading = cachedNodes === undefined;
       const stats = this.clusterStatisticsCache[element.connectionId];
-      let nodes_synchronized = stats?.synchronized ? 'Synchronized' : 'Not Synchronized';
-      let nodes_count = this.clusterNodesCache[element.connectionId]?.length;
+      const nodesLabel = nodesLoading
+        ? 'Loading nodes…'
+        : `${cachedNodes.length} Node${cachedNodes.length === 1 ? '' : 's'} ${stats?.synchronized ? 'Synchronized' : 'Not Synchronized'}`;
       items.push(
         new WeaviateTreeItem(
-          `${nodes_count || 0} Node${nodes_count === 1 ? '' : 's'} ${nodes_synchronized}`,
+          nodesLabel,
           vscode.TreeItemCollapsibleState.Expanded,
           'clusterNodes',
           element.connectionId,
           undefined,
           'clusterNodes',
-          new vscode.ThemeIcon('terminal-ubuntu'),
+          nodesLoading
+            ? new vscode.ThemeIcon('loading~spin')
+            : new vscode.ThemeIcon('terminal-ubuntu'),
           'weaviateClusterNodes'
         )
       );
@@ -3227,8 +3235,10 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
     const connection = this.connections.find((c) => c.id === connectionId);
     if (connection) {
       await this.connectionManager.disconnect(connectionId);
-      // Clear collections for this connection
+      // Clear collections and cached cluster data for this connection
       delete this.collections[connectionId];
+      delete this.clusterNodesCache[connectionId];
+      delete this.clusterStatisticsCache[connectionId];
       // Close cluster panel if it's open for this connection
       ClusterPanel.closeForConnection(connectionId);
       // Refresh connections and update tree view

--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -4356,8 +4356,9 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
    */
   private async updateClusterPanelIfOpen(connectionId: string): Promise<void> {
     try {
-      // Check if cluster panel is open
-      if (!ClusterPanel.currentPanel) {
+      // Check if cluster panel is open for this connection
+      const clusterPanel = ClusterPanel.getPanel(connectionId);
+      if (!clusterPanel) {
         return;
       }
 
@@ -4374,7 +4375,7 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       const connection = this.connectionManager.getConnection(connectionId);
 
       // Send update to the panel
-      ClusterPanel.currentPanel.postMessage({
+      clusterPanel.postMessage({
         command: 'updateData',
         nodeStatusData: nodeStatusData,
         openClusterViewOnConnect: connection?.openClusterViewOnConnect,

--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -19,6 +19,12 @@ import * as https from 'https';
 import * as http from 'http';
 import { WEAVIATE_INTEGRATION_HEADER } from '../constants';
 import { getTelemetryService, TELEMETRY_EVENTS } from '../telemetry';
+import {
+  findMultiTenantCandidates,
+  computeCandidatesDismissKey,
+  MtCandidateGroup,
+  ChecksResult,
+} from '../utils/multiTenancyCheck';
 
 /**
  * Provides data for the Weaviate Explorer tree view, displaying connections,
@@ -97,6 +103,9 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
 
   /** Cache of aliases per connection */
   private aliasesCache: Record<string, AliasItem[]> = {};
+
+  /** MT candidate groups per connection, sorted by totalObjects descending. */
+  private mtCandidates: Record<string, MtCandidateGroup[]> = {};
 
   /** VS Code extension context */
   private readonly context: vscode.ExtensionContext;
@@ -395,10 +404,20 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       }
       element.tooltip = 'Available Weaviate modules';
     } else if (element.itemType === 'collectionsGroup') {
-      if (!element.iconPath) {
-        element.iconPath = new vscode.ThemeIcon('database');
-      }
-      element.tooltip = 'Collections in this instance';
+      const mtCount = element.connectionId
+        ? (this.mtCandidates[element.connectionId]?.length ?? 0)
+        : 0;
+      element.iconPath =
+        mtCount > 0
+          ? new vscode.ThemeIcon('warning', new vscode.ThemeColor('list.warningForeground'))
+          : new vscode.ThemeIcon('database');
+      // @ts-ignore — description is read-only on TreeItem but safe to set here
+      element.description =
+        mtCount > 0 ? `⚠ ${mtCount} MT candidate${mtCount > 1 ? 's' : ''}` : undefined;
+      element.tooltip =
+        mtCount > 0
+          ? 'Some collections share identical schemas — they could use Multi-Tenancy'
+          : 'Collections in this instance';
     } else if (element.itemType === 'backups') {
       if (!element.iconPath) {
         element.iconPath = new vscode.ThemeIcon('archive');
@@ -3412,13 +3431,123 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
         this.collections[connectionId] = [];
       }
 
+      // Compute MT candidates before refresh so badges render immediately
+      const objectCounts = this._getObjectCountsFromNodes(connectionId);
+      const candidates = findMultiTenantCandidates(this.collections[connectionId], objectCounts);
+      this.mtCandidates[connectionId] = candidates;
+
       // Refresh the tree view
       this.refresh();
+
+      // Show notification async — fire and forget so it does not block the tree
+      if (candidates.length > 0) {
+        this._notifyMtCandidates(connectionId, candidates).catch(console.error);
+      }
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       console.error('Error in fetchCollectionsData:', error);
       vscode.window.showErrorMessage(`Failed to fetch collections: ${errorMessage}`);
     }
+  }
+
+  /**
+   * Shows a warning notification when collections share identical schemas.
+   * Respects the per-connection dismiss state stored in globalState.
+   * If the user clicks Update, the dismiss state is cleared and collections are re-fetched.
+   */
+  private async _notifyMtCandidates(
+    connectionId: string,
+    candidates: MtCandidateGroup[]
+  ): Promise<void> {
+    const dismissKey = `mtDismissed.${connectionId}`;
+    const storedKey = this.context.globalState.get<string>(dismissKey);
+    const currentKey = computeCandidatesDismissKey(candidates);
+
+    if (storedKey === currentKey) {
+      return; // User already dismissed this exact candidate state
+    }
+
+    const groupCount = candidates.length;
+    const msg =
+      `${groupCount} collection group${groupCount > 1 ? 's' : ''} share identical schemas ` +
+      `— they could use Weaviate Multi-Tenancy.`;
+
+    const action = await vscode.window.showWarningMessage(msg, 'Learn More', 'Update', 'Dismiss');
+
+    switch (action) {
+      case 'Learn More':
+        vscode.env.openExternal(
+          vscode.Uri.parse('https://docs.weaviate.io/weaviate/manage-collections/multi-tenancy')
+        );
+        break;
+      case 'Update':
+        // Clear dismiss state so the warning reappears with fresh data
+        await this.context.globalState.update(dismissKey, undefined);
+        await this.fetchCollectionsData(connectionId);
+        break;
+      case 'Dismiss':
+        await this.context.globalState.update(dismissKey, currentKey);
+        break;
+    }
+  }
+
+  /**
+   * Derives per-collection object counts from cached cluster node shard data.
+   * Sums objectCount across all shards and all nodes for each collection name.
+   */
+  private _getObjectCountsFromNodes(connectionId: string): Record<string, number> {
+    const nodes = this.clusterNodesCache[connectionId] ?? [];
+    const counts: Record<string, number> = {};
+    for (const node of nodes) {
+      for (const shard of (node as any).shards ?? []) {
+        const col = shard.class as string;
+        if (col) {
+          counts[col] = (counts[col] ?? 0) + (shard.objectCount ?? 0);
+        }
+      }
+    }
+    return counts;
+  }
+
+  /**
+   * Runs all checks for a connection, saves the result to globalState, and returns it.
+   * Called from the ClusterPanel "Run Checks" button.
+   */
+  public async runChecks(connectionId: string): Promise<ChecksResult> {
+    const collections = this.collections[connectionId] ?? [];
+    const objectCounts = this._getObjectCountsFromNodes(connectionId);
+    const groups = findMultiTenantCandidates(collections, objectCounts);
+
+    const result: ChecksResult = {
+      timestamp: new Date().toISOString(),
+      multiTenancy: {
+        groups,
+        hasIssues: groups.length > 0,
+      },
+    };
+
+    // Persist so the result survives panel close/reopen
+    await this.context.globalState.update(`checksResults.${connectionId}`, result);
+
+    // Update badge
+    this.mtCandidates[connectionId] = groups;
+    this.refresh();
+
+    return result;
+  }
+
+  /**
+   * Returns the last saved checks result for a connection, or null if none exists.
+   */
+  /**
+   * Returns the cached verbose nodes for a connection, if available.
+   */
+  public getCachedClusterNodes(connectionId: string): Node<'verbose'>[] | undefined {
+    return this.clusterNodesCache[connectionId];
+  }
+
+  public getLastChecksResult(connectionId: string): ChecksResult | null {
+    return this.context.globalState.get<ChecksResult>(`checksResults.${connectionId}`) ?? null;
   }
 
   /**

--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -3531,7 +3531,6 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
   public async runChecks(connectionId: string): Promise<ChecksResult> {
     const collections = this.collections[connectionId] ?? [];
     const objectCounts = this._getObjectCountsFromNodes(connectionId);
-    const groups = findMultiTenantCandidates(collections, objectCounts);
 
     const rawNodes = this.clusterNodesCache[connectionId] ?? [];
     // Filter shards to only collections still present in local state so stale
@@ -3544,8 +3543,13 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
     const mtCollections = new Set(
       collections.filter((c) => c.schema?.multiTenancy?.enabled).map((c) => c.label)
     );
-    const emptyShardEntries = findEmptyShards(nodes as any, mtCollections);
-    const replicationImbalances = findReplicationImbalances(nodes as any);
+
+    // All three checks are independent — run them in parallel.
+    const [groups, emptyShardEntries, replicationImbalances] = await Promise.all([
+      Promise.resolve(findMultiTenantCandidates(collections, objectCounts)),
+      Promise.resolve(findEmptyShards(nodes as any, mtCollections)),
+      Promise.resolve(findReplicationImbalances(nodes as any)),
+    ]);
 
     const result: ChecksResult = {
       timestamp: new Date().toISOString(),
@@ -3957,11 +3961,12 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       // Refresh the tree view
       this.refresh();
 
-      // Update cluster panel with latest node/collection stats, then recompute
-      // checks so the Checks tab reflects the deletion immediately.
+      // Refresh node cache first, then update the panel and recompute checks in parallel.
       await this.fetchNodes(connectionId);
-      await this.updateClusterPanelIfOpen(connectionId);
-      await this._recomputeChecksAndSend(connectionId);
+      await Promise.all([
+        this.updateClusterPanelIfOpen(connectionId),
+        this._recomputeChecksAndSend(connectionId),
+      ]);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error('Error in deleteCollection:', error);
@@ -4001,11 +4006,12 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       // Refresh the tree view
       this.refresh();
 
-      // Update cluster panel with latest node/collection stats, then recompute
-      // checks so the Checks tab reflects the deletion immediately.
+      // Refresh node cache first, then update the panel and recompute checks in parallel.
       await this.fetchNodes(connectionId);
-      await this.updateClusterPanelIfOpen(connectionId);
-      await this._recomputeChecksAndSend(connectionId);
+      await Promise.all([
+        this.updateClusterPanelIfOpen(connectionId),
+        this._recomputeChecksAndSend(connectionId),
+      ]);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error('Error in deleteAllCollections:', error);
@@ -4405,8 +4411,6 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
   private async _recomputeChecksAndSend(connectionId: string): Promise<void> {
     const collections = this.collections[connectionId] ?? [];
     const objectCounts = this._getObjectCountsFromNodes(connectionId);
-    const candidates = findMultiTenantCandidates(collections, objectCounts);
-    this.mtCandidates[connectionId] = candidates;
 
     const rawNodes = this.clusterNodesCache[connectionId] ?? [];
     // Filter shards to only collections still present in local state so stale
@@ -4419,8 +4423,14 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
     const mtCollections = new Set(
       collections.filter((c) => c.schema?.multiTenancy?.enabled).map((c) => c.label)
     );
-    const emptyShardEntries = findEmptyShards(nodes as any, mtCollections);
-    const replicationImbalances = findReplicationImbalances(nodes as any);
+
+    // All three checks are independent — run them in parallel.
+    const [candidates, emptyShardEntries, replicationImbalances] = await Promise.all([
+      Promise.resolve(findMultiTenantCandidates(collections, objectCounts)),
+      Promise.resolve(findEmptyShards(nodes as any, mtCollections)),
+      Promise.resolve(findReplicationImbalances(nodes as any)),
+    ]);
+    this.mtCandidates[connectionId] = candidates;
 
     const result: ChecksResult = {
       timestamp: new Date().toISOString(),

--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -416,7 +416,6 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       element.iconPath = hasAnyIssue
         ? new vscode.ThemeIcon('warning', new vscode.ThemeColor('list.warningForeground'))
         : new vscode.ThemeIcon('database');
-      // @ts-ignore — description is read-only on TreeItem but safe to set here
       element.description = hasAnyIssue
         ? `⚠ ${issueSections} check issue${issueSections > 1 ? 's' : ''}`
         : undefined;
@@ -3575,15 +3574,15 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
   }
 
   /**
-   * Returns the last saved checks result for a connection, or null if none exists.
-   */
-  /**
    * Returns the cached verbose nodes for a connection, if available.
    */
   public getCachedClusterNodes(connectionId: string): Node<'verbose'>[] | undefined {
     return this.clusterNodesCache[connectionId];
   }
 
+  /**
+   * Returns the last saved checks result for a connection, or null if none exists.
+   */
   public getLastChecksResult(connectionId: string): ChecksResult | null {
     return this.context.globalState.get<ChecksResult>(`checksResults.${connectionId}`) ?? null;
   }

--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -3446,6 +3446,21 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       const candidates = findMultiTenantCandidates(this.collections[connectionId], objectCounts);
       this.mtCandidates[connectionId] = candidates;
 
+      // Keep the saved checks result in sync with the live collection state so
+      // the ClusterPanel banner and Checks tab reflect reality without requiring
+      // the user to manually click "Run Checks". This mirrors what runChecks()
+      // does, but runs automatically on every collection fetch so the tree badge
+      // and the panel banner are always in agreement.
+      const updatedResult: ChecksResult = {
+        timestamp: new Date().toISOString(),
+        multiTenancy: { groups: candidates, hasIssues: candidates.length > 0 },
+      };
+      await this.context.globalState.update(`checksResults.${connectionId}`, updatedResult);
+      ClusterPanel.getPanel(connectionId)?.postMessage({
+        command: 'checksResult',
+        result: updatedResult,
+      });
+
       // Refresh the tree view
       this.refresh();
 

--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -21,6 +21,8 @@ import { WEAVIATE_INTEGRATION_HEADER } from '../constants';
 import { getTelemetryService, TELEMETRY_EVENTS } from '../telemetry';
 import {
   findMultiTenantCandidates,
+  findEmptyShards,
+  findReplicationImbalances,
   computeCandidatesDismissKey,
   MtCandidateGroup,
   ChecksResult,
@@ -106,6 +108,9 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
 
   /** MT candidate groups per connection, sorted by totalObjects descending. */
   private mtCandidates: Record<string, MtCandidateGroup[]> = {};
+
+  /** Number of check sections (MT, empty shards, replication) with issues, per connection. */
+  private checksIssueSectionCount: Record<string, number> = {};
 
   /** VS Code extension context */
   private readonly context: vscode.ExtensionContext;
@@ -404,23 +409,24 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       }
       element.tooltip = 'Available Weaviate modules';
     } else if (element.itemType === 'collectionsGroup') {
-      const mtCount = element.connectionId
-        ? (this.mtCandidates[element.connectionId]?.length ?? 0)
+      const issueSections = element.connectionId
+        ? (this.checksIssueSectionCount[element.connectionId] ?? 0)
         : 0;
-      element.iconPath =
-        mtCount > 0
-          ? new vscode.ThemeIcon('warning', new vscode.ThemeColor('list.warningForeground'))
-          : new vscode.ThemeIcon('database');
+      const hasAnyIssue = issueSections > 0;
+      element.iconPath = hasAnyIssue
+        ? new vscode.ThemeIcon('warning', new vscode.ThemeColor('list.warningForeground'))
+        : new vscode.ThemeIcon('database');
       // @ts-ignore — description is read-only on TreeItem but safe to set here
-      element.description =
-        mtCount > 0 ? `⚠ ${mtCount} MT candidate${mtCount > 1 ? 's' : ''}` : undefined;
-      element.tooltip =
-        mtCount > 0
-          ? 'Some collections share identical schemas — they could use Multi-Tenancy'
-          : 'Collections in this instance';
-      // Use a distinct contextValue when there's an MT warning so we can show the inline button
-      element.contextValue =
-        mtCount > 0 ? 'weaviateCollectionsGroupMtWarning' : 'weaviateCollectionsGroup';
+      element.description = hasAnyIssue
+        ? `⚠ ${issueSections} check issue${issueSections > 1 ? 's' : ''}`
+        : undefined;
+      element.tooltip = hasAnyIssue
+        ? `${issueSections} check issue${issueSections > 1 ? 's' : ''} detected — open Checks for details`
+        : 'Collections in this instance';
+      // Use a distinct contextValue when there are any check warnings so we can show the inline button
+      element.contextValue = hasAnyIssue
+        ? 'weaviateCollectionsGroupMtWarning'
+        : 'weaviateCollectionsGroup';
     } else if (element.itemType === 'backups') {
       if (!element.iconPath) {
         element.iconPath = new vscode.ThemeIcon('archive');
@@ -3441,30 +3447,15 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
         this.collections[connectionId] = [];
       }
 
-      // Compute MT candidates before refresh so badges render immediately
-      const objectCounts = this._getObjectCountsFromNodes(connectionId);
-      const candidates = findMultiTenantCandidates(this.collections[connectionId], objectCounts);
-      this.mtCandidates[connectionId] = candidates;
-
-      // Keep the saved checks result in sync with the live collection state so
-      // the ClusterPanel banner and Checks tab reflect reality without requiring
-      // the user to manually click "Run Checks". This mirrors what runChecks()
-      // does, but runs automatically on every collection fetch so the tree badge
-      // and the panel banner are always in agreement.
-      const updatedResult: ChecksResult = {
-        timestamp: new Date().toISOString(),
-        multiTenancy: { groups: candidates, hasIssues: candidates.length > 0 },
-      };
-      await this.context.globalState.update(`checksResults.${connectionId}`, updatedResult);
-      ClusterPanel.getPanel(connectionId)?.postMessage({
-        command: 'checksResult',
-        result: updatedResult,
-      });
+      // Recompute all checks and push the result to the ClusterPanel so badges
+      // and the panel banner always reflect the current collection state.
+      await this._recomputeChecksAndSend(connectionId);
 
       // Refresh the tree view
       this.refresh();
 
       // Show notification async — fire and forget so it does not block the tree
+      const candidates = this.mtCandidates[connectionId] ?? [];
       if (candidates.length > 0) {
         this._notifyMtCandidates(connectionId, candidates).catch(console.error);
       }
@@ -3543,19 +3534,41 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
     const objectCounts = this._getObjectCountsFromNodes(connectionId);
     const groups = findMultiTenantCandidates(collections, objectCounts);
 
+    const rawNodes = this.clusterNodesCache[connectionId] ?? [];
+    // Filter shards to only collections still present in local state so stale
+    // node status data cannot produce false positives immediately after a deletion.
+    const knownCollections = new Set(collections.map((c) => c.label));
+    const nodes = rawNodes.map((node) => ({
+      ...node,
+      shards: (node.shards ?? []).filter((shard) => knownCollections.has((shard as any).class)),
+    }));
+    const mtCollections = new Set(
+      collections.filter((c) => c.schema?.multiTenancy?.enabled).map((c) => c.label)
+    );
+    const emptyShardEntries = findEmptyShards(nodes as any, mtCollections);
+    const replicationImbalances = findReplicationImbalances(nodes as any);
+
     const result: ChecksResult = {
       timestamp: new Date().toISOString(),
-      multiTenancy: {
-        groups,
-        hasIssues: groups.length > 0,
+      hasIssues:
+        groups.length > 0 || emptyShardEntries.length > 0 || replicationImbalances.length > 0,
+      multiTenancy: { groups, hasIssues: groups.length > 0 },
+      emptyShards: { entries: emptyShardEntries, hasIssues: emptyShardEntries.length > 0 },
+      replicationImbalance: {
+        collections: replicationImbalances,
+        hasIssues: replicationImbalances.length > 0,
       },
     };
 
     // Persist so the result survives panel close/reopen
     await this.context.globalState.update(`checksResults.${connectionId}`, result);
 
-    // Update badge
+    // Update badges
     this.mtCandidates[connectionId] = groups;
+    this.checksIssueSectionCount[connectionId] =
+      (groups.length > 0 ? 1 : 0) +
+      (emptyShardEntries.length > 0 ? 1 : 0) +
+      (replicationImbalances.length > 0 ? 1 : 0);
     this.refresh();
 
     return result;
@@ -3945,9 +3958,11 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       // Refresh the tree view
       this.refresh();
 
-      // Update cluster panel with latest node/collection stats
+      // Update cluster panel with latest node/collection stats, then recompute
+      // checks so the Checks tab reflects the deletion immediately.
       await this.fetchNodes(connectionId);
       await this.updateClusterPanelIfOpen(connectionId);
+      await this._recomputeChecksAndSend(connectionId);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error('Error in deleteCollection:', error);
@@ -3987,9 +4002,11 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       // Refresh the tree view
       this.refresh();
 
-      // Update cluster panel with latest node/collection stats
+      // Update cluster panel with latest node/collection stats, then recompute
+      // checks so the Checks tab reflects the deletion immediately.
       await this.fetchNodes(connectionId);
       await this.updateClusterPanelIfOpen(connectionId);
+      await this._recomputeChecksAndSend(connectionId);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error('Error in deleteAllCollections:', error);
@@ -4379,6 +4396,54 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
    * A warning notification is shown so the user knows the panel may be stale
    * and can manually refresh it.
    */
+  /**
+   * Recomputes all checks from the current cached collections and nodes, persists the result,
+   * and pushes a `checksResult` message to the ClusterPanel if it is open.
+   *
+   * Call this whenever collections or node shards change (fetch, delete, etc.) so the
+   * Checks tab and tree badges stay in sync without requiring a manual "Run Checks".
+   */
+  private async _recomputeChecksAndSend(connectionId: string): Promise<void> {
+    const collections = this.collections[connectionId] ?? [];
+    const objectCounts = this._getObjectCountsFromNodes(connectionId);
+    const candidates = findMultiTenantCandidates(collections, objectCounts);
+    this.mtCandidates[connectionId] = candidates;
+
+    const rawNodes = this.clusterNodesCache[connectionId] ?? [];
+    // Filter shards to only collections still present in local state so stale
+    // node status data cannot produce false positives immediately after a deletion.
+    const knownCollections = new Set(collections.map((c) => c.label));
+    const nodes = rawNodes.map((node) => ({
+      ...node,
+      shards: (node.shards ?? []).filter((shard) => knownCollections.has((shard as any).class)),
+    }));
+    const mtCollections = new Set(
+      collections.filter((c) => c.schema?.multiTenancy?.enabled).map((c) => c.label)
+    );
+    const emptyShardEntries = findEmptyShards(nodes as any, mtCollections);
+    const replicationImbalances = findReplicationImbalances(nodes as any);
+
+    const result: ChecksResult = {
+      timestamp: new Date().toISOString(),
+      hasIssues:
+        candidates.length > 0 || emptyShardEntries.length > 0 || replicationImbalances.length > 0,
+      multiTenancy: { groups: candidates, hasIssues: candidates.length > 0 },
+      emptyShards: { entries: emptyShardEntries, hasIssues: emptyShardEntries.length > 0 },
+      replicationImbalance: {
+        collections: replicationImbalances,
+        hasIssues: replicationImbalances.length > 0,
+      },
+    };
+
+    this.checksIssueSectionCount[connectionId] =
+      (candidates.length > 0 ? 1 : 0) +
+      (emptyShardEntries.length > 0 ? 1 : 0) +
+      (replicationImbalances.length > 0 ? 1 : 0);
+
+    await this.context.globalState.update(`checksResults.${connectionId}`, result);
+    ClusterPanel.getPanel(connectionId)?.postMessage({ command: 'checksResult', result });
+  }
+
   private async updateClusterPanelIfOpen(connectionId: string): Promise<void> {
     try {
       // Check if cluster panel is open for this connection

--- a/src/WeaviateTreeDataProvider/__tests__/DataFetch.test.ts
+++ b/src/WeaviateTreeDataProvider/__tests__/DataFetch.test.ts
@@ -599,6 +599,412 @@ describe('deleteAllCollections', () => {
   });
 });
 
+// ─── runChecks ────────────────────────────────────────────────────────────────
+
+describe('runChecks', () => {
+  let provider: WeaviateTreeDataProvider;
+
+  beforeEach(() => {
+    provider = makeProvider();
+    jest.clearAllMocks();
+    mockGetClient.mockReturnValue(mockClient);
+    mockGetConnection.mockReturnValue({ id: 'c1', name: 'TestConn' });
+  });
+
+  it('returns a ChecksResult with correct structure', async () => {
+    (provider as any).collections['c1'] = [];
+    (provider as any).clusterNodesCache['c1'] = [];
+
+    const result = await provider.runChecks('c1');
+
+    expect(result).toMatchObject({
+      timestamp: expect.any(String),
+      hasIssues: false,
+      multiTenancy: { groups: [], hasIssues: false },
+      emptyShards: { entries: [], hasIssues: false },
+      replicationImbalance: { collections: [], hasIssues: false },
+    });
+  });
+
+  it('persists the result to globalState', async () => {
+    (provider as any).collections['c1'] = [];
+    (provider as any).clusterNodesCache['c1'] = [];
+
+    await provider.runChecks('c1');
+
+    expect(mockCtx.globalState.update).toHaveBeenCalledWith(
+      'checksResults.c1',
+      expect.objectContaining({ hasIssues: false })
+    );
+  });
+
+  it('filters out shards from collections no longer in local state', async () => {
+    // Only 'Article' is in collections; 'Deleted' was removed but still in node cache
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+    ];
+    (provider as any).clusterNodesCache['c1'] = [
+      {
+        name: 'node-1',
+        shards: [
+          { class: 'Article', name: 'art-shard', objectCount: 100 },
+          { class: 'Deleted', name: 'del-shard', objectCount: 0 }, // stale shard
+        ],
+      },
+    ];
+
+    const result = await provider.runChecks('c1');
+
+    // Stale shard from 'Deleted' collection must not appear in empty shards
+    expect(result.emptyShards.hasIssues).toBe(false);
+    expect(result.emptyShards.entries).toHaveLength(0);
+  });
+
+  it('reports empty shards for known collections', async () => {
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+    ];
+    (provider as any).clusterNodesCache['c1'] = [
+      {
+        name: 'node-1',
+        shards: [{ class: 'Article', name: 'art-shard', objectCount: 0 }],
+      },
+    ];
+
+    const result = await provider.runChecks('c1');
+
+    expect(result.emptyShards.hasIssues).toBe(true);
+    expect(result.emptyShards.entries[0].collectionName).toBe('Article');
+  });
+
+  it('sets checksIssueSectionCount badge correctly', async () => {
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+    ];
+    (provider as any).clusterNodesCache['c1'] = [
+      { name: 'node-1', shards: [{ class: 'Article', name: 'shard-1', objectCount: 0 }] },
+    ];
+
+    await provider.runChecks('c1');
+
+    // Empty shards issue detected → count should be 1
+    expect((provider as any).checksIssueSectionCount['c1']).toBe(1);
+  });
+
+  it('detects replication imbalance when same shard has different counts across nodes', async () => {
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+    ];
+    (provider as any).clusterNodesCache['c1'] = [
+      { name: 'node-1', shards: [{ class: 'Article', name: 'shard-1', objectCount: 100 }] },
+      { name: 'node-2', shards: [{ class: 'Article', name: 'shard-1', objectCount: 90 }] },
+    ];
+
+    const result = await provider.runChecks('c1');
+
+    expect(result.replicationImbalance.hasIssues).toBe(true);
+    expect(result.replicationImbalance.collections).toHaveLength(1);
+    expect(result.replicationImbalance.collections[0].collectionName).toBe('Article');
+  });
+
+  it('does not flag replication imbalance when replicas match', async () => {
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+    ];
+    (provider as any).clusterNodesCache['c1'] = [
+      { name: 'node-1', shards: [{ class: 'Article', name: 'shard-1', objectCount: 100 }] },
+      { name: 'node-2', shards: [{ class: 'Article', name: 'shard-1', objectCount: 100 }] },
+    ];
+
+    const result = await provider.runChecks('c1');
+
+    expect(result.replicationImbalance.hasIssues).toBe(false);
+  });
+
+  it('filters stale shards from replication imbalance check too', async () => {
+    // 'Deleted' is no longer in collections but still in node cache on both nodes
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+    ];
+    (provider as any).clusterNodesCache['c1'] = [
+      {
+        name: 'node-1',
+        shards: [
+          { class: 'Article', name: 'shard-1', objectCount: 100 },
+          { class: 'Deleted', name: 'del-shard', objectCount: 50 },
+        ],
+      },
+      {
+        name: 'node-2',
+        shards: [
+          { class: 'Article', name: 'shard-1', objectCount: 100 },
+          { class: 'Deleted', name: 'del-shard', objectCount: 10 }, // would be imbalanced
+        ],
+      },
+    ];
+
+    const result = await provider.runChecks('c1');
+
+    expect(result.replicationImbalance.hasIssues).toBe(false);
+  });
+
+  it('counts all three issue sections in checksIssueSectionCount', async () => {
+    const props = [{ name: 'title', dataType: ['text'], tokenization: 'word' }];
+    (provider as any).collections['c1'] = [
+      // Two collections with identical schema → MT candidate
+      {
+        label: 'ColA',
+        collectionName: 'ColA',
+        schema: { properties: props, multiTenancy: { enabled: false } },
+      },
+      {
+        label: 'ColB',
+        collectionName: 'ColB',
+        schema: { properties: props, multiTenancy: { enabled: false } },
+      },
+    ];
+    (provider as any).clusterNodesCache['c1'] = [
+      // ColA has an empty shard + replication imbalance
+      { name: 'node-1', shards: [{ class: 'ColA', name: 'shard-1', objectCount: 0 }] },
+      { name: 'node-2', shards: [{ class: 'ColA', name: 'shard-1', objectCount: 5 }] },
+    ];
+
+    await provider.runChecks('c1');
+
+    // MT candidates (1) + empty shards (1) + replication imbalance (1) = 3
+    expect((provider as any).checksIssueSectionCount['c1']).toBe(3);
+  });
+});
+
+// ─── _recomputeChecksAndSend ──────────────────────────────────────────────────
+
+describe('_recomputeChecksAndSend', () => {
+  let provider: WeaviateTreeDataProvider;
+
+  beforeEach(() => {
+    provider = makeProvider();
+    jest.clearAllMocks();
+  });
+
+  it('filters out shards from deleted collections when recomputing', async () => {
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+    ];
+    // Node cache still has shards for 'Deleted' — simulating API lag after deletion
+    (provider as any).clusterNodesCache['c1'] = [
+      {
+        name: 'node-1',
+        shards: [
+          { class: 'Article', name: 'art-shard', objectCount: 100 },
+          { class: 'Deleted', name: 'del-shard', objectCount: 0 },
+        ],
+      },
+    ];
+
+    await (provider as any)._recomputeChecksAndSend('c1');
+
+    const saved = (mockCtx.globalState.update as jest.Mock).mock.calls.find(
+      (call: any[]) => call[0] === 'checksResults.c1'
+    );
+    expect(saved).toBeDefined();
+    const result = saved[1];
+    expect(result.emptyShards.hasIssues).toBe(false);
+    expect(result.emptyShards.entries).toHaveLength(0);
+  });
+
+  it('sets mtCandidates from recomputed result', async () => {
+    (provider as any).collections['c1'] = [];
+    (provider as any).clusterNodesCache['c1'] = [];
+
+    await (provider as any)._recomputeChecksAndSend('c1');
+
+    expect((provider as any).mtCandidates['c1']).toEqual([]);
+  });
+
+  it('updates checksIssueSectionCount', async () => {
+    (provider as any).collections['c1'] = [
+      { label: 'Col', collectionName: 'Col', schema: { multiTenancy: { enabled: false } } },
+    ];
+    (provider as any).clusterNodesCache['c1'] = [
+      { name: 'node-1', shards: [{ class: 'Col', name: 'shard-1', objectCount: 0 }] },
+    ];
+
+    await (provider as any)._recomputeChecksAndSend('c1');
+
+    expect((provider as any).checksIssueSectionCount['c1']).toBe(1);
+  });
+
+  it('persists result to globalState', async () => {
+    (provider as any).collections['c1'] = [];
+    (provider as any).clusterNodesCache['c1'] = [];
+
+    await (provider as any)._recomputeChecksAndSend('c1');
+
+    expect(mockCtx.globalState.update).toHaveBeenCalledWith(
+      'checksResults.c1',
+      expect.objectContaining({ timestamp: expect.any(String) })
+    );
+  });
+
+  it('detects empty shards for known collections', async () => {
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+    ];
+    (provider as any).clusterNodesCache['c1'] = [
+      { name: 'node-1', shards: [{ class: 'Article', name: 'shard-1', objectCount: 0 }] },
+    ];
+
+    await (provider as any)._recomputeChecksAndSend('c1');
+
+    const saved = (mockCtx.globalState.update as jest.Mock).mock.calls.find(
+      (call: any[]) => call[0] === 'checksResults.c1'
+    );
+    expect(saved[1].emptyShards.hasIssues).toBe(true);
+    expect(saved[1].emptyShards.entries[0].collectionName).toBe('Article');
+  });
+
+  it('detects replication imbalance for known collections', async () => {
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+    ];
+    (provider as any).clusterNodesCache['c1'] = [
+      { name: 'node-1', shards: [{ class: 'Article', name: 'shard-1', objectCount: 100 }] },
+      { name: 'node-2', shards: [{ class: 'Article', name: 'shard-1', objectCount: 80 }] },
+    ];
+
+    await (provider as any)._recomputeChecksAndSend('c1');
+
+    const saved = (mockCtx.globalState.update as jest.Mock).mock.calls.find(
+      (call: any[]) => call[0] === 'checksResults.c1'
+    );
+    expect(saved[1].replicationImbalance.hasIssues).toBe(true);
+    expect(saved[1].replicationImbalance.collections[0].collectionName).toBe('Article');
+  });
+
+  it('filters stale shards from replication imbalance check', async () => {
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+    ];
+    // 'Deleted' shard appears on both nodes with different counts — but collection was deleted
+    (provider as any).clusterNodesCache['c1'] = [
+      {
+        name: 'node-1',
+        shards: [
+          { class: 'Article', name: 'shard-1', objectCount: 100 },
+          { class: 'Deleted', name: 'del-shard', objectCount: 50 },
+        ],
+      },
+      {
+        name: 'node-2',
+        shards: [
+          { class: 'Article', name: 'shard-1', objectCount: 100 },
+          { class: 'Deleted', name: 'del-shard', objectCount: 10 },
+        ],
+      },
+    ];
+
+    await (provider as any)._recomputeChecksAndSend('c1');
+
+    const saved = (mockCtx.globalState.update as jest.Mock).mock.calls.find(
+      (call: any[]) => call[0] === 'checksResults.c1'
+    );
+    expect(saved[1].replicationImbalance.hasIssues).toBe(false);
+  });
+});
+
+// ─── deleteCollection — checks update ────────────────────────────────────────
+
+describe('deleteCollection — checks update', () => {
+  let provider: WeaviateTreeDataProvider;
+
+  beforeEach(() => {
+    provider = makeProvider();
+    jest.clearAllMocks();
+    mockGetClient.mockReturnValue(mockClient);
+    mockGetConnection.mockReturnValue({ id: 'c1', name: 'TestConn', status: 'connected' });
+    mockCollectionsDelete.mockResolvedValue(undefined);
+    // After fetchNodes the cache returns no shards for the deleted collection
+    mockClusterNodes.mockResolvedValue([
+      { name: 'node-1', shards: [{ class: 'Author', name: 'auth-shard', objectCount: 50 }] },
+    ]);
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+      { label: 'Author', collectionName: 'Author', schema: { multiTenancy: { enabled: false } } },
+    ];
+  });
+
+  it('recomputes and persists checks after deleting a collection', async () => {
+    await provider.deleteCollection('c1', 'Article');
+
+    expect(mockCtx.globalState.update).toHaveBeenCalledWith(
+      'checksResults.c1',
+      expect.objectContaining({ timestamp: expect.any(String) })
+    );
+  });
+
+  it('deleted collection shards do not appear in empty shards after deletion', async () => {
+    // Simulate API lag: node cache still has Article shard with 0 objects after delete
+    mockClusterNodes.mockResolvedValue([
+      {
+        name: 'node-1',
+        shards: [
+          { class: 'Article', name: 'art-shard', objectCount: 0 }, // stale
+          { class: 'Author', name: 'auth-shard', objectCount: 50 },
+        ],
+      },
+    ]);
+
+    await provider.deleteCollection('c1', 'Article');
+
+    const saved = (mockCtx.globalState.update as jest.Mock).mock.calls
+      .filter((call: any[]) => call[0] === 'checksResults.c1')
+      .pop();
+    expect(saved).toBeDefined();
+    expect(saved[1].emptyShards.hasIssues).toBe(false);
+    expect(saved[1].emptyShards.entries).toHaveLength(0);
+  });
+});
+
+// ─── deleteAllCollections — checks update ────────────────────────────────────
+
+describe('deleteAllCollections — checks update', () => {
+  let provider: WeaviateTreeDataProvider;
+
+  beforeEach(() => {
+    provider = makeProvider();
+    jest.clearAllMocks();
+    mockGetClient.mockReturnValue(mockClient);
+    mockGetConnection.mockReturnValue({ id: 'c1', name: 'TestConn', status: 'connected' });
+    mockCollectionsDeleteAll.mockResolvedValue(undefined);
+    mockClusterNodes.mockResolvedValue([]);
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+    ];
+  });
+
+  it('recomputes and persists checks after deleting all collections', async () => {
+    await provider.deleteAllCollections('c1');
+
+    expect(mockCtx.globalState.update).toHaveBeenCalledWith(
+      'checksResults.c1',
+      expect.objectContaining({ hasIssues: false })
+    );
+  });
+
+  it('checks show no issues after all collections removed', async () => {
+    await provider.deleteAllCollections('c1');
+
+    const saved = (mockCtx.globalState.update as jest.Mock).mock.calls
+      .filter((call: any[]) => call[0] === 'checksResults.c1')
+      .pop();
+    expect(saved).toBeDefined();
+    const result = saved[1];
+    expect(result.emptyShards.hasIssues).toBe(false);
+    expect(result.multiTenancy.hasIssues).toBe(false);
+    expect(result.replicationImbalance.hasIssues).toBe(false);
+  });
+});
+
 // ─── refreshCollections ───────────────────────────────────────────────────────
 
 describe('refreshCollections', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1733,7 +1733,7 @@ export function activate(context: vscode.ExtensionContext) {
           weaviateTreeDataProvider.getCachedClusterNodes(item.connectionId) ?? null;
 
         // Open panel immediately — show cached data right away or loading state if no cache.
-        ClusterPanel.createOrShow(
+        const clusterPanel = ClusterPanel.createOrShow(
           context.extensionUri,
           item.connectionId,
           cachedNodeData,
@@ -1826,9 +1826,25 @@ export function activate(context: vscode.ExtensionContext) {
           connection?.openClusterViewOnConnect,
           weaviateTreeDataProvider.getLastChecksResult(item.connectionId)
         );
+
+        // If a specific tab was requested (e.g. opening directly to the Checks tab),
+        // tell the webview to switch to it after the panel is shown.
+        if (item.openTab) {
+          clusterPanel.postMessage({ command: 'switchTab', tab: item.openTab });
+        }
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
         vscode.window.showErrorMessage(`Failed to get cluster information: ${errorMessage}`);
+      }
+    }),
+
+    vscode.commands.registerCommand('weaviate.openMtChecks', (item) => {
+      const connectionId = item?.connectionId;
+      if (connectionId) {
+        vscode.commands.executeCommand('weaviate.viewClusterInfo', {
+          connectionId,
+          openTab: 'checks',
+        });
       }
     }),
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1724,20 +1724,38 @@ export function activate(context: vscode.ExtensionContext) {
           return;
         }
 
-        // Get node status data
-        const nodeStatusData = await client.cluster.nodes({ output: 'verbose' });
-
         // Get connection to access openClusterViewOnConnect setting
         const connection = connectionManager.getConnection(item.connectionId);
 
-        // Open cluster panel
+        // Use cached node data (already fetched by the tree view) for immediate display.
+        // If the cache is empty, the panel will show a loading state until the fetch below completes.
+        const cachedNodeData =
+          weaviateTreeDataProvider.getCachedClusterNodes(item.connectionId) ?? null;
+
+        // Open panel immediately — show cached data right away or loading state if no cache.
         ClusterPanel.createOrShow(
           context.extensionUri,
           item.connectionId,
-          nodeStatusData,
+          cachedNodeData,
           connection?.name || 'Unknown',
           async (message, postMessage) => {
-            if (message.command === 'refresh') {
+            if (message.command === 'ready' && cachedNodeData == null) {
+              // No cached data — fetch now and push to the panel when ready.
+              // The webview already received 'init' with null and is showing loading state.
+              try {
+                const updatedData = await client.cluster.nodes({ output: 'verbose' });
+                const updatedConnection = connectionManager.getConnection(item.connectionId);
+                postMessage({
+                  command: 'updateData',
+                  nodeStatusData: updatedData,
+                  openClusterViewOnConnect: updatedConnection?.openClusterViewOnConnect,
+                });
+              } catch (error: unknown) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                vscode.window.showErrorMessage(`Failed to load cluster data: ${errorMessage}`);
+                postMessage({ command: 'updateData', nodeStatusData: [] });
+              }
+            } else if (message.command === 'refresh') {
               // Refresh node status data
               const updatedData = await client.cluster.nodes({ output: 'verbose' });
               const updatedConnection = connectionManager.getConnection(item.connectionId);
@@ -1792,9 +1810,21 @@ export function activate(context: vscode.ExtensionContext) {
                 const errorMessage = error instanceof Error ? error.message : 'Unknown error';
                 vscode.window.showErrorMessage(`Failed to update shard status: ${errorMessage}`);
               }
+            } else if (message.command === 'runChecks') {
+              try {
+                const result = await weaviateTreeDataProvider.runChecks(item.connectionId);
+                postMessage({ command: 'checksResult', result });
+              } catch (error: unknown) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                vscode.window.showErrorMessage(`Failed to run checks: ${errorMessage}`);
+                postMessage({ command: 'checksResult', result: null });
+              }
+            } else if (message.command === 'openExternal') {
+              vscode.env.openExternal(vscode.Uri.parse(message.url));
             }
           },
-          connection?.openClusterViewOnConnect
+          connection?.openClusterViewOnConnect,
+          weaviateTreeDataProvider.getLastChecksResult(item.connectionId)
         );
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1828,6 +1828,16 @@ export function activate(context: vscode.ExtensionContext) {
               }
             } else if (message.command === 'runChecks') {
               try {
+                // Refresh node status first so checks and the UI both use up-to-date data.
+                await weaviateTreeDataProvider.fetchNodes(item.connectionId);
+                const freshNodes =
+                  weaviateTreeDataProvider.getCachedClusterNodes(item.connectionId) ?? [];
+                const updatedConnection = connectionManager.getConnection(item.connectionId);
+                postMessage({
+                  command: 'updateData',
+                  nodeStatusData: freshNodes,
+                  openClusterViewOnConnect: updatedConnection?.openClusterViewOnConnect,
+                });
                 const result = await weaviateTreeDataProvider.runChecks(item.connectionId);
                 postMessage({ command: 'checksResult', result });
               } catch (error: unknown) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1595,6 +1595,14 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.window.showInformationMessage(
             `Collection "${item.collectionName}" deleted successfully`
           );
+          // Re-run checks if a previous result exists, so stale candidates are cleared.
+          if (weaviateTreeDataProvider.getLastChecksResult(item.connectionId)) {
+            const updatedResult = await weaviateTreeDataProvider.runChecks(item.connectionId);
+            ClusterPanel.getPanel(item.connectionId)?.postMessage({
+              command: 'checksResult',
+              result: updatedResult,
+            });
+          }
         } catch (error) {
           vscode.window.showErrorMessage(
             `Failed to delete collection: ${error instanceof Error ? error.message : String(error)}`
@@ -1634,6 +1642,14 @@ export function activate(context: vscode.ExtensionContext) {
         try {
           await weaviateTreeDataProvider.deleteAllCollections(item.connectionId);
           vscode.window.showInformationMessage('All collections deleted successfully');
+          // Re-run checks if a previous result exists, so stale candidates are cleared.
+          if (weaviateTreeDataProvider.getLastChecksResult(item.connectionId)) {
+            const updatedResult = await weaviateTreeDataProvider.runChecks(item.connectionId);
+            ClusterPanel.getPanel(item.connectionId)?.postMessage({
+              command: 'checksResult',
+              result: updatedResult,
+            });
+          }
         } catch (error) {
           vscode.window.showErrorMessage(
             `Failed to delete all collections: ${error instanceof Error ? error.message : String(error)}`
@@ -1828,9 +1844,9 @@ export function activate(context: vscode.ExtensionContext) {
         );
 
         // If a specific tab was requested (e.g. opening directly to the Checks tab),
-        // tell the webview to switch to it after the panel is shown.
+        // queue the switch so it's safe for both new and already-open panels.
         if (item.openTab) {
-          clusterPanel.postMessage({ command: 'switchTab', tab: item.openTab });
+          clusterPanel.setPendingTab(item.openTab);
         }
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -165,6 +165,7 @@ export interface ConnectionConfig extends WeaviateConnection {
  * Extends vscode.TreeItem to include Weaviate-specific properties.
  */
 export class WeaviateTreeItem extends vscode.TreeItem {
+  public override description?: string | boolean;
   /**
    * Creates a new instance of WeaviateTreeItem
    * @param label - The display label for the tree item
@@ -260,7 +261,6 @@ export class WeaviateTreeItem extends vscode.TreeItem {
     }
 
     if (description !== null && description !== undefined) {
-      // @ts-ignore - We're setting a read-only property here
       this.description = description;
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -165,7 +165,7 @@ export interface ConnectionConfig extends WeaviateConnection {
  * Extends vscode.TreeItem to include Weaviate-specific properties.
  */
 export class WeaviateTreeItem extends vscode.TreeItem {
-  public override description?: string | boolean;
+  declare public description?: string | boolean;
   /**
    * Creates a new instance of WeaviateTreeItem
    * @param label - The display label for the tree item

--- a/src/utils/__tests__/multiTenancyCheck.test.ts
+++ b/src/utils/__tests__/multiTenancyCheck.test.ts
@@ -1,0 +1,462 @@
+import {
+  computeCollectionHash,
+  computeCandidatesDismissKey,
+  findMultiTenantCandidates,
+  MtCandidateGroup,
+  PropertyLike,
+} from '../multiTenancyCheck';
+import { CollectionWithSchema } from '../../types';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeCollection(
+  name: string,
+  properties: PropertyLike[] = [],
+  multiTenancyEnabled = false
+): CollectionWithSchema {
+  return {
+    label: name,
+    collapsibleState: 0,
+    itemType: 'collection',
+    schema: {
+      name,
+      properties: properties as any,
+      multiTenancy: { enabled: multiTenancyEnabled } as any,
+    } as any,
+  } as unknown as CollectionWithSchema;
+}
+
+function groupNames(group: MtCandidateGroup): string[] {
+  return group.collections.map((c) => c.name);
+}
+
+// ─── computeCollectionHash ────────────────────────────────────────────────────
+
+describe('computeCollectionHash', () => {
+  it('returns empty string for empty property list', () => {
+    expect(computeCollectionHash([])).toBe('');
+  });
+
+  it('returns empty string for null/undefined input', () => {
+    expect(computeCollectionHash(null as any)).toBe('');
+    expect(computeCollectionHash(undefined as any)).toBe('');
+  });
+
+  it('produces a non-empty fingerprint for a single property', () => {
+    const props: PropertyLike[] = [{ name: 'title', dataType: ['text'], tokenization: 'word' }];
+    expect(computeCollectionHash(props)).toBe('title|word|text');
+  });
+
+  it('sorts properties alphabetically so declaration order does not matter (scenario 5)', () => {
+    const propsA: PropertyLike[] = [
+      { name: 'title', dataType: ['text'], tokenization: 'word' },
+      { name: 'age', dataType: ['int'] },
+    ];
+    const propsB: PropertyLike[] = [
+      { name: 'age', dataType: ['int'] },
+      { name: 'title', dataType: ['text'], tokenization: 'word' },
+    ];
+    expect(computeCollectionHash(propsA)).toBe(computeCollectionHash(propsB));
+  });
+
+  it('treats null tokenization as "word" (scenario 11)', () => {
+    const withNull: PropertyLike[] = [{ name: 'title', dataType: ['text'], tokenization: null }];
+    const withWord: PropertyLike[] = [{ name: 'title', dataType: ['text'], tokenization: 'word' }];
+    expect(computeCollectionHash(withNull)).toBe(computeCollectionHash(withWord));
+  });
+
+  it('treats undefined tokenization as "word" (scenario 11)', () => {
+    const withUndefined: PropertyLike[] = [{ name: 'title', dataType: ['text'] }];
+    const withWord: PropertyLike[] = [{ name: 'title', dataType: ['text'], tokenization: 'word' }];
+    expect(computeCollectionHash(withUndefined)).toBe(computeCollectionHash(withWord));
+  });
+
+  it('treats empty string tokenization as "word" (scenario 12)', () => {
+    const withEmpty: PropertyLike[] = [{ name: 'title', dataType: ['text'], tokenization: '' }];
+    const withWord: PropertyLike[] = [{ name: 'title', dataType: ['text'], tokenization: 'word' }];
+    expect(computeCollectionHash(withEmpty)).toBe(computeCollectionHash(withWord));
+  });
+
+  it('treats whitespace-only tokenization as "word"', () => {
+    const withSpace: PropertyLike[] = [{ name: 'title', dataType: ['text'], tokenization: '   ' }];
+    const withWord: PropertyLike[] = [{ name: 'title', dataType: ['text'], tokenization: 'word' }];
+    expect(computeCollectionHash(withSpace)).toBe(computeCollectionHash(withWord));
+  });
+
+  it('produces different hashes for different tokenizations (scenario 7)', () => {
+    const field: PropertyLike[] = [{ name: 'title', dataType: ['text'], tokenization: 'field' }];
+    const word: PropertyLike[] = [{ name: 'title', dataType: ['text'], tokenization: 'word' }];
+    expect(computeCollectionHash(field)).not.toBe(computeCollectionHash(word));
+  });
+
+  it('produces different hashes for different dataTypes (scenario 6)', () => {
+    const text: PropertyLike[] = [{ name: 'value', dataType: ['text'] }];
+    const int: PropertyLike[] = [{ name: 'value', dataType: ['int'] }];
+    expect(computeCollectionHash(text)).not.toBe(computeCollectionHash(int));
+  });
+
+  it('sorts multi-value dataType arrays for consistent ordering (scenario 13)', () => {
+    const propsA: PropertyLike[] = [{ name: 'ref', dataType: ['int', 'text'] }];
+    const propsB: PropertyLike[] = [{ name: 'ref', dataType: ['text', 'int'] }];
+    expect(computeCollectionHash(propsA)).toBe(computeCollectionHash(propsB));
+  });
+
+  it('handles string dataType (non-array) without throwing', () => {
+    const props: PropertyLike[] = [{ name: 'title', dataType: 'text' as any }];
+    expect(() => computeCollectionHash(props)).not.toThrow();
+    expect(computeCollectionHash(props)).toBe('title|word|text');
+  });
+
+  it('handles property with no dataType', () => {
+    const props: PropertyLike[] = [{ name: 'title' }];
+    expect(() => computeCollectionHash(props)).not.toThrow();
+    expect(computeCollectionHash(props)).toBe('title|word|');
+  });
+
+  // ── Nested / object properties ──────────────────────────────────────────────
+
+  it('includes nested properties in fingerprint for object type (scenario 14)', () => {
+    const props: PropertyLike[] = [
+      {
+        name: 'meta',
+        dataType: ['object'],
+        nestedProperties: [
+          { name: 'author', dataType: ['text'] },
+          { name: 'year', dataType: ['int'] },
+        ],
+      },
+    ];
+    expect(computeCollectionHash(props)).toBe('meta|word|object{author|word|text;year|word|int}');
+  });
+
+  it('sorts nested properties alphabetically (scenario 14)', () => {
+    const propsA: PropertyLike[] = [
+      {
+        name: 'meta',
+        dataType: ['object'],
+        nestedProperties: [
+          { name: 'year', dataType: ['int'] },
+          { name: 'author', dataType: ['text'] },
+        ],
+      },
+    ];
+    const propsB: PropertyLike[] = [
+      {
+        name: 'meta',
+        dataType: ['object'],
+        nestedProperties: [
+          { name: 'author', dataType: ['text'] },
+          { name: 'year', dataType: ['int'] },
+        ],
+      },
+    ];
+    expect(computeCollectionHash(propsA)).toBe(computeCollectionHash(propsB));
+  });
+
+  it('produces different hashes for different nested property names (scenario 15)', () => {
+    const propsA: PropertyLike[] = [
+      {
+        name: 'meta',
+        dataType: ['object'],
+        nestedProperties: [{ name: 'author', dataType: ['text'] }],
+      },
+    ];
+    const propsB: PropertyLike[] = [
+      {
+        name: 'meta',
+        dataType: ['object'],
+        nestedProperties: [{ name: 'writer', dataType: ['text'] }],
+      },
+    ];
+    expect(computeCollectionHash(propsA)).not.toBe(computeCollectionHash(propsB));
+  });
+
+  it('produces different hashes for different nested tokenizations (scenario 16)', () => {
+    const propsA: PropertyLike[] = [
+      {
+        name: 'meta',
+        dataType: ['object'],
+        nestedProperties: [{ name: 'tag', dataType: ['text'], tokenization: 'word' }],
+      },
+    ];
+    const propsB: PropertyLike[] = [
+      {
+        name: 'meta',
+        dataType: ['object'],
+        nestedProperties: [{ name: 'tag', dataType: ['text'], tokenization: 'field' }],
+      },
+    ];
+    expect(computeCollectionHash(propsA)).not.toBe(computeCollectionHash(propsB));
+  });
+
+  it('handles 3-level deep nesting consistently (scenario 17)', () => {
+    const deep: PropertyLike[] = [
+      {
+        name: 'level1',
+        dataType: ['object'],
+        nestedProperties: [
+          {
+            name: 'level2',
+            dataType: ['object'],
+            nestedProperties: [{ name: 'level3', dataType: ['text'] }],
+          },
+        ],
+      },
+    ];
+    const deepCopy: PropertyLike[] = [
+      {
+        name: 'level1',
+        dataType: ['object'],
+        nestedProperties: [
+          {
+            name: 'level2',
+            dataType: ['object'],
+            nestedProperties: [{ name: 'level3', dataType: ['text'] }],
+          },
+        ],
+      },
+    ];
+    expect(computeCollectionHash(deep)).toBe(computeCollectionHash(deepCopy));
+    expect(computeCollectionHash(deep)).toBe(
+      'level1|word|object{level2|word|object{level3|word|text}}'
+    );
+  });
+
+  it('object type with no nestedProperties produces no nested segment (scenario 18)', () => {
+    const propsA: PropertyLike[] = [{ name: 'meta', dataType: ['object'] }];
+    const propsB: PropertyLike[] = [{ name: 'meta', dataType: ['object'], nestedProperties: [] }];
+    expect(computeCollectionHash(propsA)).toBe(computeCollectionHash(propsB));
+    expect(computeCollectionHash(propsA)).toBe('meta|word|object');
+  });
+
+  it('multi-type property including object sorts types and appends nested (scenario 19)', () => {
+    const props: PropertyLike[] = [
+      {
+        name: 'ref',
+        dataType: ['text', 'object'],
+        nestedProperties: [{ name: 'id', dataType: ['int'] }],
+      },
+    ];
+    expect(computeCollectionHash(props)).toBe('ref|word|object+text{id|word|int}');
+  });
+});
+
+// ─── findMultiTenantCandidates ─────────────────────────────────────────────────
+
+describe('findMultiTenantCandidates', () => {
+  it('returns empty array for empty collection list (scenario 1)', () => {
+    expect(findMultiTenantCandidates([])).toHaveLength(0);
+  });
+
+  it('returns empty array for a single collection (scenario 2)', () => {
+    const cols = [makeCollection('A', [{ name: 'title', dataType: ['text'] }])];
+    expect(findMultiTenantCandidates(cols)).toHaveLength(0);
+  });
+
+  it('groups two collections with identical flat properties (scenario 3)', () => {
+    const props: PropertyLike[] = [{ name: 'title', dataType: ['text'], tokenization: 'word' }];
+    const cols = [makeCollection('ColA', props), makeCollection('ColB', props)];
+    const result = findMultiTenantCandidates(cols);
+    expect(result).toHaveLength(1);
+    expect(groupNames(result[0])).toEqual(expect.arrayContaining(['ColA', 'ColB']));
+    expect(result[0].count).toBe(2);
+  });
+
+  it('groups two matching collections and excludes the different one (scenario 4)', () => {
+    const sharedProps: PropertyLike[] = [{ name: 'title', dataType: ['text'] }];
+    const uniqueProps: PropertyLike[] = [{ name: 'score', dataType: ['int'] }];
+    const cols = [
+      makeCollection('ColA', sharedProps),
+      makeCollection('ColB', sharedProps),
+      makeCollection('ColC', uniqueProps),
+    ];
+    const result = findMultiTenantCandidates(cols);
+    expect(result).toHaveLength(1);
+    expect(groupNames(result[0])).toEqual(expect.arrayContaining(['ColA', 'ColB']));
+    expect(groupNames(result[0])).not.toContain('ColC');
+  });
+
+  it('excludes collections with multiTenancy already enabled (scenario 9)', () => {
+    const props: PropertyLike[] = [{ name: 'title', dataType: ['text'] }];
+    const cols = [
+      makeCollection('ColA', props, false),
+      makeCollection('ColB', props, true), // already MT
+    ];
+    expect(findMultiTenantCandidates(cols)).toHaveLength(0);
+  });
+
+  it('does not group when only one non-MT collection remains after exclusion (scenario 10)', () => {
+    const props: PropertyLike[] = [{ name: 'title', dataType: ['text'] }];
+    const cols = [
+      makeCollection('ColA', props, false),
+      makeCollection('ColB', props, true), // excluded
+      makeCollection('ColC', props, true), // excluded
+    ];
+    expect(findMultiTenantCandidates(cols)).toHaveLength(0);
+  });
+
+  it('groups all no-property collections together (scenario 8)', () => {
+    const cols = [
+      makeCollection('Empty1', []),
+      makeCollection('Empty2', []),
+      makeCollection('Empty3', []),
+    ];
+    const result = findMultiTenantCandidates(cols);
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(3);
+  });
+
+  it('does not group collections with different schemas', () => {
+    const cols = [
+      makeCollection('ColA', [{ name: 'title', dataType: ['text'] }]),
+      makeCollection('ColB', [{ name: 'score', dataType: ['int'] }]),
+    ];
+    expect(findMultiTenantCandidates(cols)).toHaveLength(0);
+  });
+
+  it('returns multiple independent candidate groups', () => {
+    const propsGroup1: PropertyLike[] = [{ name: 'title', dataType: ['text'] }];
+    const propsGroup2: PropertyLike[] = [{ name: 'score', dataType: ['int'] }];
+    const cols = [
+      makeCollection('A1', propsGroup1),
+      makeCollection('A2', propsGroup1),
+      makeCollection('B1', propsGroup2),
+      makeCollection('B2', propsGroup2),
+    ];
+    const result = findMultiTenantCandidates(cols);
+    expect(result).toHaveLength(2);
+  });
+
+  // ── Object count integration ────────────────────────────────────────────────
+
+  it('uses objectCounts to populate entry counts, defaulting to 0', () => {
+    const props: PropertyLike[] = [{ name: 'title', dataType: ['text'] }];
+    const cols = [makeCollection('ColA', props), makeCollection('ColB', props)];
+    const result = findMultiTenantCandidates(cols, { ColA: 500, ColB: 200 });
+    expect(result[0].collections.find((c) => c.name === 'ColA')?.objectCount).toBe(500);
+    expect(result[0].collections.find((c) => c.name === 'ColB')?.objectCount).toBe(200);
+  });
+
+  it('defaults objectCount to 0 when not in objectCounts map', () => {
+    const props: PropertyLike[] = [{ name: 'title', dataType: ['text'] }];
+    const cols = [makeCollection('ColA', props), makeCollection('ColB', props)];
+    const result = findMultiTenantCandidates(cols, {});
+    expect(result[0].collections[0].objectCount).toBe(0);
+    expect(result[0].collections[1].objectCount).toBe(0);
+  });
+
+  it('sorts collections within a group by objectCount descending', () => {
+    const props: PropertyLike[] = [{ name: 'title', dataType: ['text'] }];
+    const cols = [
+      makeCollection('Small', props),
+      makeCollection('Large', props),
+      makeCollection('Medium', props),
+    ];
+    const result = findMultiTenantCandidates(cols, { Small: 10, Large: 1000, Medium: 300 });
+    const names = groupNames(result[0]);
+    expect(names[0]).toBe('Large');
+    expect(names[1]).toBe('Medium');
+    expect(names[2]).toBe('Small');
+  });
+
+  it('computes totalObjects correctly', () => {
+    const props: PropertyLike[] = [{ name: 'title', dataType: ['text'] }];
+    const cols = [makeCollection('ColA', props), makeCollection('ColB', props)];
+    const result = findMultiTenantCandidates(cols, { ColA: 400, ColB: 100 });
+    expect(result[0].totalObjects).toBe(500);
+  });
+
+  it('sorts groups by totalObjects descending so highest-impact group is first', () => {
+    const propsG1: PropertyLike[] = [{ name: 'x', dataType: ['text'] }];
+    const propsG2: PropertyLike[] = [{ name: 'y', dataType: ['int'] }];
+    const cols = [
+      makeCollection('G1A', propsG1),
+      makeCollection('G1B', propsG1),
+      makeCollection('G2A', propsG2),
+      makeCollection('G2B', propsG2),
+    ];
+    // Group 2 has more total objects
+    const result = findMultiTenantCandidates(cols, { G1A: 100, G1B: 50, G2A: 2000, G2B: 1000 });
+    expect(result[0].totalObjects).toBe(3000); // G2 group first
+    expect(result[1].totalObjects).toBe(150); // G1 group second
+    expect(groupNames(result[0])).toEqual(expect.arrayContaining(['G2A', 'G2B']));
+  });
+
+  it('works correctly without objectCounts parameter (all zeros, stable sort)', () => {
+    const props: PropertyLike[] = [{ name: 'title', dataType: ['text'] }];
+    const cols = [makeCollection('ColA', props), makeCollection('ColB', props)];
+    const result = findMultiTenantCandidates(cols);
+    expect(result).toHaveLength(1);
+    expect(result[0].totalObjects).toBe(0);
+    expect(result[0].collections.every((c) => c.objectCount === 0)).toBe(true);
+  });
+});
+
+// ─── computeCandidatesDismissKey ──────────────────────────────────────────────
+
+describe('computeCandidatesDismissKey', () => {
+  it('returns empty string for empty groups array', () => {
+    expect(computeCandidatesDismissKey([])).toBe('');
+  });
+
+  it('returns sorted collection names joined by comma', () => {
+    const groups: MtCandidateGroup[] = [
+      {
+        collections: [
+          { name: 'ColB', objectCount: 0 },
+          { name: 'ColA', objectCount: 0 },
+        ],
+        count: 2,
+        totalObjects: 0,
+      },
+    ];
+    expect(computeCandidatesDismissKey(groups)).toBe('ColA,ColB');
+  });
+
+  it('flattens and sorts across multiple groups', () => {
+    const groups: MtCandidateGroup[] = [
+      {
+        collections: [
+          { name: 'ColD', objectCount: 0 },
+          { name: 'ColA', objectCount: 0 },
+        ],
+        count: 2,
+        totalObjects: 0,
+      },
+      {
+        collections: [
+          { name: 'ColC', objectCount: 0 },
+          { name: 'ColB', objectCount: 0 },
+        ],
+        count: 2,
+        totalObjects: 0,
+      },
+    ];
+    expect(computeCandidatesDismissKey(groups)).toBe('ColA,ColB,ColC,ColD');
+  });
+
+  it('produces different keys when collections change', () => {
+    const before: MtCandidateGroup[] = [
+      {
+        collections: [
+          { name: 'ColA', objectCount: 0 },
+          { name: 'ColB', objectCount: 0 },
+        ],
+        count: 2,
+        totalObjects: 0,
+      },
+    ];
+    const after: MtCandidateGroup[] = [
+      {
+        collections: [
+          { name: 'ColA', objectCount: 0 },
+          { name: 'ColB', objectCount: 0 },
+          { name: 'ColC', objectCount: 0 },
+        ],
+        count: 3,
+        totalObjects: 0,
+      },
+    ];
+    expect(computeCandidatesDismissKey(before)).not.toBe(computeCandidatesDismissKey(after));
+  });
+});

--- a/src/utils/__tests__/multiTenancyCheck.test.ts
+++ b/src/utils/__tests__/multiTenancyCheck.test.ts
@@ -2,7 +2,10 @@ import {
   computeCollectionHash,
   computeCandidatesDismissKey,
   findMultiTenantCandidates,
+  findEmptyShards,
+  findReplicationImbalances,
   MtCandidateGroup,
+  NodeLike,
   PropertyLike,
 } from '../multiTenancyCheck';
 import { CollectionWithSchema } from '../../types';
@@ -457,5 +460,150 @@ describe('computeCandidatesDismissKey', () => {
       },
     ];
     expect(computeCandidatesDismissKey(before)).not.toBe(computeCandidatesDismissKey(after));
+  });
+});
+
+// ─── findEmptyShards ──────────────────────────────────────────────────────────
+
+function makeNode(
+  name: string,
+  shards: { class: string; name: string; objectCount: number }[]
+): NodeLike {
+  return { name, shards };
+}
+
+describe('findEmptyShards', () => {
+  it('returns empty array when there are no nodes', () => {
+    expect(findEmptyShards([])).toHaveLength(0);
+  });
+
+  it('returns empty array when no shards have zero objects', () => {
+    const nodes = [makeNode('node-1', [{ class: 'Article', name: 'shard-1', objectCount: 100 }])];
+    expect(findEmptyShards(nodes)).toHaveLength(0);
+  });
+
+  it('reports a shard with zero objects', () => {
+    const nodes = [makeNode('node-1', [{ class: 'Article', name: 'shard-1', objectCount: 0 }])];
+    const result = findEmptyShards(nodes);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      collectionName: 'Article',
+      nodeName: 'node-1',
+      shardName: 'shard-1',
+    });
+  });
+
+  it('reports empty shards across multiple nodes', () => {
+    const nodes = [
+      makeNode('node-1', [{ class: 'Article', name: 'shard-a', objectCount: 0 }]),
+      makeNode('node-2', [{ class: 'Article', name: 'shard-b', objectCount: 0 }]),
+    ];
+    expect(findEmptyShards(nodes)).toHaveLength(2);
+  });
+
+  it('only reports shards with exactly zero objects', () => {
+    const nodes = [
+      makeNode('node-1', [
+        { class: 'Article', name: 'shard-empty', objectCount: 0 },
+        { class: 'Article', name: 'shard-full', objectCount: 1 },
+      ]),
+    ];
+    const result = findEmptyShards(nodes);
+    expect(result).toHaveLength(1);
+    expect(result[0].shardName).toBe('shard-empty');
+  });
+
+  it('skips collections listed in skipCollections', () => {
+    const nodes = [
+      makeNode('node-1', [
+        { class: 'MTCollection', name: 'tenant-shard', objectCount: 0 },
+        { class: 'RegularCollection', name: 'empty-shard', objectCount: 0 },
+      ]),
+    ];
+    const result = findEmptyShards(nodes, new Set(['MTCollection']));
+    expect(result).toHaveLength(1);
+    expect(result[0].collectionName).toBe('RegularCollection');
+  });
+
+  it('handles nodes with null/undefined shards gracefully', () => {
+    const nodes: NodeLike[] = [{ name: 'node-1', shards: null }];
+    expect(() => findEmptyShards(nodes)).not.toThrow();
+    expect(findEmptyShards(nodes)).toHaveLength(0);
+  });
+});
+
+// ─── findReplicationImbalances ────────────────────────────────────────────────
+
+describe('findReplicationImbalances', () => {
+  it('returns empty array when there are no nodes', () => {
+    expect(findReplicationImbalances([])).toHaveLength(0);
+  });
+
+  it('returns empty array when each shard appears on only one node', () => {
+    const nodes = [
+      makeNode('node-1', [{ class: 'Article', name: 'shard-1', objectCount: 100 }]),
+      makeNode('node-2', [{ class: 'Article', name: 'shard-2', objectCount: 200 }]),
+    ];
+    expect(findReplicationImbalances(nodes)).toHaveLength(0);
+  });
+
+  it('returns empty array when replicas have matching object counts', () => {
+    const nodes = [
+      makeNode('node-1', [{ class: 'Article', name: 'shard-1', objectCount: 100 }]),
+      makeNode('node-2', [{ class: 'Article', name: 'shard-1', objectCount: 100 }]),
+    ];
+    expect(findReplicationImbalances(nodes)).toHaveLength(0);
+  });
+
+  it('detects an imbalance when the same shard has different counts on two nodes', () => {
+    const nodes = [
+      makeNode('node-1', [{ class: 'Article', name: 'shard-1', objectCount: 100 }]),
+      makeNode('node-2', [{ class: 'Article', name: 'shard-1', objectCount: 90 }]),
+    ];
+    const result = findReplicationImbalances(nodes);
+    expect(result).toHaveLength(1);
+    expect(result[0].collectionName).toBe('Article');
+    expect(result[0].shards).toHaveLength(1);
+    expect(result[0].shards[0].shardName).toBe('shard-1');
+    expect(result[0].shards[0].replicas).toHaveLength(2);
+  });
+
+  it('only flags the imbalanced shard when a collection has a mix', () => {
+    const nodes = [
+      makeNode('node-1', [
+        { class: 'Article', name: 'balanced', objectCount: 50 },
+        { class: 'Article', name: 'skewed', objectCount: 100 },
+      ]),
+      makeNode('node-2', [
+        { class: 'Article', name: 'balanced', objectCount: 50 },
+        { class: 'Article', name: 'skewed', objectCount: 10 },
+      ]),
+    ];
+    const result = findReplicationImbalances(nodes);
+    expect(result).toHaveLength(1);
+    expect(result[0].shards).toHaveLength(1);
+    expect(result[0].shards[0].shardName).toBe('skewed');
+  });
+
+  it('reports imbalances across multiple collections independently', () => {
+    const nodes = [
+      makeNode('node-1', [
+        { class: 'Article', name: 'shard-a', objectCount: 100 },
+        { class: 'Comment', name: 'shard-b', objectCount: 200 },
+      ]),
+      makeNode('node-2', [
+        { class: 'Article', name: 'shard-a', objectCount: 50 },
+        { class: 'Comment', name: 'shard-b', objectCount: 199 },
+      ]),
+    ];
+    const result = findReplicationImbalances(nodes);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.collectionName).sort()).toEqual(['Article', 'Comment']);
+  });
+
+  it('handles nodes with null/undefined shards gracefully', () => {
+    const nodes: NodeLike[] = [{ name: 'node-1', shards: undefined }];
+    expect(() => findReplicationImbalances(nodes)).not.toThrow();
+    expect(findReplicationImbalances(nodes)).toHaveLength(0);
   });
 });

--- a/src/utils/__tests__/multiTenancyCheck.test.ts
+++ b/src/utils/__tests__/multiTenancyCheck.test.ts
@@ -295,15 +295,14 @@ describe('findMultiTenantCandidates', () => {
     expect(findMultiTenantCandidates(cols)).toHaveLength(0);
   });
 
-  it('groups all no-property collections together (scenario 8)', () => {
+  it('excludes no-property collections — they have no meaningful schema to compare (scenario 8)', () => {
     const cols = [
       makeCollection('Empty1', []),
       makeCollection('Empty2', []),
       makeCollection('Empty3', []),
     ];
-    const result = findMultiTenantCandidates(cols);
-    expect(result).toHaveLength(1);
-    expect(result[0].count).toBe(3);
+    // Collections without properties are skipped: no schema fingerprint to compare.
+    expect(findMultiTenantCandidates(cols)).toHaveLength(0);
   });
 
   it('does not group collections with different schemas', () => {

--- a/src/utils/multiTenancyCheck.ts
+++ b/src/utils/multiTenancyCheck.ts
@@ -1,0 +1,198 @@
+/**
+ * Multi-tenancy compatibility checker.
+ *
+ * Collections with identical property fingerprints (same property names, tokenization,
+ * and data types) can be consolidated into a single multi-tenant collection in Weaviate.
+ *
+ * @see https://docs.weaviate.io/weaviate/manage-collections/multi-tenancy
+ */
+
+import { CollectionWithSchema } from '../types';
+
+export interface PropertyLike {
+  name: string;
+  dataType?: string | string[];
+  tokenization?: string | null;
+  nestedProperties?: PropertyLike[];
+}
+
+/** A single collection entry within a candidate group, with its object count. */
+export interface MtCollectionEntry {
+  name: string;
+  /** Total object count across all shards/nodes. 0 when node data is unavailable. */
+  objectCount: number;
+}
+
+/**
+ * A group of collections that share an identical schema fingerprint and could
+ * be consolidated into a single multi-tenant collection.
+ *
+ * Collections are sorted by `objectCount` descending so the most-impactful
+ * migration candidate appears first.
+ */
+export interface MtCandidateGroup {
+  /** Collections in this group, sorted by objectCount descending. */
+  collections: MtCollectionEntry[];
+  /** Number of collections in this group (= collections.length). */
+  count: number;
+  /** Sum of objectCount across all collections in the group. */
+  totalObjects: number;
+}
+
+/**
+ * The result payload returned by a full checks run.
+ * Serialized to globalState so it survives panel close/reopen.
+ */
+export interface ChecksResult {
+  /** ISO-8601 timestamp of when the check was last run. */
+  timestamp: string;
+  multiTenancy: {
+    groups: MtCandidateGroup[];
+    hasIssues: boolean;
+  };
+}
+
+// ─── Internal hash helpers ────────────────────────────────────────────────────
+
+/**
+ * Normalizes tokenization: null / undefined / blank → "word" (Weaviate default).
+ */
+function normalizeTokenization(t: string | null | undefined): string {
+  if (!t || t.trim() === '') {
+    return 'word';
+  }
+  return t;
+}
+
+/**
+ * Computes a deterministic fingerprint segment for a single property.
+ * Format: `name|tokenization|type1+type2`
+ * For object/object[] types, nested properties are appended as `{nestedFingerprint}`.
+ */
+function computePropertyFingerprint(prop: PropertyLike): string {
+  const name = prop.name;
+  const tokenization = normalizeTokenization(prop.tokenization);
+
+  // Normalize dataType to a sorted array to guarantee consistent ordering
+  let dataTypeArr: string[];
+  if (Array.isArray(prop.dataType)) {
+    dataTypeArr = [...prop.dataType].sort();
+  } else if (prop.dataType) {
+    dataTypeArr = [prop.dataType];
+  } else {
+    dataTypeArr = [];
+  }
+  const dataType = dataTypeArr.join('+');
+
+  let segment = `${name}|${tokenization}|${dataType}`;
+
+  // Recursively fingerprint nested properties (object / object[] types)
+  if (prop.nestedProperties && prop.nestedProperties.length > 0) {
+    segment += `{${buildPropertiesFingerprint(prop.nestedProperties)}}`;
+  }
+
+  return segment;
+}
+
+/**
+ * Sorts properties by name and concatenates their fingerprints with `;`.
+ * Sorting guarantees that property declaration order does not affect the result.
+ */
+function buildPropertiesFingerprint(properties: PropertyLike[]): string {
+  return [...properties]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(computePropertyFingerprint)
+    .join(';');
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Computes a deterministic fingerprint for a collection's full property list.
+ * Returns `""` for collections with no properties.
+ *
+ * Two collections with the same hash have identical schemas and are candidates
+ * for consolidation into a single multi-tenant collection.
+ */
+export function computeCollectionHash(properties: PropertyLike[]): string {
+  if (!properties || properties.length === 0) {
+    return '';
+  }
+  return buildPropertiesFingerprint(properties);
+}
+
+/**
+ * Finds groups of collections that share identical schema fingerprints.
+ *
+ * Collections that already have multi-tenancy enabled are excluded — they are
+ * already consolidated and do not need to be warned about.
+ *
+ * Within each group, collections are sorted by `objectCount` descending.
+ * Groups themselves are sorted by `totalObjects` descending so the
+ * highest-impact candidates appear first.
+ *
+ * @param collections  All collections for a connection.
+ * @param objectCounts Optional map of collection name → total object count,
+ *                     derived from cluster node shard data.
+ * @returns Array of candidate groups (only groups with ≥ 2 collections).
+ */
+export function findMultiTenantCandidates(
+  collections: CollectionWithSchema[],
+  objectCounts?: Record<string, number>
+): MtCandidateGroup[] {
+  const hashToEntries = new Map<string, MtCollectionEntry[]>();
+
+  for (const col of collections) {
+    // Skip collections already using multi-tenancy
+    if (col.schema?.multiTenancy?.enabled) {
+      continue;
+    }
+
+    const properties = (col.schema?.properties as PropertyLike[] | undefined) ?? [];
+    const hash = computeCollectionHash(properties);
+    const entry: MtCollectionEntry = {
+      name: col.label,
+      objectCount: objectCounts?.[col.label] ?? 0,
+    };
+
+    const existing = hashToEntries.get(hash);
+    if (existing) {
+      existing.push(entry);
+    } else {
+      hashToEntries.set(hash, [entry]);
+    }
+  }
+
+  const groups: MtCandidateGroup[] = [];
+
+  for (const entries of hashToEntries.values()) {
+    if (entries.length < 2) {
+      continue;
+    }
+
+    // Sort collections within the group by object count descending
+    const sorted = [...entries].sort((a, b) => b.objectCount - a.objectCount);
+    const totalObjects = sorted.reduce((sum, e) => sum + e.objectCount, 0);
+
+    groups.push({ collections: sorted, count: sorted.length, totalObjects });
+  }
+
+  // Sort groups by total objects descending — highest-impact first
+  groups.sort((a, b) => b.totalObjects - a.totalObjects);
+
+  return groups;
+}
+
+/**
+ * Creates a stable string key representing the current MT candidate state.
+ *
+ * Stored in globalState to track dismiss actions. If the schema changes
+ * (collections added, removed, or modified), the key changes and the warning
+ * reappears automatically without requiring any manual reset.
+ */
+export function computeCandidatesDismissKey(groups: MtCandidateGroup[]): string {
+  return groups
+    .flatMap((g) => g.collections.map((c) => c.name))
+    .sort()
+    .join(',');
+}

--- a/src/utils/multiTenancyCheck.ts
+++ b/src/utils/multiTenancyCheck.ts
@@ -150,6 +150,10 @@ export function findMultiTenantCandidates(
 
     const properties = (col.schema?.properties as PropertyLike[] | undefined) ?? [];
     const hash = computeCollectionHash(properties);
+    // Skip collections with no properties — they have no meaningful schema to compare
+    if (!hash) {
+      continue;
+    }
     const entry: MtCollectionEntry = {
       name: col.label,
       objectCount: objectCounts?.[col.label] ?? 0,

--- a/src/utils/multiTenancyCheck.ts
+++ b/src/utils/multiTenancyCheck.ts
@@ -39,6 +39,52 @@ export interface MtCandidateGroup {
   totalObjects: number;
 }
 
+// ─── Shared node/shard shape ─────────────────────────────────────────────────
+
+/** Minimal shard shape required by cluster checks (compatible with weaviate-client Node). */
+export interface ShardLike {
+  class: string;
+  name: string;
+  objectCount: number;
+}
+
+/** Minimal node shape required by cluster checks. */
+export interface NodeLike {
+  name: string;
+  shards: ShardLike[] | null | undefined;
+}
+
+// ─── Empty shards check ───────────────────────────────────────────────────────
+
+/** A single shard entry identified as empty. */
+export interface EmptyShardEntry {
+  collectionName: string;
+  nodeName: string;
+  shardName: string;
+}
+
+// ─── Replication imbalance check ─────────────────────────────────────────────
+
+/** Object-count breakdown for one replica of a shard. */
+export interface ShardReplica {
+  nodeName: string;
+  objectCount: number;
+}
+
+/** A shard whose replicas have mismatched object counts. */
+export interface ImbalancedShard {
+  shardName: string;
+  replicas: ShardReplica[];
+}
+
+/** A collection that contains at least one imbalanced shard. */
+export interface ReplicationImbalanceCollection {
+  collectionName: string;
+  shards: ImbalancedShard[];
+}
+
+// ─── Combined result ──────────────────────────────────────────────────────────
+
 /**
  * The result payload returned by a full checks run.
  * Serialized to globalState so it survives panel close/reopen.
@@ -46,8 +92,18 @@ export interface MtCandidateGroup {
 export interface ChecksResult {
   /** ISO-8601 timestamp of when the check was last run. */
   timestamp: string;
+  /** True when any individual check has issues. */
+  hasIssues: boolean;
   multiTenancy: {
     groups: MtCandidateGroup[];
+    hasIssues: boolean;
+  };
+  emptyShards: {
+    entries: EmptyShardEntry[];
+    hasIssues: boolean;
+  };
+  replicationImbalance: {
+    collections: ReplicationImbalanceCollection[];
     hasIssues: boolean;
   };
 }
@@ -185,6 +241,85 @@ export function findMultiTenantCandidates(
   groups.sort((a, b) => b.totalObjects - a.totalObjects);
 
   return groups;
+}
+
+/**
+ * Finds shards with zero objects across all nodes.
+ *
+ * Multi-tenant collections are skipped via `skipCollections` because individual
+ * tenant shards start empty by design and would generate false positives.
+ *
+ * @param nodes           Verbose cluster node data.
+ * @param skipCollections Collection names to exclude (e.g. MT-enabled ones).
+ */
+export function findEmptyShards(
+  nodes: NodeLike[],
+  skipCollections?: Set<string>
+): EmptyShardEntry[] {
+  const result: EmptyShardEntry[] = [];
+  for (const node of nodes) {
+    for (const shard of node.shards ?? []) {
+      if (skipCollections?.has(shard.class)) {
+        continue;
+      }
+      if (shard.objectCount === 0) {
+        result.push({
+          collectionName: shard.class,
+          nodeName: node.name,
+          shardName: shard.name,
+        });
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Finds collections whose shards have inconsistent object counts across replicas.
+ *
+ * When the same shard name appears on multiple nodes (replication factor > 1)
+ * with different object counts, it may indicate async replication is disabled
+ * or lagging behind.
+ *
+ * Note: object counts in node status are not immediately synchronised and may
+ * be slightly delayed, so small short-lived discrepancies are expected.
+ */
+export function findReplicationImbalances(nodes: NodeLike[]): ReplicationImbalanceCollection[] {
+  // collectionName → shardName → replicas
+  const byCollection = new Map<string, Map<string, ShardReplica[]>>();
+
+  for (const node of nodes) {
+    for (const shard of node.shards ?? []) {
+      if (!byCollection.has(shard.class)) {
+        byCollection.set(shard.class, new Map());
+      }
+      const byShardName = byCollection.get(shard.class)!;
+      if (!byShardName.has(shard.name)) {
+        byShardName.set(shard.name, []);
+      }
+      byShardName.get(shard.name)!.push({ nodeName: node.name, objectCount: shard.objectCount });
+    }
+  }
+
+  const result: ReplicationImbalanceCollection[] = [];
+
+  for (const [collectionName, byShardName] of byCollection) {
+    const imbalanced: ImbalancedShard[] = [];
+    for (const [shardName, replicas] of byShardName) {
+      if (replicas.length < 2) {
+        continue; // single replica — nothing to compare
+      }
+      const first = replicas[0].objectCount;
+      if (replicas.some((r) => r.objectCount !== first)) {
+        imbalanced.push({ shardName, replicas });
+      }
+    }
+    if (imbalanced.length > 0) {
+      result.push({ collectionName, shards: imbalanced });
+    }
+  }
+
+  return result;
 }
 
 /**

--- a/src/views/ClusterPanel.ts
+++ b/src/views/ClusterPanel.ts
@@ -13,8 +13,11 @@ export class ClusterPanel {
   private _disposables: vscode.Disposable[] = [];
   private readonly _connectionId: string;
   /** Holds the init payload until the webview signals it is ready. */
-  private _pendingInitData: { nodeStatusData: any; openClusterViewOnConnect?: boolean } | null =
-    null;
+  private _pendingInitData: {
+    nodeStatusData: any;
+    openClusterViewOnConnect?: boolean;
+    checksResult?: any;
+  } | null = null;
 
   private constructor(
     panel: vscode.WebviewPanel,
@@ -54,7 +57,8 @@ export class ClusterPanel {
     nodeStatusData: any,
     connectionName: string,
     onMessageCallback?: (message: any, postMessage: (msg: any) => void) => Promise<void>,
-    openClusterViewOnConnect?: boolean
+    openClusterViewOnConnect?: boolean,
+    checksResult?: any
   ): ClusterPanel {
     const column = vscode.window.activeTextEditor
       ? vscode.window.activeTextEditor.viewColumn
@@ -63,12 +67,14 @@ export class ClusterPanel {
     // If we already have a panel, show it and update data.
     if (ClusterPanel.currentPanel) {
       ClusterPanel.currentPanel._panel.reveal(column);
-      // Send update command to the webview with new data
-      ClusterPanel.currentPanel.postMessage({
-        command: 'updateData',
-        nodeStatusData,
-        openClusterViewOnConnect,
-      });
+      // Only send update if we have real data; if null, caller will send updateData separately.
+      if (nodeStatusData != null) {
+        ClusterPanel.currentPanel.postMessage({
+          command: 'updateData',
+          nodeStatusData,
+          openClusterViewOnConnect,
+        });
+      }
       return ClusterPanel.currentPanel;
     }
 
@@ -78,16 +84,11 @@ export class ClusterPanel {
       `Cluster Info: ${connectionName}`,
       column || vscode.ViewColumn.One,
       {
-        // Enable javascript in the webview
         enableScripts: true,
-
-        // And restrict the webview to only loading content from our extension's directory.
         localResourceRoots: [
           vscode.Uri.joinPath(extensionUri, 'dist'),
           vscode.Uri.joinPath(extensionUri, 'out'),
         ],
-
-        // Retain content when hidden
         retainContextWhenHidden: true,
       }
     );
@@ -104,10 +105,12 @@ export class ClusterPanel {
       onMessageCallback
     );
 
-    // Store init data to be delivered once the webview signals it is ready.
-    // Posting immediately would race against the React bundle loading and the
-    // message would be lost before the event listener is attached.
-    ClusterPanel.currentPanel._pendingInitData = { nodeStatusData, openClusterViewOnConnect };
+    // Store init data — sent when the webview signals ready.
+    ClusterPanel.currentPanel._pendingInitData = {
+      nodeStatusData,
+      openClusterViewOnConnect,
+      checksResult,
+    };
 
     // Track feature opened event
     getTelemetryService().trackUsage(TELEMETRY_EVENTS.CLUSTER_OPENED);
@@ -127,10 +130,7 @@ export class ClusterPanel {
    */
   public dispose(): void {
     ClusterPanel.currentPanel = undefined;
-
-    // Clean up resources
     this._panel.dispose();
-
     while (this._disposables.length) {
       const disposable = this._disposables.pop();
       if (disposable) {
@@ -139,43 +139,37 @@ export class ClusterPanel {
     }
   }
 
-  /**
-   * Gets the connection ID for this panel
-   */
   public getConnectionId(): string {
     return this._connectionId;
   }
 
-  /**
-   * Closes the panel if it's for the specified connection
-   */
   public static closeForConnection(connectionId: string): void {
     if (ClusterPanel.currentPanel && ClusterPanel.currentPanel.getConnectionId() === connectionId) {
       ClusterPanel.currentPanel.dispose();
     }
   }
 
-  /**
-   * Handles messages from the webview
-   */
   private async _handleMessage(message: any): Promise<void> {
+    // Handle 'ready' immediately — send init before awaiting any async callback,
+    // so the webview is never blocked waiting for a long-running handler.
+    if (message.command === 'ready') {
+      if (this._pendingInitData) {
+        this.postMessage({
+          command: 'init',
+          nodeStatusData: this._pendingInitData.nodeStatusData,
+          openClusterViewOnConnect: this._pendingInitData.openClusterViewOnConnect,
+          checksResult: this._pendingInitData.checksResult,
+        });
+        // Keep a copy so repeated 'ready' from React StrictMode double-invoke still works.
+        this._pendingInitData = null;
+      }
+    }
+
     if (this.onMessageCallback) {
       await this.onMessageCallback(message, this.postMessage.bind(this));
     }
 
     switch (message.command) {
-      case 'ready':
-        // Webview has mounted and its message listener is now active.
-        // Flush any pending init data that was stored before the webview was ready.
-        if (this._pendingInitData) {
-          this.postMessage({
-            command: 'init',
-            nodeStatusData: this._pendingInitData.nodeStatusData,
-            openClusterViewOnConnect: this._pendingInitData.openClusterViewOnConnect,
-          });
-          this._pendingInitData = null;
-        }
-        break;
       case 'error':
         vscode.window.showErrorMessage(message.text);
         break;
@@ -185,36 +179,22 @@ export class ClusterPanel {
     }
   }
 
-  /**
-   * Updates the webview HTML content
-   */
   private _update(): void {
-    const webview = this._panel.webview;
-    this._panel.webview.html = this._getHtmlForWebview(webview);
+    this._panel.webview.html = this._getHtmlForWebview(this._panel.webview);
   }
 
-  /**
-   * Generates the HTML content for the webview
-   */
   private _getHtmlForWebview(webview: vscode.Webview): string {
-    // Path to dist/webview folder
     const distPath = vscode.Uri.joinPath(this._extensionUri, 'dist', 'webview');
-
-    // Try to read the built HTML file
     const htmlPath = path.join(distPath.fsPath, 'cluster.html');
 
     let html: string;
     try {
       html = fs.readFileSync(htmlPath, 'utf8');
     } catch (error) {
-      // If the file doesn't exist, show an error message
-      return `<!DOCTYPE html>
-        <html>
-        <body>
-          <h1>Error loading Cluster panel</h1>
-          <p>The webview bundle has not been built. Please run: npm run build:webview</p>
-        </body>
-        </html>`;
+      return `<!DOCTYPE html><html><body>
+        <h1>Error loading Cluster panel</h1>
+        <p>The webview bundle has not been built. Please run: npm run build:webview</p>
+        </body></html>`;
     }
 
     // Replace asset paths to use webview URIs
@@ -241,9 +221,6 @@ export class ClusterPanel {
     return html;
   }
 
-  /**
-   * Generates a nonce for CSP
-   */
   private _getNonce(): string {
     let text = '';
     const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';

--- a/src/views/ClusterPanel.ts
+++ b/src/views/ClusterPanel.ts
@@ -7,7 +7,7 @@ import { getTelemetryService, TELEMETRY_EVENTS } from '../telemetry';
  * Manages the Cluster Panel webview
  */
 export class ClusterPanel {
-  public static currentPanel: ClusterPanel | undefined;
+  private static _panels: Map<string, ClusterPanel> = new Map();
   private readonly _panel: vscode.WebviewPanel;
   private readonly _extensionUri: vscode.Uri;
   private _disposables: vscode.Disposable[] = [];
@@ -49,7 +49,8 @@ export class ClusterPanel {
   }
 
   /**
-   * Creates or shows the Cluster panel
+   * Creates or shows the Cluster panel for the given connection.
+   * Each connection gets its own panel instance.
    */
   public static createOrShow(
     extensionUri: vscode.Uri,
@@ -64,18 +65,19 @@ export class ClusterPanel {
       ? vscode.window.activeTextEditor.viewColumn
       : undefined;
 
-    // If we already have a panel, show it and update data.
-    if (ClusterPanel.currentPanel) {
-      ClusterPanel.currentPanel._panel.reveal(column);
+    // If we already have a panel for this connection, show it and update data.
+    const existing = ClusterPanel._panels.get(connectionId);
+    if (existing) {
+      existing._panel.reveal(column);
       // Only send update if we have real data; if null, caller will send updateData separately.
       if (nodeStatusData != null) {
-        ClusterPanel.currentPanel.postMessage({
+        existing.postMessage({
           command: 'updateData',
           nodeStatusData,
           openClusterViewOnConnect,
         });
       }
-      return ClusterPanel.currentPanel;
+      return existing;
     }
 
     // Otherwise, create a new panel.
@@ -98,24 +100,21 @@ export class ClusterPanel {
     };
     panel.iconPath = iconPath;
 
-    ClusterPanel.currentPanel = new ClusterPanel(
-      panel,
-      extensionUri,
-      connectionId,
-      onMessageCallback
-    );
+    const clusterPanel = new ClusterPanel(panel, extensionUri, connectionId, onMessageCallback);
 
     // Store init data — sent when the webview signals ready.
-    ClusterPanel.currentPanel._pendingInitData = {
+    clusterPanel._pendingInitData = {
       nodeStatusData,
       openClusterViewOnConnect,
       checksResult,
     };
 
+    ClusterPanel._panels.set(connectionId, clusterPanel);
+
     // Track feature opened event
     getTelemetryService().trackUsage(TELEMETRY_EVENTS.CLUSTER_OPENED);
 
-    return ClusterPanel.currentPanel;
+    return clusterPanel;
   }
 
   /**
@@ -129,7 +128,7 @@ export class ClusterPanel {
    * Disposes the panel
    */
   public dispose(): void {
-    ClusterPanel.currentPanel = undefined;
+    ClusterPanel._panels.delete(this._connectionId);
     this._panel.dispose();
     while (this._disposables.length) {
       const disposable = this._disposables.pop();
@@ -143,10 +142,12 @@ export class ClusterPanel {
     return this._connectionId;
   }
 
+  public static getPanel(connectionId: string): ClusterPanel | undefined {
+    return ClusterPanel._panels.get(connectionId);
+  }
+
   public static closeForConnection(connectionId: string): void {
-    if (ClusterPanel.currentPanel && ClusterPanel.currentPanel.getConnectionId() === connectionId) {
-      ClusterPanel.currentPanel.dispose();
-    }
+    ClusterPanel._panels.get(connectionId)?.dispose();
   }
 
   private async _handleMessage(message: any): Promise<void> {

--- a/src/views/ClusterPanel.ts
+++ b/src/views/ClusterPanel.ts
@@ -17,6 +17,7 @@ export class ClusterPanel {
     nodeStatusData: any;
     openClusterViewOnConnect?: boolean;
     checksResult?: any;
+    openTab?: string;
   } | null = null;
 
   private constructor(
@@ -125,6 +126,19 @@ export class ClusterPanel {
   }
 
   /**
+   * Requests a tab switch. For new panels (pending init not yet flushed) the switch
+   * is queued alongside the init payload so it isn't lost before the webview loads.
+   * For already-open panels it is sent immediately.
+   */
+  public setPendingTab(tab: string): void {
+    if (this._pendingInitData) {
+      this._pendingInitData.openTab = tab;
+    } else {
+      this.postMessage({ command: 'switchTab', tab });
+    }
+  }
+
+  /**
    * Disposes the panel
    */
   public dispose(): void {
@@ -161,6 +175,9 @@ export class ClusterPanel {
           openClusterViewOnConnect: this._pendingInitData.openClusterViewOnConnect,
           checksResult: this._pendingInitData.checksResult,
         });
+        if (this._pendingInitData.openTab) {
+          this.postMessage({ command: 'switchTab', tab: this._pendingInitData.openTab });
+        }
         // Keep a copy so repeated 'ready' from React StrictMode double-invoke still works.
         this._pendingInitData = null;
       }

--- a/src/views/__tests__/ClusterPanel.test.ts
+++ b/src/views/__tests__/ClusterPanel.test.ts
@@ -10,8 +10,8 @@ describe('ClusterPanel', () => {
   let mockExtensionUri: vscode.Uri;
 
   beforeEach(() => {
-    // Reset singleton
-    (ClusterPanel as any).currentPanel = undefined;
+    // Reset panels map
+    (ClusterPanel as any)._panels = new Map();
 
     mockPanel = {
       webview: {
@@ -76,12 +76,12 @@ describe('ClusterPanel', () => {
 
       ClusterPanel.createOrShow(mockExtensionUri, connectionId, nodeStatusData, 'Test Connection');
 
-      expect(ClusterPanel.currentPanel).toBeDefined();
+      expect(ClusterPanel.getPanel(connectionId)).toBeDefined();
 
       // Close for the same connection
       ClusterPanel.closeForConnection(connectionId);
 
-      expect(ClusterPanel.currentPanel).toBeUndefined();
+      expect(ClusterPanel.getPanel(connectionId)).toBeUndefined();
       expect(mockPanel.dispose).toHaveBeenCalled();
     });
 
@@ -91,14 +91,14 @@ describe('ClusterPanel', () => {
 
       ClusterPanel.createOrShow(mockExtensionUri, connectionId, nodeStatusData, 'Test Connection');
 
-      const panelBefore = ClusterPanel.currentPanel;
+      const panelBefore = ClusterPanel.getPanel(connectionId);
       expect(panelBefore).toBeDefined();
 
       // Try to close for a different connection
       ClusterPanel.closeForConnection('different-connection-456');
 
       // Panel should still be open
-      expect(ClusterPanel.currentPanel).toBe(panelBefore);
+      expect(ClusterPanel.getPanel(connectionId)).toBe(panelBefore);
       expect(mockPanel.dispose).not.toHaveBeenCalled();
     });
 
@@ -132,6 +132,43 @@ describe('ClusterPanel', () => {
       );
     });
 
+    test('creates separate panels for different connections', () => {
+      const connectionId1 = 'connection-aaa';
+      const connectionId2 = 'connection-bbb';
+
+      jest.mocked(vscode.window.createWebviewPanel).mockClear();
+
+      const panel1 = ClusterPanel.createOrShow(
+        mockExtensionUri,
+        connectionId1,
+        { nodes: [{ name: 'node-a' }] },
+        'Connection A'
+      );
+
+      // createWebviewPanel is called once so far
+      expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1);
+
+      const panel2 = ClusterPanel.createOrShow(
+        mockExtensionUri,
+        connectionId2,
+        { nodes: [{ name: 'node-b' }] },
+        'Connection B'
+      );
+
+      // A second panel should have been created
+      expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(2);
+
+      // They must be distinct instances tracked separately
+      expect(panel1).not.toBe(panel2);
+      expect(ClusterPanel.getPanel(connectionId1)).toBe(panel1);
+      expect(ClusterPanel.getPanel(connectionId2)).toBe(panel2);
+
+      // Closing one should not affect the other
+      ClusterPanel.closeForConnection(connectionId1);
+      expect(ClusterPanel.getPanel(connectionId1)).toBeUndefined();
+      expect(ClusterPanel.getPanel(connectionId2)).toBe(panel2);
+    });
+
     test('disposes panel when dispose is called', () => {
       const connectionId = 'test-connection-123';
       const nodeStatusData = { nodes: [] };
@@ -143,14 +180,14 @@ describe('ClusterPanel', () => {
         'Test Connection'
       );
 
-      expect(ClusterPanel.currentPanel).toBe(panel);
+      expect(ClusterPanel.getPanel(connectionId)).toBe(panel);
 
       // Manually call the dispose callback to simulate panel disposal
       if (mockPanel._disposeCallback) {
         mockPanel._disposeCallback();
       }
 
-      expect(ClusterPanel.currentPanel).toBeUndefined();
+      expect(ClusterPanel.getPanel(connectionId)).toBeUndefined();
       expect(mockPanel.dispose).toHaveBeenCalled();
     });
   });
@@ -833,14 +870,14 @@ describe('ClusterPanel', () => {
   });
 
   describe('Dispose and cleanup', () => {
-    test('clears singleton on dispose', () => {
+    test('removes panel from map on dispose', () => {
       const panel = ClusterPanel.createOrShow(mockExtensionUri, 'test-id', { nodes: [] }, 'Test');
 
-      expect(ClusterPanel.currentPanel).toBe(panel);
+      expect(ClusterPanel.getPanel('test-id')).toBe(panel);
 
       panel.dispose();
 
-      expect(ClusterPanel.currentPanel).toBeUndefined();
+      expect(ClusterPanel.getPanel('test-id')).toBeUndefined();
     });
 
     test('disposes all registered disposables', () => {

--- a/src/views/__tests__/ClusterPanel.test.ts
+++ b/src/views/__tests__/ClusterPanel.test.ts
@@ -904,6 +904,147 @@ describe('ClusterPanel', () => {
     });
   });
 
+  describe('Checks integration', () => {
+    const sampleChecksResult = {
+      timestamp: '2024-01-01T00:00:00.000Z',
+      hasIssues: true,
+      multiTenancy: {
+        groups: [
+          {
+            collections: [
+              { name: 'Col1', objectCount: 10 },
+              { name: 'Col2', objectCount: 5 },
+            ],
+            count: 2,
+            totalObjects: 15,
+          },
+        ],
+        hasIssues: true,
+      },
+      emptyShards: { entries: [], hasIssues: false },
+      replicationImbalance: { collections: [], hasIssues: false },
+    };
+
+    test('includes checksResult in init message when provided', () => {
+      const connectionId = 'test-connection-123';
+
+      ClusterPanel.createOrShow(
+        mockExtensionUri,
+        connectionId,
+        { nodes: [] },
+        'Test',
+        undefined,
+        undefined,
+        sampleChecksResult
+      );
+
+      const messageHandler = mockPanel.webview.onDidReceiveMessage.mock.calls[0][0];
+      messageHandler({ command: 'ready' });
+
+      expect(mockPanel.webview.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: 'init',
+          checksResult: sampleChecksResult,
+        })
+      );
+    });
+
+    test('checksResult is null in init message when not provided', () => {
+      ClusterPanel.createOrShow(mockExtensionUri, 'test-id', { nodes: [] }, 'Test');
+
+      const messageHandler = mockPanel.webview.onDidReceiveMessage.mock.calls[0][0];
+      messageHandler({ command: 'ready' });
+
+      const initCall = mockPanel.webview.postMessage.mock.calls.find(
+        (call: any) => call[0].command === 'init'
+      );
+      expect(initCall).toBeDefined();
+      expect(initCall[0].checksResult).toBeUndefined();
+    });
+
+    test('postMessage sends checksResult to webview', () => {
+      const connectionId = 'test-connection-123';
+      const panel = ClusterPanel.createOrShow(
+        mockExtensionUri,
+        connectionId,
+        { nodes: [] },
+        'Test'
+      );
+
+      mockPanel.webview.postMessage.mockClear();
+
+      panel.postMessage({ command: 'checksResult', result: sampleChecksResult });
+
+      expect(mockPanel.webview.postMessage).toHaveBeenCalledWith({
+        command: 'checksResult',
+        result: sampleChecksResult,
+      });
+    });
+
+    test('runChecks command is forwarded to onMessageCallback', async () => {
+      const onMessageCallback = jest.fn().mockResolvedValue(undefined);
+      const connectionId = 'test-connection-123';
+
+      ClusterPanel.createOrShow(
+        mockExtensionUri,
+        connectionId,
+        { nodes: [] },
+        'Test',
+        onMessageCallback
+      );
+
+      const messageHandler = mockPanel.webview.onDidReceiveMessage.mock.calls[0][0];
+      await messageHandler({ command: 'runChecks' });
+
+      expect(onMessageCallback).toHaveBeenCalledWith(
+        { command: 'runChecks' },
+        expect.any(Function)
+      );
+    });
+
+    test('switchTab command sent via setPendingTab before ready', () => {
+      const connectionId = 'test-connection-123';
+      const panel = ClusterPanel.createOrShow(
+        mockExtensionUri,
+        connectionId,
+        { nodes: [] },
+        'Test'
+      );
+
+      panel.setPendingTab('checks');
+
+      const messageHandler = mockPanel.webview.onDidReceiveMessage.mock.calls[0][0];
+      mockPanel.webview.postMessage.mockClear();
+      messageHandler({ command: 'ready' });
+
+      expect(mockPanel.webview.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'switchTab', tab: 'checks' })
+      );
+    });
+
+    test('switchTab command sent immediately via setPendingTab after ready', () => {
+      const connectionId = 'test-connection-123';
+      const panel = ClusterPanel.createOrShow(
+        mockExtensionUri,
+        connectionId,
+        { nodes: [] },
+        'Test'
+      );
+
+      // Fire ready first so _pendingInitData is cleared
+      const messageHandler = mockPanel.webview.onDidReceiveMessage.mock.calls[0][0];
+      messageHandler({ command: 'ready' });
+      mockPanel.webview.postMessage.mockClear();
+
+      panel.setPendingTab('checks');
+
+      expect(mockPanel.webview.postMessage).toHaveBeenCalledWith({
+        command: 'switchTab',
+        tab: 'checks',
+      });
+    });
+  });
+
   describe('Edge cases', () => {
     test('handles multiple rapid createOrShow calls', () => {
       const connectionId = 'test-connection-123';

--- a/src/webview/Cluster.css
+++ b/src/webview/Cluster.css
@@ -472,6 +472,37 @@
   font-weight: 600;
 }
 
+.shards-pagination {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.shards-page-btn {
+  padding: 3px 10px;
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.shards-page-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.shards-page-btn:not(:disabled):hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.shards-page-info {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+}
+
 .shards-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
@@ -782,6 +813,231 @@
 .collection-node-header .node-info {
   display: flex;
   gap: 12px;
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+}
+
+/* ── Checks view ─────────────────────────────────────────────────────────── */
+
+.checks-view {
+  padding: 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.checks-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.checks-timestamp {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.run-checks-button {
+  padding: 6px 14px;
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  border: none;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  font-family: var(--vscode-font-family);
+}
+
+.run-checks-button:hover:not(:disabled) {
+  background-color: var(--vscode-button-hoverBackground);
+}
+
+.run-checks-button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.checks-empty {
+  color: var(--vscode-descriptionForeground);
+  font-size: 13px;
+}
+
+.checks-results {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.checks-section-title {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.checks-section-desc {
+  margin: 0 0 12px 0;
+  font-size: 13px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.checks-link {
+  color: var(--vscode-textLink-foreground);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.checks-link:hover {
+  text-decoration: underline;
+}
+
+.checks-ok {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--vscode-testing-iconPassed, #4caf50);
+}
+
+.checks-ok-icon {
+  font-size: 16px;
+}
+
+.checks-group {
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 10px;
+}
+
+.checks-group-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background-color: var(--vscode-sideBar-background, var(--vscode-editor-background));
+  border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.checks-group-label {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.checks-group-count,
+.checks-group-total {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  background-color: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+  padding: 1px 7px;
+  border-radius: 10px;
+}
+
+.checks-group-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.checks-group-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 12px;
+  font-size: 13px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.checks-group-item:last-child {
+  border-bottom: none;
+}
+
+.checks-col-name {
+  font-weight: 500;
+}
+
+/* Truncated collection/shard name with click-to-copy */
+.truncated-name {
+  display: inline-block;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+  cursor: pointer;
+}
+
+.truncated-name:hover {
+  text-decoration: underline dotted var(--vscode-descriptionForeground);
+}
+
+/* Checks warning banner */
+.checks-warning-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  margin-bottom: 12px;
+  border: 1px solid var(--vscode-panel-border);
+  background-color: var(--vscode-editorInfo-background, var(--vscode-sideBar-background));
+}
+
+.checks-warning-banner.has-issues {
+  border-color: var(--vscode-editorWarning-foreground, #e2c600);
+  background-color: var(--vscode-editorWarning-background, rgba(226, 198, 0, 0.08));
+}
+
+.checks-warning-body {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--vscode-foreground);
+  font-size: 12px;
+}
+
+.checks-warning-icon {
+  flex-shrink: 0;
+}
+
+.checks-warning-text {
+  flex: 1;
+}
+
+.checks-warning-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: var(--vscode-font-family);
+  font-size: 12px;
+  color: var(--vscode-textLink-foreground);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.checks-warning-link:hover {
+  color: var(--vscode-textLink-activeForeground);
+}
+
+.checks-warning-dismiss {
+  background: none;
+  border: none;
+  color: var(--vscode-descriptionForeground);
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 11px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.checks-warning-dismiss:hover {
+  color: var(--vscode-foreground);
+  background: var(--vscode-toolbar-hoverBackground);
+}
+
+.checks-col-count {
   font-size: 12px;
   color: var(--vscode-descriptionForeground);
 }

--- a/src/webview/Cluster.css
+++ b/src/webview/Cluster.css
@@ -905,6 +905,23 @@
   margin: 0 0 8px 0;
   font-size: 14px;
   font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.checks-section--warning {
+  border-left: 3px solid var(--vscode-editorWarning-foreground, #cca700);
+  padding-left: 12px;
+}
+
+.checks-section--warning .checks-section-title {
+  color: var(--vscode-editorWarning-foreground, #cca700);
+}
+
+.checks-section-warning-icon {
+  font-size: 15px;
+  line-height: 1;
 }
 
 .checks-section-desc {
@@ -921,6 +938,26 @@
 
 .checks-link:hover {
   text-decoration: underline;
+}
+
+.checks-info-callout {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  background-color: var(--vscode-textBlockQuote-background, rgba(0, 120, 212, 0.08));
+  border-left: 3px solid var(--vscode-textLink-foreground, #3794ff);
+  border-radius: 0 4px 4px 0;
+  font-size: 12px;
+  color: var(--vscode-foreground);
+  line-height: 1.5;
+}
+
+.checks-info-callout-icon {
+  flex-shrink: 0;
+  font-size: 14px;
+  line-height: 1.5;
 }
 
 .checks-ok {
@@ -1072,4 +1109,66 @@
 .checks-col-count {
   font-size: 12px;
   color: var(--vscode-descriptionForeground);
+}
+
+/* Empty shards table */
+.checks-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  margin-top: 8px;
+}
+
+.checks-table th {
+  text-align: left;
+  padding: 4px 8px;
+  font-weight: 600;
+  color: var(--vscode-descriptionForeground);
+  border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.checks-table td {
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  color: var(--vscode-foreground);
+}
+
+.checks-table tr:last-child td {
+  border-bottom: none;
+}
+
+.checks-shard-name {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+}
+
+/* Replication imbalance */
+.checks-imbalance-shard {
+  margin: 6px 0 6px 8px;
+  padding: 6px 10px;
+  border-left: 2px solid var(--vscode-panel-border);
+}
+
+.checks-replica-list {
+  list-style: none;
+  padding: 0;
+  margin: 4px 0 0 0;
+}
+
+.checks-replica-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2px 0;
+  font-size: 12px;
+}
+
+.checks-replica-node {
+  color: var(--vscode-foreground);
+}
+
+.checks-replica-count {
+  color: var(--vscode-descriptionForeground);
+  font-size: 11px;
 }

--- a/src/webview/Cluster.css
+++ b/src/webview/Cluster.css
@@ -253,13 +253,45 @@
   overflow: auto;
 }
 
-.loading,
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-spinner {
+  animation: spin 1s linear infinite;
+  flex-shrink: 0;
+}
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 200px;
+  gap: 12px;
+  color: var(--vscode-descriptionForeground);
+}
+
 .no-data {
   display: flex;
   justify-content: center;
   align-items: center;
   height: 200px;
   color: var(--vscode-descriptionForeground);
+}
+
+.checks-running {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 20px;
+  color: var(--vscode-descriptionForeground);
+  font-size: 13px;
 }
 
 /* Nodes List */

--- a/src/webview/ClusterPanel.tsx
+++ b/src/webview/ClusterPanel.tsx
@@ -913,6 +913,11 @@ function ClusterPanelWebview() {
           setChecksResult(message.result ?? null);
           setIsRunningChecks(false);
           break;
+        case 'switchTab':
+          if (message.tab === 'node' || message.tab === 'collection' || message.tab === 'checks') {
+            setViewType(message.tab);
+          }
+          break;
       }
     };
 

--- a/src/webview/ClusterPanel.tsx
+++ b/src/webview/ClusterPanel.tsx
@@ -852,6 +852,10 @@ function ClusterPanelWebview() {
       if (message.openClusterViewOnConnect !== undefined) {
         setOpenClusterViewOnConnect(message.openClusterViewOnConnect !== false);
       }
+      // Still apply checksResult from globalState even while node data is loading.
+      if (message.checksResult) {
+        setChecksResult(message.checksResult);
+      }
       return;
     }
 

--- a/src/webview/ClusterPanel.tsx
+++ b/src/webview/ClusterPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo, startTransition } from 'react';
 import { createRoot } from 'react-dom/client';
 import './theme.css';
 import './Cluster.css';
@@ -14,6 +14,28 @@ try {
   </div>`;
   throw error;
 }
+
+// ── Module-level init handshake ──────────────────────────────────────────────
+// We send 'ready' and capture the 'init' reply here, BEFORE React mounts.
+// This avoids React StrictMode double-effect races where the message lands on
+// a discarded effect instance and its state setters have no effect.
+
+let __initPayload: {
+  nodeStatusData: any;
+  openClusterViewOnConnect?: boolean;
+  checksResult?: any;
+} | null = null;
+let __onInitPayload: ((payload: typeof __initPayload) => void) | null = null;
+
+window.addEventListener('message', (event: MessageEvent) => {
+  if (event.data?.command === 'init') {
+    __initPayload = event.data;
+    __onInitPayload?.(event.data); // notify React if already mounted
+  }
+});
+
+// Send ready immediately — extension will queue the init reply.
+vscode.postMessage({ command: 'ready' });
 
 // Types
 interface Shard {
@@ -42,6 +64,172 @@ interface Node {
   };
   status: string;
   version: string;
+}
+
+// Checks types (mirrored from multiTenancyCheck.ts — kept local to avoid bundling src/utils)
+interface MtCollectionEntry {
+  name: string;
+  objectCount: number;
+}
+
+interface MtCandidateGroup {
+  collections: MtCollectionEntry[];
+  count: number;
+  totalObjects: number;
+}
+
+interface ChecksResult {
+  timestamp: string;
+  multiTenancy: {
+    groups: MtCandidateGroup[];
+    hasIssues: boolean;
+  };
+}
+
+// ─── ChecksView ───────────────────────────────────────────────────────────────
+
+interface ChecksViewProps {
+  checksResult: ChecksResult | null;
+  isRunning: boolean;
+  onRunChecks: () => void;
+}
+
+function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
+  const groups = checksResult?.multiTenancy.groups ?? [];
+  const timestamp = checksResult?.timestamp
+    ? new Date(checksResult.timestamp).toLocaleString()
+    : null;
+
+  return (
+    <div className="checks-view">
+      <div className="checks-header">
+        <div className="checks-meta">
+          {timestamp && <span className="checks-timestamp">Last run: {timestamp}</span>}
+        </div>
+        <button
+          className="run-checks-button"
+          onClick={onRunChecks}
+          disabled={isRunning}
+          title="Run all checks"
+        >
+          {isRunning ? 'Running…' : 'Run Checks'}
+        </button>
+      </div>
+
+      {!checksResult && !isRunning && (
+        <div className="checks-empty">
+          <p>
+            No checks have been run yet. Click <strong>Run Checks</strong> to analyse your
+            collections.
+          </p>
+        </div>
+      )}
+
+      {checksResult && (
+        <div className="checks-results">
+          <div className="checks-section">
+            <h3 className="checks-section-title">Multi-Tenancy Candidates</h3>
+            {groups.length === 0 ? (
+              <div className="checks-ok">
+                <span className="checks-ok-icon">✓</span>
+                No collections share identical schemas. No action needed.
+              </div>
+            ) : (
+              <>
+                <p className="checks-section-desc">
+                  The following groups of collections share identical schemas and could be
+                  consolidated into a single multi-tenant collection.{' '}
+                  <a
+                    href="https://docs.weaviate.io/weaviate/manage-collections/multi-tenancy"
+                    className="checks-link"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      vscode.postMessage({
+                        command: 'openExternal',
+                        url: 'https://docs.weaviate.io/weaviate/manage-collections/multi-tenancy',
+                      });
+                    }}
+                  >
+                    Learn more ↗
+                  </a>
+                </p>
+                {groups.map((group, idx) => (
+                  <div key={idx} className="checks-group">
+                    <div className="checks-group-header">
+                      <span className="checks-group-label">Group {idx + 1}</span>
+                      <span className="checks-group-count">{group.count} collections</span>
+                      {group.totalObjects > 0 && (
+                        <span className="checks-group-total">
+                          {group.totalObjects.toLocaleString()} total objects
+                        </span>
+                      )}
+                    </div>
+                    <ul className="checks-group-list">
+                      {group.collections.map((col) => (
+                        <li key={col.name} className="checks-group-item">
+                          <span className="checks-col-name">{col.name}</span>
+                          <span className="checks-col-count">
+                            {col.objectCount.toLocaleString()} objects
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Truncated name with click-to-copy
+function TruncatedName({ name, tag: Tag = 'span' }: { name: string; tag?: 'span' | 'h3' | 'h4' }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(name).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <Tag className="truncated-name" title={copied ? '✓ Copied!' : name} onClick={handleClick}>
+      {name}
+    </Tag>
+  );
+}
+
+// Checks warning banner shown on Node and Collection views
+interface ChecksWarningBannerProps {
+  checksResult: ChecksResult | null;
+  onOpenChecks: () => void;
+  onDismiss: () => void;
+}
+
+function ChecksWarningBanner({ checksResult, onOpenChecks, onDismiss }: ChecksWarningBannerProps) {
+  const hasIssues = checksResult?.multiTenancy?.hasIssues;
+
+  return (
+    <div className={`checks-warning-banner ${hasIssues ? 'has-issues' : 'info'}`}>
+      <div className="checks-warning-body">
+        <span className="checks-warning-icon">{hasIssues ? '⚠️' : 'ℹ️'}</span>
+        <span className="checks-warning-text">
+          Your cluster has potential issues on your collections schema.{' '}
+          <button className="checks-warning-link" onClick={onOpenChecks}>
+            View Checks →
+          </button>
+        </span>
+      </div>
+      <button className="checks-warning-dismiss" onClick={onDismiss} title="Dismiss">
+        ✕
+      </button>
+    </div>
+  );
 }
 
 // Shard Component
@@ -94,7 +282,7 @@ function ShardComponent({ shard, nodeName, isSelected, onSelect }: ShardComponen
     <div className={`shard-item ${isSelected ? 'selected' : ''}`} onClick={onSelect}>
       <div className="shard-header">
         <div className="shard-title-group">
-          <h4>{shard.class}</h4>
+          <TruncatedName name={shard.class} tag="h4" />
           <span className="shard-name">{shard.name}</span>
         </div>
         <div className="shard-menu-container" ref={menuRef}>
@@ -154,6 +342,73 @@ function ShardComponent({ shard, nodeName, isSelected, onSelect }: ShardComponen
         </div>
       )}
     </div>
+  );
+}
+
+// Paginated shard grid — renders a page of ShardComponents with prev/next controls.
+const SHARDS_PAGE_SIZE = 50;
+
+interface PaginatedShardGridProps {
+  shards: Shard[];
+  nodeName: string;
+  selectedShardName: string | null;
+  onShardSelect: (shardName: string) => void;
+}
+
+function PaginatedShardGrid({
+  shards,
+  nodeName,
+  selectedShardName,
+  onShardSelect,
+}: PaginatedShardGridProps) {
+  const [page, setPage] = useState(0);
+
+  // Reset to first page whenever the shard list changes (node switch, filter, etc.)
+  const shardsKey = shards.map((s) => s.name).join(',');
+  useEffect(() => {
+    setPage(0);
+  }, [shardsKey]);
+
+  const pageCount = Math.ceil(shards.length / SHARDS_PAGE_SIZE);
+  const pageShards = shards.slice(page * SHARDS_PAGE_SIZE, (page + 1) * SHARDS_PAGE_SIZE);
+  const start = page * SHARDS_PAGE_SIZE + 1;
+  const end = Math.min((page + 1) * SHARDS_PAGE_SIZE, shards.length);
+
+  return (
+    <>
+      {pageCount > 1 && (
+        <div className="shards-pagination">
+          <button
+            className="shards-page-btn"
+            disabled={page === 0}
+            onClick={() => setPage((p) => p - 1)}
+          >
+            ‹ Prev
+          </button>
+          <span className="shards-page-info">
+            {start}–{end} of {shards.length}
+          </span>
+          <button
+            className="shards-page-btn"
+            disabled={page === pageCount - 1}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next ›
+          </button>
+        </div>
+      )}
+      <div className="shards-grid">
+        {pageShards.map((shard) => (
+          <ShardComponent
+            key={shard.name}
+            shard={shard}
+            nodeName={nodeName}
+            isSelected={selectedShardName === shard.name}
+            onSelect={() => onShardSelect(shard.name)}
+          />
+        ))}
+      </div>
+    </>
   );
 }
 
@@ -308,27 +563,15 @@ function NodeComponent({
 
           <div className="shards-container">
             <h4>Shards ({shards.length})</h4>
-            <div className="shards-grid">
-              {[...shards]
-                .sort((a, b) => {
-                  // First sort by collection name
-                  const collectionCompare = a.class.localeCompare(b.class);
-                  if (collectionCompare !== 0) {
-                    return collectionCompare;
-                  }
-                  // Then sort by shard name
-                  return a.name.localeCompare(b.name);
-                })
-                .map((shard) => (
-                  <ShardComponent
-                    key={shard.name}
-                    shard={shard}
-                    nodeName={node.name}
-                    isSelected={selectedShardName === shard.name}
-                    onSelect={() => onShardSelect(shard.name)}
-                  />
-                ))}
-            </div>
+            <PaginatedShardGrid
+              shards={[...shards].sort((a, b) => {
+                const c = a.class.localeCompare(b.class);
+                return c !== 0 ? c : a.name.localeCompare(b.name);
+              })}
+              nodeName={node.name}
+              selectedShardName={selectedShardName}
+              onShardSelect={onShardSelect}
+            />
           </div>
         </>
       )}
@@ -558,19 +801,14 @@ function CollectionView({
 
                           {isNodeSelected && (
                             <div className="shards-container">
-                              <div className="shards-grid">
-                                {nodeData.shards
-                                  .sort((a, b) => a.name.localeCompare(b.name))
-                                  .map((shard) => (
-                                    <ShardComponent
-                                      key={shard.name}
-                                      shard={shard}
-                                      nodeName={nodeData.nodeName}
-                                      isSelected={selectedShardName === shard.name}
-                                      onSelect={() => onShardSelect(shard.name)}
-                                    />
-                                  ))}
-                              </div>
+                              <PaginatedShardGrid
+                                shards={[...nodeData.shards].sort((a, b) =>
+                                  a.name.localeCompare(b.name)
+                                )}
+                                nodeName={nodeData.nodeName}
+                                selectedShardName={selectedShardName}
+                                onShardSelect={onShardSelect}
+                              />
                             </div>
                           )}
                         </div>
@@ -594,8 +832,10 @@ function ClusterPanelWebview() {
   const [selectedCollectionName, setSelectedCollectionName] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [openClusterViewOnConnect, setOpenClusterViewOnConnect] = useState<boolean>(true);
-  const [viewType, setViewType] = useState<'node' | 'collection'>('node');
-  const [hasInitialized, setHasInitialized] = useState<boolean>(false);
+  const [viewType, setViewType] = useState<'node' | 'collection' | 'checks'>('node');
+  const [checksResult, setChecksResult] = useState<ChecksResult | null>(null);
+  const [isRunningChecks, setIsRunningChecks] = useState(false);
+  const [checksWarningDismissed, setChecksWarningDismissed] = useState(false);
   const [autoRefreshInterval, setAutoRefreshInterval] = useState<'off' | '5s' | '10s' | '30s'>(
     'off'
   );
@@ -605,90 +845,79 @@ function ClusterPanelWebview() {
   const scrollPositionRef = useRef<number>(0);
   const prevNodeStatusDataRef = useRef<Node[]>([]);
 
-  // Signal to the extension that the webview is ready to receive data.
-  // This must run before the message listener is set up so the extension
-  // can respond with the initial 'init' payload without a race condition.
-  useEffect(() => {
-    vscode.postMessage({ command: 'ready' });
+  const applyInitOrUpdate = useCallback((message: any) => {
+    if (message.nodeStatusData == null) {
+      // null means the extension has no cached data yet and is fetching in the background.
+      // Keep isLoading=true so the spinner stays visible until updateData arrives.
+      if (message.openClusterViewOnConnect !== undefined) {
+        setOpenClusterViewOnConnect(message.openClusterViewOnConnect !== false);
+      }
+      return;
+    }
+
+    const newData: Node[] = message.nodeStatusData || [];
+    prevNodeStatusDataRef.current = newData;
+
+    // Use startTransition so React yields to the browser between renders,
+    // preventing the UI thread from freezing on large datasets.
+    startTransition(() => {
+      setNodeStatusData(newData);
+      setIsLoading(false);
+
+      if (message.openClusterViewOnConnect !== undefined) {
+        setOpenClusterViewOnConnect(message.openClusterViewOnConnect !== false);
+      }
+      if (message.checksResult) {
+        setChecksResult(message.checksResult);
+      }
+    });
   }, []);
 
   useEffect(() => {
-    // Handle messages from the extension
+    // If the module-level listener already captured the init payload, apply it now.
+    if (__initPayload) {
+      applyInitOrUpdate(__initPayload);
+    }
+
+    // Register callback for init arriving after this effect runs.
+    __onInitPayload = (payload) => applyInitOrUpdate(payload);
+
     const messageHandler = (event: MessageEvent) => {
       const message = event.data;
-
       switch (message.command) {
-        case 'init':
-        case 'updateData':
-          // Only update if data has actually changed (using ref to avoid stale closure)
-          const newData = message.nodeStatusData || [];
-          const hasDataChanged =
-            JSON.stringify(newData) !== JSON.stringify(prevNodeStatusDataRef.current);
-
-          // Only update state if there are actual changes
-          if (hasDataChanged || prevNodeStatusDataRef.current.length === 0) {
-            prevNodeStatusDataRef.current = newData;
+        case 'updateData': {
+          const newData: Node[] = message.nodeStatusData || [];
+          prevNodeStatusDataRef.current = newData;
+          const scrollPos = scrollPositionRef.current;
+          startTransition(() => {
             setNodeStatusData(newData);
-
-            // Update openClusterViewOnConnect state
+            setIsLoading(false);
             if (message.openClusterViewOnConnect !== undefined) {
               setOpenClusterViewOnConnect(message.openClusterViewOnConnect !== false);
             }
-
-            // Auto-select defaults on initial load only, not on refresh
-            if (message.nodeStatusData && message.nodeStatusData.length > 0 && !hasInitialized) {
-              const data: Node[] = message.nodeStatusData;
-
-              // Node view: expand the first node in the list
-              setSelectedNodeName(data[0].name);
-
-              // Collection view: expand the first collection (alphabetically) and its first node
-              const allCollectionNames = new Set<string>();
-              data.forEach((node) => {
-                (node.shards || []).forEach((shard) => allCollectionNames.add(shard.class));
-              });
-              const sortedCollections = Array.from(allCollectionNames).sort((a, b) =>
-                a.localeCompare(b)
-              );
-              if (sortedCollections.length > 0) {
-                const firstCollection = sortedCollections[0];
-                setSelectedCollectionName(firstCollection);
-                // Find the first node (alphabetically) that has shards in this collection
-                const nodesInFirstCollection = data
-                  .filter((node) =>
-                    (node.shards || []).some((shard) => shard.class === firstCollection)
-                  )
-                  .sort((a, b) => a.name.localeCompare(b.name));
-                if (nodesInFirstCollection.length > 0) {
-                  setSelectedNodeName(nodesInFirstCollection[0].name);
-                }
+          });
+          if (contentRef.current && scrollPos > 0) {
+            setTimeout(() => {
+              if (contentRef.current) {
+                contentRef.current.scrollTop = scrollPos;
               }
-
-              setHasInitialized(true);
-            }
-
-            // Restore scroll position after data update
-            if (contentRef.current && scrollPositionRef.current > 0) {
-              setTimeout(() => {
-                if (contentRef.current) {
-                  contentRef.current.scrollTop = scrollPositionRef.current;
-                }
-              }, 0);
-            }
+            }, 0);
           }
-
-          // Always stop loading indicator
-          setIsLoading(false);
+          break;
+        }
+        case 'checksResult':
+          setChecksResult(message.result ?? null);
+          setIsRunningChecks(false);
           break;
       }
     };
 
     window.addEventListener('message', messageHandler);
-
     return () => {
+      __onInitPayload = null;
       window.removeEventListener('message', messageHandler);
     };
-  }, [selectedNodeName, hasInitialized]);
+  }, [applyInitOrUpdate]);
 
   const filteredNodeStatusData = useMemo(() => {
     if (!searchQuery.trim()) {
@@ -743,6 +972,11 @@ function ClusterPanelWebview() {
       });
       return newValue;
     });
+  }, []);
+
+  const handleRunChecks = useCallback(() => {
+    setIsRunningChecks(true);
+    vscode.postMessage({ command: 'runChecks' });
   }, []);
 
   const handleAutoRefreshChange = useCallback((interval: 'off' | '5s' | '10s' | '30s') => {
@@ -803,6 +1037,59 @@ function ClusterPanelWebview() {
     };
   }, [showAutoRefreshMenu]);
 
+  // Must be called unconditionally — cannot be inside a ternary (Rules of Hooks)
+  const nodeOrCollectionContent = useMemo(
+    () =>
+      nodeStatusData && nodeStatusData.length > 0 ? (
+        viewType === 'node' ? (
+          <div className="nodes-list">
+            {filteredNodeStatusData.length > 0 ? (
+              filteredNodeStatusData.map((node) => (
+                <NodeComponent
+                  key={node.name}
+                  node={node}
+                  isSelected={selectedNodeName === node.name}
+                  onSelect={() => handleNodeSelect(node.name)}
+                  selectedShardName={selectedShardName}
+                  onShardSelect={handleShardSelect}
+                />
+              ))
+            ) : (
+              <div className="no-data">
+                <p>No results match your search</p>
+              </div>
+            )}
+          </div>
+        ) : (
+          <CollectionView
+            nodeStatusData={filteredNodeStatusData}
+            selectedNodeName={selectedNodeName}
+            selectedShardName={selectedShardName}
+            selectedCollectionName={selectedCollectionName}
+            onNodeSelect={handleNodeSelect}
+            onShardSelect={handleShardSelect}
+            onCollectionSelect={handleCollectionSelect}
+          />
+        )
+      ) : isLoading ? (
+        <div className="no-data">
+          <p>Loading cluster data…</p>
+        </div>
+      ) : (
+        <div className="no-data">
+          <p>No cluster data available</p>
+        </div>
+      ),
+    [
+      nodeStatusData,
+      filteredNodeStatusData,
+      viewType,
+      selectedNodeName,
+      selectedShardName,
+      selectedCollectionName,
+    ]
+  );
+
   return (
     <div className="cluster-panel">
       <div className="cluster-header">
@@ -844,6 +1131,15 @@ function ClusterPanelWebview() {
               onClick={() => setViewType('collection')}
             >
               Collection
+            </button>
+            <button
+              className={`view-toggle-button ${viewType === 'checks' ? 'active' : ''}`}
+              onClick={() => setViewType('checks')}
+            >
+              Checks
+              {checksResult?.multiTenancy?.groups?.length
+                ? ` (${checksResult.multiTenancy.groups.length})`
+                : ''}
             </button>
           </div>
           <div className="refresh-button-group">
@@ -901,52 +1197,21 @@ function ClusterPanelWebview() {
       </div>
 
       <div className="cluster-content" ref={contentRef}>
-        {useMemo(
-          () =>
-            nodeStatusData && nodeStatusData.length > 0 ? (
-              viewType === 'node' ? (
-                <div className="nodes-list">
-                  {filteredNodeStatusData.length > 0 ? (
-                    filteredNodeStatusData.map((node) => (
-                      <NodeComponent
-                        key={node.name}
-                        node={node}
-                        isSelected={selectedNodeName === node.name}
-                        onSelect={() => handleNodeSelect(node.name)}
-                        selectedShardName={selectedShardName}
-                        onShardSelect={handleShardSelect}
-                      />
-                    ))
-                  ) : (
-                    <div className="no-data">
-                      <p>No results match your search</p>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <CollectionView
-                  nodeStatusData={filteredNodeStatusData}
-                  selectedNodeName={selectedNodeName}
-                  selectedShardName={selectedShardName}
-                  selectedCollectionName={selectedCollectionName}
-                  onNodeSelect={handleNodeSelect}
-                  onShardSelect={handleShardSelect}
-                  onCollectionSelect={handleCollectionSelect}
-                />
-              )
-            ) : (
-              <div className="no-data">
-                <p>No cluster data available</p>
-              </div>
-            ),
-          [
-            nodeStatusData,
-            filteredNodeStatusData,
-            viewType,
-            selectedNodeName,
-            selectedShardName,
-            selectedCollectionName,
-          ]
+        {viewType !== 'checks' && !checksWarningDismissed && (
+          <ChecksWarningBanner
+            checksResult={checksResult}
+            onOpenChecks={() => setViewType('checks')}
+            onDismiss={() => setChecksWarningDismissed(true)}
+          />
+        )}
+        {viewType === 'checks' ? (
+          <ChecksView
+            checksResult={checksResult}
+            isRunning={isRunningChecks}
+            onRunChecks={handleRunChecks}
+          />
+        ) : (
+          nodeOrCollectionContent
         )}
       </div>
 

--- a/src/webview/ClusterPanel.tsx
+++ b/src/webview/ClusterPanel.tsx
@@ -387,10 +387,15 @@ function TruncatedName({ name, tag: Tag = 'span' }: { name: string; tag?: 'span'
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    navigator.clipboard.writeText(name).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
+    navigator.clipboard
+      .writeText(name)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch((err) => {
+        console.warn('Failed to copy to clipboard:', err);
+      });
   };
 
   return (

--- a/src/webview/ClusterPanel.tsx
+++ b/src/webview/ClusterPanel.tsx
@@ -78,10 +78,41 @@ interface MtCandidateGroup {
   totalObjects: number;
 }
 
+interface EmptyShardEntry {
+  collectionName: string;
+  nodeName: string;
+  shardName: string;
+}
+
+interface ShardReplica {
+  nodeName: string;
+  objectCount: number;
+}
+
+interface ImbalancedShard {
+  shardName: string;
+  replicas: ShardReplica[];
+}
+
+interface ReplicationImbalanceCollection {
+  collectionName: string;
+  shards: ImbalancedShard[];
+}
+
 interface ChecksResult {
   timestamp: string;
+  /** True when any individual check has issues. Present in newer results. */
+  hasIssues?: boolean;
   multiTenancy: {
     groups: MtCandidateGroup[];
+    hasIssues: boolean;
+  };
+  emptyShards?: {
+    entries: EmptyShardEntry[];
+    hasIssues: boolean;
+  };
+  replicationImbalance?: {
+    collections: ReplicationImbalanceCollection[];
     hasIssues: boolean;
   };
 }
@@ -94,8 +125,29 @@ interface ChecksViewProps {
   onRunChecks: () => void;
 }
 
+function SpinnerIcon() {
+  return (
+    <svg
+      className="loading-spinner"
+      width="20"
+      height="20"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M13.451 5.609l-.579-.939-1.068.812-.076.094c-.335.415-.927 1.341-1.124 2.876l-.021.165.033.163.071.345c0 1.654-1.346 3-3 3-.795 0-1.545-.311-2.107-.868-.563-.567-.873-1.317-.873-2.111 0-1.431 1.007-2.632 2.351-2.929v2.498l2.528-2.134-2.528-2.076v2.11C4.753 6.867 3 8.819 3 11.131c0 1.14.445 2.21 1.253 3.014.808.803 1.883 1.246 3.027 1.246 2.31 0 4.216-1.751 4.455-4.027.098-.858.451-1.935.832-2.489.167-.237.351-.469.555-.678l.131-.117zm-2.359.81c-.172-.268-.33-.518-.475-.748-1.303-2.066-2.916-2.758-4.093-2.758-1.087 0-2.1.563-2.7 1.5-.302.473-.5 1.013-.6 1.596l1.013.014c.087-.484.245-.95.465-1.371.437-.838 1.176-1.34 1.987-1.34.852 0 1.839.428 2.659 1.147.411.363.771.77 1.073 1.211.136.202.261.408.376.616.092-.085.184-.168.278-.25l.017-.017z" />
+    </svg>
+  );
+}
+
+function openExternalLink(url: string) {
+  vscode.postMessage({ command: 'openExternal', url });
+}
+
 function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
   const groups = checksResult?.multiTenancy.groups ?? [];
+  const emptyShardEntries = checksResult?.emptyShards?.entries ?? [];
+  const replicationCollections = checksResult?.replicationImbalance?.collections ?? [];
   const timestamp = checksResult?.timestamp
     ? new Date(checksResult.timestamp).toLocaleString()
     : null;
@@ -118,16 +170,7 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
 
       {isRunning && (
         <div className="checks-running">
-          <svg
-            className="loading-spinner"
-            width="20"
-            height="20"
-            viewBox="0 0 16 16"
-            fill="currentColor"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path d="M13.451 5.609l-.579-.939-1.068.812-.076.094c-.335.415-.927 1.341-1.124 2.876l-.021.165.033.163.071.345c0 1.654-1.346 3-3 3-.795 0-1.545-.311-2.107-.868-.563-.567-.873-1.317-.873-2.111 0-1.431 1.007-2.632 2.351-2.929v2.498l2.528-2.134-2.528-2.076v2.11C4.753 6.867 3 8.819 3 11.131c0 1.14.445 2.21 1.253 3.014.808.803 1.883 1.246 3.027 1.246 2.31 0 4.216-1.751 4.455-4.027.098-.858.451-1.935.832-2.489.167-.237.351-.469.555-.678l.131-.117zm-2.359.81c-.172-.268-.33-.518-.475-.748-1.303-2.066-2.916-2.758-4.093-2.758-1.087 0-2.1.563-2.7 1.5-.302.473-.5 1.013-.6 1.596l1.013.014c.087-.484.245-.95.465-1.371.437-.838 1.176-1.34 1.987-1.34.852 0 1.839.428 2.659 1.147.411.363.771.77 1.073 1.211.136.202.261.408.376.616.092-.085.184-.168.278-.25l.017-.017z" />
-          </svg>
+          <SpinnerIcon />
           <p>Running checks…</p>
         </div>
       )}
@@ -143,8 +186,12 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
 
       {checksResult && (
         <div className="checks-results">
-          <div className="checks-section">
-            <h3 className="checks-section-title">Multi-Tenancy Candidates</h3>
+          {/* ── Multi-Tenancy Candidates ──────────────────────────────── */}
+          <div className={`checks-section${groups.length > 0 ? ' checks-section--warning' : ''}`}>
+            <h3 className="checks-section-title">
+              {groups.length > 0 && <span className="checks-section-warning-icon">⚠</span>}
+              Multi-Tenancy Candidates
+            </h3>
             {groups.length === 0 ? (
               <div className="checks-ok">
                 <span className="checks-ok-icon">✓</span>
@@ -160,10 +207,9 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
                     className="checks-link"
                     onClick={(e) => {
                       e.preventDefault();
-                      vscode.postMessage({
-                        command: 'openExternal',
-                        url: 'https://docs.weaviate.io/weaviate/manage-collections/multi-tenancy',
-                      });
+                      openExternalLink(
+                        'https://docs.weaviate.io/weaviate/manage-collections/multi-tenancy'
+                      );
                     }}
                   >
                     Learn more ↗
@@ -190,6 +236,140 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
                         </li>
                       ))}
                     </ul>
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+
+          {/* ── Empty Shards ──────────────────────────────────────────── */}
+          <div
+            className={`checks-section${emptyShardEntries.length > 0 ? ' checks-section--warning' : ''}`}
+          >
+            <h3 className="checks-section-title">
+              {emptyShardEntries.length > 0 && (
+                <span className="checks-section-warning-icon">⚠</span>
+              )}
+              Empty Shards
+            </h3>
+            {emptyShardEntries.length === 0 ? (
+              <div className="checks-ok">
+                <span className="checks-ok-icon">✓</span>
+                No empty shards detected across the cluster.
+              </div>
+            ) : (
+              <>
+                <p className="checks-section-desc">
+                  The following shards contain zero objects. Empty shards may indicate incomplete
+                  data ingestion or collections that are no longer in use. Even without any objects,
+                  an empty collection adds overhead to your cluster — consider deleting collections
+                  that are no longer needed.
+                </p>
+                <div className="checks-info-callout">
+                  <span className="checks-info-callout-icon">ℹ️</span>
+                  Object counts reported by node status are not immediately synchronized and may be
+                  slightly delayed — only act on shards that consistently show zero over time.
+                </div>
+                {Object.entries(
+                  emptyShardEntries.reduce<Record<string, EmptyShardEntry[]>>((acc, entry) => {
+                    (acc[entry.collectionName] ??= []).push(entry);
+                    return acc;
+                  }, {})
+                ).map(([collectionName, entries]) => (
+                  <div key={collectionName} className="checks-group">
+                    <div className="checks-group-header">
+                      <span className="checks-group-label">{collectionName}</span>
+                      <span className="checks-group-count">
+                        {entries.length} empty shard{entries.length !== 1 ? 's' : ''}
+                      </span>
+                    </div>
+                    <table className="checks-table">
+                      <thead>
+                        <tr>
+                          <th>Node</th>
+                          <th>Shard</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {entries.map((entry, idx) => (
+                          <tr key={idx}>
+                            <td>{entry.nodeName}</td>
+                            <td className="checks-shard-name">{entry.shardName}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+
+          {/* ── Replication Imbalance ─────────────────────────────────── */}
+          <div
+            className={`checks-section${replicationCollections.length > 0 ? ' checks-section--warning' : ''}`}
+          >
+            <h3 className="checks-section-title">
+              {replicationCollections.length > 0 && (
+                <span className="checks-section-warning-icon">⚠</span>
+              )}
+              Replication Imbalance
+            </h3>
+            {replicationCollections.length === 0 ? (
+              <div className="checks-ok">
+                <span className="checks-ok-icon">✓</span>
+                All shard replicas have consistent object counts.
+              </div>
+            ) : (
+              <>
+                <p className="checks-section-desc">
+                  The following collections have shards whose replicas report different object
+                  counts across nodes. Persistent imbalances after ingestion finishes may indicate
+                  that async replication is disabled or lagging.{' '}
+                  <a
+                    href="https://docs.weaviate.io/deploy/configuration/async-rep"
+                    className="checks-link"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      openExternalLink('https://docs.weaviate.io/deploy/configuration/async-rep');
+                    }}
+                  >
+                    Enable async replication ↗
+                  </a>
+                </p>
+                <div className="checks-info-callout">
+                  <span className="checks-info-callout-icon">ℹ️</span>
+                  If you are actively ingesting data, this is normal — replicas sync asynchronously
+                  and imbalances resolve once ingestion completes.
+                </div>
+                <div className="checks-info-callout">
+                  <span className="checks-info-callout-icon">ℹ️</span>
+                  Object counts reported by node status are not immediately synchronized and may be
+                  slightly delayed — only act on imbalances that persist over time.
+                </div>
+                {replicationCollections.map((col) => (
+                  <div key={col.collectionName} className="checks-group">
+                    <div className="checks-group-header">
+                      <span className="checks-group-label">{col.collectionName}</span>
+                      <span className="checks-group-count">
+                        {col.shards.length} imbalanced shard{col.shards.length !== 1 ? 's' : ''}
+                      </span>
+                    </div>
+                    {col.shards.map((shard) => (
+                      <div key={shard.shardName} className="checks-imbalance-shard">
+                        <span className="checks-shard-name">{shard.shardName}</span>
+                        <ul className="checks-replica-list">
+                          {shard.replicas.map((replica) => (
+                            <li key={replica.nodeName} className="checks-replica-item">
+                              <span className="checks-replica-node">{replica.nodeName}</span>
+                              <span className="checks-replica-count">
+                                {replica.objectCount.toLocaleString()} objects
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ))}
                   </div>
                 ))}
               </>
@@ -228,7 +408,7 @@ interface ChecksWarningBannerProps {
 }
 
 function ChecksWarningBanner({ checksResult, onOpenChecks, onDismiss }: ChecksWarningBannerProps) {
-  const hasIssues = checksResult?.multiTenancy?.hasIssues;
+  const hasIssues = checksResult?.hasIssues ?? checksResult?.multiTenancy?.hasIssues;
 
   return (
     <div className={`checks-warning-banner ${hasIssues ? 'has-issues' : 'info'}`}>
@@ -256,7 +436,7 @@ interface ShardComponentProps {
   onSelect: () => void;
 }
 
-function ShardComponent({ shard, nodeName, isSelected, onSelect }: ShardComponentProps) {
+function ShardComponent({ shard, isSelected, onSelect }: ShardComponentProps) {
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const statusOptions: Array<'READY' | 'READONLY'> = ['READY', 'READONLY'];
@@ -630,7 +810,7 @@ function CollectionView({
     const collectionMap = new Map<string, CollectionData>();
 
     nodeStatusData.forEach((node) => {
-      node.shards.forEach((shard) => {
+      (node.shards ?? []).forEach((shard) => {
         if (!collectionMap.has(shard.class)) {
           collectionMap.set(shard.class, {
             name: shard.class,
@@ -667,6 +847,14 @@ function CollectionView({
     onNodeSelect(nodeName);
     onShardSelect(''); // Reset shard selection
   };
+
+  if (collections.length === 0) {
+    return (
+      <div className="no-data">
+        <p>No collections found in this cluster.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="collections-list">
@@ -930,7 +1118,7 @@ function ClusterPanelWebview() {
           setIsRunningChecks(false);
           // Re-show the banner whenever fresh results arrive with issues,
           // even if the user previously dismissed it.
-          if (newResult?.multiTenancy?.hasIssues) {
+          if (newResult?.hasIssues ?? newResult?.multiTenancy?.hasIssues) {
             setChecksWarningDismissed(false);
           }
           break;
@@ -1152,29 +1340,31 @@ function ClusterPanelWebview() {
       <div className="cluster-header">
         <h1>Cluster Information</h1>
         <div className="header-controls">
-          <div className="search-input-wrapper">
-            <span className="search-icon">
-              <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor">
-                <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.099zm-5.242 1.656a5.5 5.5 0 1 1 0-11 5.5 5.5 0 0 1 0 11z" />
-              </svg>
-            </span>
-            <input
-              className="search-input"
-              type="text"
-              placeholder="Filter by collection, shard, status…"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
-            {searchQuery && (
-              <button
-                className="search-clear-button"
-                onClick={() => setSearchQuery('')}
-                title="Clear search"
-              >
-                ✕
-              </button>
-            )}
-          </div>
+          {viewType !== 'checks' && (
+            <div className="search-input-wrapper">
+              <span className="search-icon">
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.099zm-5.242 1.656a5.5 5.5 0 1 1 0-11 5.5 5.5 0 0 1 0 11z" />
+                </svg>
+              </span>
+              <input
+                className="search-input"
+                type="text"
+                placeholder="Filter by collection, shard, status…"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+              {searchQuery && (
+                <button
+                  className="search-clear-button"
+                  onClick={() => setSearchQuery('')}
+                  title="Clear search"
+                >
+                  ✕
+                </button>
+              )}
+            </div>
+          )}
           <span className="view-toggle-label">View:</span>
           <div className="view-toggle">
             <button
@@ -1194,9 +1384,15 @@ function ClusterPanelWebview() {
               onClick={() => setViewType('checks')}
             >
               Checks
-              {checksResult?.multiTenancy?.groups?.length
-                ? ` (${checksResult.multiTenancy.groups.length})`
-                : ''}
+              {(() => {
+                if (!checksResult) return '';
+                const issueCount = [
+                  checksResult.multiTenancy?.hasIssues,
+                  checksResult.emptyShards?.hasIssues,
+                  checksResult.replicationImbalance?.hasIssues,
+                ].filter(Boolean).length;
+                return issueCount > 0 ? ` (${issueCount})` : '';
+              })()}
             </button>
           </div>
           <div className="refresh-button-group">
@@ -1256,7 +1452,7 @@ function ClusterPanelWebview() {
       <div className="cluster-content" ref={contentRef}>
         {viewType !== 'checks' &&
           !checksWarningDismissed &&
-          checksResult?.multiTenancy?.hasIssues && (
+          (checksResult?.hasIssues ?? checksResult?.multiTenancy?.hasIssues) && (
             <ChecksWarningBanner
               checksResult={checksResult}
               onOpenChecks={() => setViewType('checks')}

--- a/src/webview/ClusterPanel.tsx
+++ b/src/webview/ClusterPanel.tsx
@@ -116,6 +116,22 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
         </button>
       </div>
 
+      {isRunning && (
+        <div className="checks-running">
+          <svg
+            className="loading-spinner"
+            width="20"
+            height="20"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M13.451 5.609l-.579-.939-1.068.812-.076.094c-.335.415-.927 1.341-1.124 2.876l-.021.165.033.163.071.345c0 1.654-1.346 3-3 3-.795 0-1.545-.311-2.107-.868-.563-.567-.873-1.317-.873-2.111 0-1.431 1.007-2.632 2.351-2.929v2.498l2.528-2.134-2.528-2.076v2.11C4.753 6.867 3 8.819 3 11.131c0 1.14.445 2.21 1.253 3.014.808.803 1.883 1.246 3.027 1.246 2.31 0 4.216-1.751 4.455-4.027.098-.858.451-1.935.832-2.489.167-.237.351-.469.555-.678l.131-.117zm-2.359.81c-.172-.268-.33-.518-.475-.748-1.303-2.066-2.916-2.758-4.093-2.758-1.087 0-2.1.563-2.7 1.5-.302.473-.5 1.013-.6 1.596l1.013.014c.087-.484.245-.95.465-1.371.437-.838 1.176-1.34 1.987-1.34.852 0 1.839.428 2.659 1.147.411.363.771.77 1.073 1.211.136.202.261.408.376.616.092-.085.184-.168.278-.25l.017-.017z" />
+          </svg>
+          <p>Running checks…</p>
+        </div>
+      )}
+
       {!checksResult && !isRunning && (
         <div className="checks-empty">
           <p>
@@ -582,9 +598,9 @@ function NodeComponent({
 // Collection View Component
 interface CollectionViewProps {
   nodeStatusData: Node[];
-  selectedNodeName: string | null;
+  selectedNodeNames: Set<string>;
   selectedShardName: string | null;
-  selectedCollectionName: string | null;
+  selectedCollectionNames: Set<string>;
   onNodeSelect: (nodeName: string) => void;
   onShardSelect: (shardName: string) => void;
   onCollectionSelect: (collectionName: string) => void;
@@ -602,9 +618,9 @@ interface CollectionData {
 
 function CollectionView({
   nodeStatusData,
-  selectedNodeName,
+  selectedNodeNames,
   selectedShardName,
-  selectedCollectionName,
+  selectedCollectionNames,
   onNodeSelect,
   onShardSelect,
   onCollectionSelect,
@@ -644,19 +660,18 @@ function CollectionView({
   }, [nodeStatusData]);
 
   const handleCollectionSelect = (collectionName: string) => {
-    onCollectionSelect(collectionName === selectedCollectionName ? '' : collectionName);
-    onNodeSelect(''); // Reset node selection
+    onCollectionSelect(collectionName);
   };
 
   const handleNodeSelectInCollection = (nodeName: string) => {
-    onNodeSelect(nodeName === selectedNodeName ? '' : nodeName);
+    onNodeSelect(nodeName);
     onShardSelect(''); // Reset shard selection
   };
 
   return (
     <div className="collections-list">
       {collections.map((collection) => {
-        const isCollectionSelected = selectedCollectionName === collection.name;
+        const isCollectionSelected = selectedCollectionNames.has(collection.name);
 
         // Check for READONLY shards in this collection
         const readonlyShards = collection.nodes.flatMap((node) =>
@@ -759,7 +774,7 @@ function CollectionView({
                   {collection.nodes
                     .sort((a, b) => a.nodeName.localeCompare(b.nodeName))
                     .map((nodeData) => {
-                      const isNodeSelected = selectedNodeName === nodeData.nodeName;
+                      const isNodeSelected = selectedNodeNames.has(nodeData.nodeName);
                       const nodeReadonlyShards = nodeData.shards.filter(
                         (shard) => shard.vectorIndexingStatus === 'READONLY'
                       );
@@ -827,9 +842,9 @@ function CollectionView({
 function ClusterPanelWebview() {
   const [nodeStatusData, setNodeStatusData] = useState<Node[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [selectedNodeName, setSelectedNodeName] = useState<string | null>(null);
+  const [selectedNodeNames, setSelectedNodeNames] = useState<Set<string>>(new Set());
   const [selectedShardName, setSelectedShardName] = useState<string | null>(null);
-  const [selectedCollectionName, setSelectedCollectionName] = useState<string | null>(null);
+  const [selectedCollectionNames, setSelectedCollectionNames] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
   const [openClusterViewOnConnect, setOpenClusterViewOnConnect] = useState<boolean>(true);
   const [viewType, setViewType] = useState<'node' | 'collection' | 'checks'>('node');
@@ -909,10 +924,17 @@ function ClusterPanelWebview() {
           }
           break;
         }
-        case 'checksResult':
-          setChecksResult(message.result ?? null);
+        case 'checksResult': {
+          const newResult = message.result ?? null;
+          setChecksResult(newResult);
           setIsRunningChecks(false);
+          // Re-show the banner whenever fresh results arrive with issues,
+          // even if the user previously dismissed it.
+          if (newResult?.multiTenancy?.hasIssues) {
+            setChecksWarningDismissed(false);
+          }
           break;
+        }
         case 'switchTab':
           if (message.tab === 'node' || message.tab === 'collection' || message.tab === 'checks') {
             setViewType(message.tab);
@@ -958,7 +980,15 @@ function ClusterPanelWebview() {
   }, []);
 
   const handleNodeSelect = useCallback((nodeName: string) => {
-    setSelectedNodeName((prev) => (prev === nodeName ? null : nodeName));
+    setSelectedNodeNames((prev) => {
+      const next = new Set(prev);
+      if (next.has(nodeName)) {
+        next.delete(nodeName);
+      } else {
+        next.add(nodeName);
+      }
+      return next;
+    });
     setSelectedShardName(null);
   }, []);
 
@@ -967,8 +997,15 @@ function ClusterPanelWebview() {
   }, []);
 
   const handleCollectionSelect = useCallback((collectionName: string) => {
-    setSelectedCollectionName((prev) => (prev === collectionName ? null : collectionName));
-    setSelectedNodeName(null);
+    setSelectedCollectionNames((prev) => {
+      const next = new Set(prev);
+      if (next.has(collectionName)) {
+        next.delete(collectionName);
+      } else {
+        next.add(collectionName);
+      }
+      return next;
+    });
     setSelectedShardName(null);
   }, []);
 
@@ -1057,7 +1094,7 @@ function ClusterPanelWebview() {
                 <NodeComponent
                   key={node.name}
                   node={node}
-                  isSelected={selectedNodeName === node.name}
+                  isSelected={selectedNodeNames.has(node.name)}
                   onSelect={() => handleNodeSelect(node.name)}
                   selectedShardName={selectedShardName}
                   onShardSelect={handleShardSelect}
@@ -1072,16 +1109,26 @@ function ClusterPanelWebview() {
         ) : (
           <CollectionView
             nodeStatusData={filteredNodeStatusData}
-            selectedNodeName={selectedNodeName}
+            selectedNodeNames={selectedNodeNames}
             selectedShardName={selectedShardName}
-            selectedCollectionName={selectedCollectionName}
+            selectedCollectionNames={selectedCollectionNames}
             onNodeSelect={handleNodeSelect}
             onShardSelect={handleShardSelect}
             onCollectionSelect={handleCollectionSelect}
           />
         )
       ) : isLoading ? (
-        <div className="no-data">
+        <div className="loading">
+          <svg
+            className="loading-spinner"
+            width="24"
+            height="24"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M13.451 5.609l-.579-.939-1.068.812-.076.094c-.335.415-.927 1.341-1.124 2.876l-.021.165.033.163.071.345c0 1.654-1.346 3-3 3-.795 0-1.545-.311-2.107-.868-.563-.567-.873-1.317-.873-2.111 0-1.431 1.007-2.632 2.351-2.929v2.498l2.528-2.134-2.528-2.076v2.11C4.753 6.867 3 8.819 3 11.131c0 1.14.445 2.21 1.253 3.014.808.803 1.883 1.246 3.027 1.246 2.31 0 4.216-1.751 4.455-4.027.098-.858.451-1.935.832-2.489.167-.237.351-.469.555-.678l.131-.117zm-2.359.81c-.172-.268-.33-.518-.475-.748-1.303-2.066-2.916-2.758-4.093-2.758-1.087 0-2.1.563-2.7 1.5-.302.473-.5 1.013-.6 1.596l1.013.014c.087-.484.245-.95.465-1.371.437-.838 1.176-1.34 1.987-1.34.852 0 1.839.428 2.659 1.147.411.363.771.77 1.073 1.211.136.202.261.408.376.616.092-.085.184-.168.278-.25l.017-.017z" />
+          </svg>
           <p>Loading cluster data…</p>
         </div>
       ) : (
@@ -1090,12 +1137,13 @@ function ClusterPanelWebview() {
         </div>
       ),
     [
+      isLoading,
       nodeStatusData,
       filteredNodeStatusData,
       viewType,
-      selectedNodeName,
+      selectedNodeNames,
       selectedShardName,
-      selectedCollectionName,
+      selectedCollectionNames,
     ]
   );
 
@@ -1206,13 +1254,15 @@ function ClusterPanelWebview() {
       </div>
 
       <div className="cluster-content" ref={contentRef}>
-        {viewType !== 'checks' && !checksWarningDismissed && (
-          <ChecksWarningBanner
-            checksResult={checksResult}
-            onOpenChecks={() => setViewType('checks')}
-            onDismiss={() => setChecksWarningDismissed(true)}
-          />
-        )}
+        {viewType !== 'checks' &&
+          !checksWarningDismissed &&
+          checksResult?.multiTenancy?.hasIssues && (
+            <ChecksWarningBanner
+              checksResult={checksResult}
+              onOpenChecks={() => setViewType('checks')}
+              onDismiss={() => setChecksWarningDismissed(true)}
+            />
+          )}
         {viewType === 'checks' ? (
           <ChecksView
             checksResult={checksResult}


### PR DESCRIPTION
- 🛡️ Now Cluster Panel is battle tested for large clusters with shard pagination!
- ⚠️ Implements an 3 checks:
    -  Multiple collections with the same property that can be groupped on a single Multi tenancy collection
    - Empty shards that can be deleted
    - Replication imbalance, when not using Async Replication
- 🐛 Fixes a bug that wasn't allowing multiple cluster panels.
- 🖥️ Fix big collection name messing with buttons.
- Fix a bug on collectio view when cluster had no collections

<img width="1235" height="692" alt="image" src="https://github.com/user-attachments/assets/f30ec748-cc54-4708-907c-1a6938c7a242" />

<img width="733" height="179" alt="image" src="https://github.com/user-attachments/assets/7d9624a7-2ce2-4f4a-a4e4-9a75382ac7e3" />

<img width="1111" height="1041" alt="image" src="https://github.com/user-attachments/assets/f438f64a-f933-47a7-b9db-909be456a03b" />

