### PR TITLE
Multi-Vector Search (Muvera) UI & v4 SDK Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to the Weaviate Studio extension will be documented in this 
 The format is based on [Keep a Changelog](https://keep.achangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2026-04-30
+
+### ✨ Added — Multi-Vector Search (Muvera)
+
+- **Multi-Target Vector Search UI** — Full support for Weaviate's named-vector / Muvera search in the Data Explorer
+  - **Target Vector selector** in Vector Options drawer — check one or more named vectors per collection; each item shows the vectorizer badge (`text2vec-weaviate`, `none`, etc.)
+  - **Auto-selection** — all named vectors are pre-selected when opening a multi-vector collection, preventing the "no target vectors provided" error for first-time users
+  - **Join Strategy selector** — choose how distances from multiple vector spaces are combined:
+    - `Minimum` (default conservative merge)
+    - `Sum`, `Average`
+    - `Manual Weights`, `Relative Score` (reveal the Weight Editor for per-vector tuning)
+  - **Weight Editor** — sliders for fine-grained per-vector distance weighting with a "Normalize" button
+  - **Copy as Code** — generated TypeScript / Python snippets include the correct `multiTargetVector` combination call
+  - Requires Weaviate **v1.26+** for near queries and **v1.27+** for hybrid; a version-gate notice is shown on older servers
+
+### 🐛 Fixed
+
+- **Server version detection broken on weaviate-client v4** — `getServerVersion()` was calling the v3-only `misc.metaGetter().do()` API which silently threw on v4, returning `null`. The version gate therefore always showed the "requires v1.26+" warning even on v1.37+ servers. Fixed by preferring the v4 `client.getMeta()` method with a fallback to the v3 API (`DataExplorerAPI.ts`)
+
+- **Multi-target search payload never included selected vectors** — `useVectorSearch.ts` built the search payload using only `searchParams.targetVector` (a legacy single-string field), completely ignoring `selectedTargetVectors`, `joinStrategy`, and `vectorWeights` from context state. All checked vectors were silently discarded, producing the Weaviate error _"class has multiple vectors, but no target vectors were provided"_. Fixed by reading multi-target state from context and building the correct payload:
+  - 1 vector selected → single-string `targetVector`
+  - 2+ vectors selected → `{ combination, targetVectors, weights? }` object consumed by `multiTargetVector.*()` SDK factory methods
+
+### 🎨 Changed — Vector Search UX
+
+- **Max Distance default raised from `0.5` to `1.0`** — cosine distance `0.5` is strict (~0.75 certainty) and silently dropped many valid results. At `1.0` the distance filter is **omitted from the query entirely**, letting Weaviate return pure top-N results. Users can tighten the slider; the label shows **"1.00 (no filter)"** at the default position
+- **Distance slider** now has three range labels: `0 (exact)` · `1.0 (no filter)` · `2 (distant)` for clear semantic guidance
+- **Run Vector Search button** is disabled when a multi-vector collection has no target vectors checked, with a clear validation guard instead of a cryptic server error
+
+### Internal
+
+- Added `sandbox/populate_cloud_muvera.py` — reproducible test fixture for multi-vector cloud collections using `text2vec-weaviate` (built-in, no external API key required)
+- Added `sandbox/check_modules.py` — utility to inspect available vectorizer/generative modules on a Weaviate Cloud instance
+
 ## [1.6.0] - 2026-03-21
 
 ### 🔭 Added - Telemetry System

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -5,6 +5,7 @@ This guide helps you validate the extension end‑to‑end before publishing.
 ## 📦 Pre‑Testing Setup
 
 ### 1) Create Test Package
+
 ```bash
 # Install dependencies (clean)
 npm ci
@@ -17,11 +18,13 @@ ls -la weaviate-studio-*.vsix
 ```
 
 Tip: To install the latest packaged file quickly on macOS/Linux:
+
 ```bash
 code --install-extension "$(ls -t weaviate-studio-*.vsix | head -n1)" --force
 ```
 
 ### 2) Prepare Test Environment
+
 - VS Code: Latest stable (or at least the minimum supported — see Compatibility)
 - Weaviate instance: Local or cloud
 - Seed data: Sample collections with varied data types
@@ -35,18 +38,21 @@ code --install-extension "$(ls -t weaviate-studio-*.vsix | head -n1)" --force
 ## 🎯 Testing Checklist
 
 ### ✅ Installation
+
 - [ ] Install from VSIX: `code --install-extension weaviate-studio-<version>.vsix`
 - [ ] **Verify Installation**: Extension appears in Extensions panel
 - [ ] **Check Activation**: Weaviate icon appears in Activity Bar
 - [ ] **No Console Errors**: Check Developer Tools (Help > Toggle Developer Tools)
 
 ### ✅ UI/UX
+
 - [ ] **Activity Bar Icon**: Weaviate icon displays correctly
 - [ ] **Tree View**: Connections panel loads without errors
 - [ ] **Welcome Message**: "No connections found" message appears
 - [ ] **Icons**: All icons display properly (database, add, refresh, etc.)
 
 ### ✅ Connection Management
+
 - [ ] **Add Connection**: Click "Add New Weaviate Connection"
 - [ ] **Form Validation**: Test with invalid URLs/credentials
 - [ ] **Successful Connection**: Connect to a real Weaviate instance
@@ -55,6 +61,7 @@ code --install-extension "$(ls -t weaviate-studio-*.vsix | head -n1)" --force
 - [ ] **Delete Connection**: Remove connection with confirmation
 
 ### ✅ Tree View
+
 - [ ] **Expand/Collapse**: All tree items expand/collapse properly
 - [ ] **Connect Prompt on Expand**: Expanding a disconnected connection prompts to connect
 - [ ] **Connection Info**: Server info, cluster health display correctly
@@ -63,6 +70,7 @@ code --install-extension "$(ls -t weaviate-studio-*.vsix | head -n1)" --force
 - [ ] **Statistics**: Live object counts and statistics display
 
 ### ✅ Query Editor
+
 - [ ] **Open Query Editor**: Right-click collection → "Query Collection"
 - [ ] **Monaco Editor**: GraphQL syntax highlighting works
 - [ ] **Auto-completion**: Schema-aware suggestions appear
@@ -72,6 +80,7 @@ code --install-extension "$(ls -t weaviate-studio-*.vsix | head -n1)" --force
 - [ ] **Error Handling**: Invalid queries show proper errors
 
 ### ✅ Schema Management
+
 - [ ] **View Detailed Schema**: Right-click collection → "View Detailed Schema"
 - [ ] **Overview Tab**: Shows collection stats and configuration
 - [ ] **Properties Tab**: Lists all properties with types
@@ -80,6 +89,7 @@ code --install-extension "$(ls -t weaviate-studio-*.vsix | head -n1)" --force
 - [ ] **Creation Scripts Tab**: Python scripts for recreation
 
 ### ✅ Advanced Features
+
 - [ ] **Multiple Tabs**: Open multiple query tabs
 - [ ] **Reference Fields**: Test queries with cross-references
 - [ ] **Complex Queries**: Vector search, filters, aggregations
@@ -87,46 +97,73 @@ code --install-extension "$(ls -t weaviate-studio-*.vsix | head -n1)" --force
 - [ ] **Delete Collection**: Remove collections with confirmation
 - [ ] **Delete All Collections**: Destructive bulk delete requires double confirmation and updates tree
 
+### ✅ Multi-Vector Search (Muvera) — requires Weaviate v1.26+
+
+> Use a collection with 2+ named vectors (e.g. `MultiVectorCollection` seeded by `sandbox/populate_cloud_muvera.py`).
+
+- [ ] **Target Vectors drawer** — Vector Options expands and shows all named vectors with vectorizer badges
+- [ ] **Auto-selection** — all vectors are pre-checked on first open; user can deselect individually
+- [ ] **Single-target search** — check exactly one vector, run Text Semantic search; returns results, no error
+- [ ] **Multi-target search** — check 2+ vectors, "Join Strategy" dropdown is enabled; run search; results returned
+- [ ] **Join Strategy: Minimum** — default; search completes without error
+- [ ] **Join Strategy: Sum / Average** — change strategy, re-run; different result ordering may appear
+- [ ] **Join Strategy: Manual Weights** — Weight Editor appears; adjust sliders, click Normalize, re-run search
+- [ ] **Run button disabled** — deselect all vectors; "Run Vector Search" button is greyed out
+- [ ] **Version gate** — on a server older than v1.26, the Join Strategy section shows the version warning message
+- [ ] **Max Distance default** — slider starts at `1.00 (no filter)`; search returns results without distance filtering
+- [ ] **Max Distance tightened** — move slider below 1.0; verify fewer/no results returned for distant vectors
+- [ ] **Copy as Code** — TypeScript/Python snippet includes correct `multiTargetVector` combination call
+- [ ] **Text (Semantic)** — works when collection has a vectorizer; error shown if no vectorizer configured
+- [ ] **Similar Object / Raw Vector** — work for collections without a vectorizer (no-vectorizer `none` collections)
+
 ### ✅ Performance
+
 - [ ] **Load Time**: Extension loads within 2-3 seconds
 - [ ] **Memory Usage**: Check memory consumption in Activity Monitor
 - [ ] **Large Datasets**: Test with collections having 1000+ objects
 - [ ] **Multiple Connections**: Test with 3+ simultaneous connections
 
 ### ✅ Error Handling
+
 - [ ] **Network Errors**: Disconnect internet and test error messages
 - [ ] **Invalid Credentials**: Test with wrong API keys
 - [ ] **Server Down**: Test when Weaviate server is unavailable
 - [ ] **Malformed Queries**: Test GraphQL syntax error handling
 
 ### ✅ Cross‑Platform
+
 - [ ] **macOS**: Test on macOS (current)
 - [ ] **Windows**: Test on Windows if available
 - [ ] **Linux**: Test on Linux if available
 - [ ] **Different VS Code Versions**: Test on VS Code 1.85+ and latest
 
 ### ✅ Webview Security (CSP/Nonce)
+
 - [ ] DevTools Console has no CSP violations
 - [ ] `<script nonce="...">` present in webview HTML (search Elements panel)
 - [ ] Loading works in strict environments (e.g., corporate policies)
 
 ### ✅ Weaviate Compatibility
+
 - [ ] Server supports Collections API (extension lists collections, not legacy classes)
 - [ ] GraphQL queries succeed via /v1/graphql (with API key when needed)
 
 ## 🐛 Common Issues to Check
 
 ### Installation
+
 - **Extension won't install**: Check VS Code version compatibility
 - **Missing dependencies**: Verify all files are included in package
 - **Permission errors**: Check file permissions
 
 ### Runtime
+
 - **Extension not activating**: Check activation events in package.json
 - **Webview not loading**: Check webpack configuration
 - **Monaco Editor errors**: Verify Monaco webpack plugin setup
 
 ### Performance
+
 - **Slow loading**: Check bundle size and optimization
 - **Memory leaks**: Monitor memory usage during extended use
 - **UI freezing**: Test with large datasets
@@ -137,6 +174,7 @@ code --install-extension "$(ls -t weaviate-studio-*.vsix | head -n1)" --force
 ## Test Results - [Date]
 
 ### ✅ Passed Tests
+
 - Installation: ✅
 - Connection Management: ✅
 - Query Editor: ✅
@@ -144,15 +182,18 @@ code --install-extension "$(ls -t weaviate-studio-*.vsix | head -n1)" --force
 - Performance: ✅
 
 ### ⚠️ Issues Found
+
 - [Issue description]
 - [Severity: Low/Medium/High]
 - [Steps to reproduce]
 
 ### 🔧 Fixes Applied
+
 - [Fix description]
 - [Files modified]
 
 ### 📝 Notes
+
 - [Additional observations]
 - [Performance metrics]
 - [User experience feedback]
@@ -161,6 +202,7 @@ code --install-extension "$(ls -t weaviate-studio-*.vsix | head -n1)" --force
 ## 🚀 Pre‑Publishing Checklist
 
 Before publishing, ensure:
+
 - [ ] Tests pass: `npm test`
 - [ ] Lint passes: `npm run lint`
 - [ ] Builds are green: `npm run compile && npm run build:webview`
@@ -174,18 +216,21 @@ Before publishing, ensure:
 ## 🆘 Troubleshooting
 
 ### If Extension Won't Load
+
 1. Check VS Code Developer Console for errors
 2. Verify all dependencies are bundled
 3. Check webpack configuration
 4. Test in clean VS Code environment
 
 ### If Webview Won't Load
+
 1. Check webpack.webview.config.js
 2. Verify Monaco Editor configuration
 3. Check browser console for errors
 4. Test with different VS Code versions
 
 ### If Queries Fail
+
 1. Verify Weaviate connection
 2. Check GraphQL schema
 3. Test with simple queries first
@@ -193,4 +238,4 @@ Before publishing, ensure:
 
 ---
 
-**Remember**: Thorough testing ensures a smooth user experience and reduces support requests after publishing! 
+**Remember**: Thorough testing ensures a smooth user experience and reduces support requests after publishing!

--- a/sandbox/check_modules.py
+++ b/sandbox/check_modules.py
@@ -1,0 +1,20 @@
+"""Check available modules on the cloud instance."""
+import weaviate
+
+REST_URL = "https://fnl3iugnrviq0uvkjjl2yg.c0.us-west3.gcp.weaviate.cloud"
+API_KEY = "bkhHUE92K2VPbWlWQnY0R18xNWxNanFtc1dwOGs3eUYzYnAwUmNFaS9LTVRpMkUrNGFzdjBKamhaVVRVPV92MjAw"
+
+client = weaviate.connect_to_weaviate_cloud(
+    cluster_url=REST_URL,
+    auth_credentials=weaviate.auth.AuthApiKey(API_KEY),
+)
+
+try:
+    meta = client.get_meta()
+    modules = meta.get("modules", {})
+    print(f"Version: {meta.get('version')}")
+    print(f"\nAvailable modules ({len(modules)}):")
+    for name in sorted(modules.keys()):
+        print(f"  - {name}")
+finally:
+    client.close()

--- a/sandbox/populate_cloud_muvera.py
+++ b/sandbox/populate_cloud_muvera.py
@@ -1,0 +1,128 @@
+"""
+populate_cloud_muvera.py
+Populates a Weaviate Cloud instance with a MultiVectorCollection
+configured for Multi-Vector Search (Muvera) testing.
+
+Uses text2vec-weaviate (built-in, no external API key needed) so that
+Text (Semantic) search mode works in the extension.
+"""
+
+import weaviate
+from weaviate.classes.config import Property, DataType, Configure
+
+REST_URL = ""
+GRPC_URL = ""
+API_KEY  = ""
+
+DOCUMENTS = [
+    {
+        "title": "Introduction to Vector Databases",
+        "description": (
+            "A comprehensive guide to how vector databases work and their use "
+            "cases in AI. Learn about embeddings, approximate nearest neighbour "
+            "search, and HNSW indexing."
+        ),
+    },
+    {
+        "title": "Multi-Vector Search Explained",
+        "description": (
+            "Deep dive into Muvera and how to combine results from multiple vector "
+            "targets. Covers join strategies: sum, average, minimum, and "
+            "manual-weights."
+        ),
+    },
+    {
+        "title": "Cloud Native AI Applications",
+        "description": (
+            "Building scalable AI solutions using cloud-native architectures and "
+            "vector search. Includes container orchestration, auto-scaling, and "
+            "observability patterns."
+        ),
+    },
+    {
+        "title": "Semantic Search with Weaviate",
+        "description": (
+            "End-to-end tutorial on building a semantic search engine using Weaviate, "
+            "Python, and the weaviate-client library. Covers schema design, data "
+            "ingestion, and query optimization."
+        ),
+    },
+    {
+        "title": "Understanding Hybrid Search",
+        "description": (
+            "Hybrid search combines keyword BM25 scoring with dense vector similarity. "
+            "Learn how the alpha parameter balances the two signals and when each "
+            "approach performs best."
+        ),
+    },
+]
+
+
+def populate_cloud() -> None:
+    print(f"Connecting to Weaviate Cloud: {REST_URL}...")
+
+    client = weaviate.connect_to_weaviate_cloud(
+        cluster_url=REST_URL,
+        auth_credentials=weaviate.auth.AuthApiKey(API_KEY),
+    )
+
+    try:
+        # --- Delete existing collection ---
+        if client.collections.exists("MultiVectorCollection"):
+            print("Deleting existing MultiVectorCollection...")
+            client.collections.delete("MultiVectorCollection")
+
+        # --- Create collection with 3 named vectors using text2vec-weaviate ---
+        # text2vec-weaviate is built-in on all Weaviate Cloud instances
+        # (no external API key required).
+        # Each named vector embeds a different source property so the
+        # multi-target search has meaningful signal differences.
+        print("Creating MultiVectorCollection with text2vec-weaviate named vectors...")
+        client.collections.create(
+            name="MultiVectorCollection",
+            vectorizer_config=[
+                Configure.NamedVectors.text2vec_weaviate(
+                    name="title_vector",
+                    source_properties=["title"],
+                ),
+                Configure.NamedVectors.text2vec_weaviate(
+                    name="desc_vector",
+                    source_properties=["description"],
+                ),
+                Configure.NamedVectors.text2vec_weaviate(
+                    name="combined_vector",
+                    source_properties=["title", "description"],
+                ),
+            ],
+            properties=[
+                Property(name="title",       data_type=DataType.TEXT),
+                Property(name="description", data_type=DataType.TEXT),
+            ],
+        )
+
+        # --- Insert sample documents (vectors auto-generated) ---
+        collection = client.collections.get("MultiVectorCollection")
+        print(f"Inserting {len(DOCUMENTS)} documents (vectors auto-generated)...")
+
+        with collection.batch.dynamic() as batch:
+            for doc in DOCUMENTS:
+                batch.add_object(properties=doc)
+
+        print("\n✓ MultiVectorCollection populated on Weaviate Cloud!")
+        print("  - 3 named vectors: title_vector, desc_vector, combined_vector")
+        print("  - Vectorizer: text2vec-weaviate (no API key needed)")
+        print(f"  - {len(DOCUMENTS)} documents inserted")
+        print("\nYou can now test ALL search modes in Weaviate Studio:")
+        print("  • Text (Semantic) — type any query and pick target vectors")
+        print("  • Raw Vector      — paste a vector array")
+        print("  • Similar Object  — pick any UUID from the collection")
+        print("  • Hybrid          — combines keyword + semantic search")
+
+    except Exception as e:
+        print(f"\n✗ Error: {e}")
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    populate_cloud()

--- a/src/data-explorer/extension/DataExplorerAPI.ts
+++ b/src/data-explorer/extension/DataExplorerAPI.ts
@@ -85,8 +85,38 @@ export class DataExplorerAPI {
   private countCache = new Map<string, { count: number; timestamp: number }>();
   private readonly CACHE_TTL = 60000; // 1 minute
   private readonly REQUEST_TIMEOUT = DEFAULT_TIMEOUT_MS;
+  private serverVersion: string | null = null;
+  private serverVersionFetchedAt = 0;
+  private readonly VERSION_CACHE_TTL = 3600000; // 1 hour
 
   constructor(private client: WeaviateClient) {}
+
+  /**
+   * Get the Weaviate server version
+   * Cached for 1 hour to avoid repeated requests
+   */
+  async getServerVersion(): Promise<string | null> {
+    const now = Date.now();
+    if (this.serverVersion && now - this.serverVersionFetchedAt < this.VERSION_CACHE_TTL) {
+      return this.serverVersion;
+    }
+
+    try {
+      // Use misc.metaGetter().do() which fetches /meta and returns { version, ... }
+      const meta = await (this.client as any).misc.metaGetter().do();
+
+      if (meta && typeof meta === 'object' && 'version' in meta) {
+        this.serverVersion = (meta as any).version as string;
+        this.serverVersionFetchedAt = now;
+        return this.serverVersion;
+      }
+
+      return null;
+    } catch (err) {
+      console.warn('Failed to fetch server version:', err);
+      return null;
+    }
+  }
 
   /**
    * Helper method to check if a collection schema has multi-tenancy enabled
@@ -425,9 +455,48 @@ export class DataExplorerAPI {
       vectorOptions.distanceMetric = vectorSearch.distanceMetric;
     }
 
-    // Add target vector for named vectors
+    // Add target vector for named vectors or multi-target configuration
     if (vectorSearch.targetVector) {
-      vectorOptions.targetVector = vectorSearch.targetVector;
+      // Handle both single string (single target vector) and multi-target payload objects
+      if (typeof vectorSearch.targetVector === 'string') {
+        // Single target vector
+        vectorOptions.targetVector = vectorSearch.targetVector;
+      } else if (typeof vectorSearch.targetVector === 'object') {
+        // Multi-target payload
+        const mtPayload = vectorSearch.targetVector as any;
+        const { combination, targetVectors, weights } = mtPayload;
+
+        if (targetVectors && targetVectors.length > 0) {
+          try {
+            // Build multi-target join using SDK factory methods
+            let joinStrategy: any;
+
+            switch (combination) {
+              case 'sum':
+                joinStrategy = collection.multiTargetVector.sum(targetVectors);
+                break;
+              case 'average':
+                joinStrategy = collection.multiTargetVector.average(targetVectors);
+                break;
+              case 'manual-weights':
+                joinStrategy = collection.multiTargetVector.manualWeights(weights || {});
+                break;
+              case 'relative-score':
+                joinStrategy = collection.multiTargetVector.relativeScore(weights || {});
+                break;
+              case 'minimum':
+              default:
+                joinStrategy = collection.multiTargetVector.minimum(targetVectors);
+                break;
+            }
+
+            vectorOptions.targetVector = joinStrategy;
+          } catch (err) {
+            const errorMsg = err instanceof Error ? err.message : String(err);
+            throw new Error(`Failed to build multi-target vector configuration: ${errorMsg}`);
+          }
+        }
+      }
     }
 
     // Execute appropriate vector search

--- a/src/data-explorer/extension/DataExplorerAPI.ts
+++ b/src/data-explorer/extension/DataExplorerAPI.ts
@@ -102,11 +102,23 @@ export class DataExplorerAPI {
     }
 
     try {
-      // Use misc.metaGetter().do() which fetches /meta and returns { version, ... }
-      const meta = await (this.client as any).misc.metaGetter().do();
+      let meta: { version?: string } | null = null;
 
-      if (meta && typeof meta === 'object' && 'version' in meta) {
-        this.serverVersion = (meta as any).version as string;
+      // weaviate-client v4: client.getMeta() returns { version, ... }
+      if (typeof (this.client as any).getMeta === 'function') {
+        meta = await (this.client as any).getMeta();
+      } else {
+        // Fallback: v3-style misc.metaGetter().do()
+        meta = await (this.client as any).misc.metaGetter().do();
+      }
+
+      if (
+        meta &&
+        typeof meta === 'object' &&
+        'version' in meta &&
+        typeof meta.version === 'string'
+      ) {
+        this.serverVersion = meta.version;
         this.serverVersionFetchedAt = now;
         return this.serverVersion;
       }

--- a/src/data-explorer/extension/DataExplorerPanel.ts
+++ b/src/data-explorer/extension/DataExplorerPanel.ts
@@ -338,8 +338,12 @@ export class DataExplorerPanel {
       return;
     }
 
-    // Get schema first
-    const schema = await this._api.getCollectionSchema(this._collectionName);
+    // Get schema and server version
+    const [schema, serverVersion] = await Promise.all([
+      this._api.getCollectionSchema(this._collectionName),
+      this._api.getServerVersion().catch(() => null),
+    ]);
+
     this._isMultiTenant = !!(schema.multiTenancy as any)?.enabled;
 
     // If multi-tenant, get tenants immediately and send everything together
@@ -355,6 +359,7 @@ export class DataExplorerPanel {
           collectionName: this._collectionName,
           isMultiTenant: true,
           tenants,
+          serverVersion: serverVersion || undefined,
         });
 
         // Do NOT fetch objects - wait for tenant selection
@@ -375,6 +380,7 @@ export class DataExplorerPanel {
       schema,
       collectionName: this._collectionName,
       isMultiTenant: false,
+      serverVersion: serverVersion || undefined,
     });
 
     // Fetch initial objects for non-multi-tenant collections

--- a/src/data-explorer/types/index.ts
+++ b/src/data-explorer/types/index.ts
@@ -199,6 +199,26 @@ export type FilterMatchMode = 'AND' | 'OR';
 // Vector search types for Phase 3
 export type VectorSearchType = 'none' | 'nearText' | 'nearVector' | 'nearObject' | 'hybrid';
 
+// Multi-target vector search types
+export type JoinStrategy = 'minimum' | 'sum' | 'average' | 'manual-weights' | 'relative-score';
+
+export interface MultiTargetPayload {
+  combination: JoinStrategy;
+  targetVectors: string[];
+  weights?: Record<string, number>;
+}
+
+export interface NamedVectorInfo {
+  name: string;
+  vectorizerName: string;
+  vectorizerConfig: unknown;
+  indexType: string;
+  indexConfig: unknown;
+  isMuvera: boolean;
+  isMultiVector: boolean;
+  properties?: string[];
+}
+
 export interface VectorSearchParams {
   type: VectorSearchType;
   // nearText parameters
@@ -211,7 +231,7 @@ export interface VectorSearchParams {
   certainty?: number;
   distance?: number;
   distanceMetric?: string;
-  targetVector?: string;
+  targetVector?: string | MultiTargetPayload;
   // Hybrid search parameters
   alpha?: number; // 0 = pure BM25, 1 = pure vector
   fusionType?: 'rankedFusion' | 'relativeScoreFusion';
@@ -293,6 +313,8 @@ export interface ExtensionMessage {
   tenants?: TenantInfo[];
   tenant?: string;
   isMultiTenant?: boolean;
+  // Server metadata
+  serverVersion?: string;
   // Phase 5: Aggregations and Export
   aggregations?: AggregationResult;
   exportResult?: ExportResult;

--- a/src/data-explorer/types/weaviate.ts
+++ b/src/data-explorer/types/weaviate.ts
@@ -78,8 +78,8 @@ export interface WeaviateVectorQueryOptions extends Omit<WeaviateQueryOptions, '
   /** Distance metric override (if different from collection default) */
   distanceMetric?: string;
 
-  /** Target vector name for named vectors */
-  targetVector?: string;
+  /** Target vector name for named vectors or multi-target vector join configuration */
+  targetVector?: string | unknown; // unknown allows MultiTargetVectorJoin<V> from SDK
 
   /** Allow additional properties for SDK compatibility */
   [key: string]: unknown;

--- a/src/data-explorer/webview/components/VectorSearch/CopyAsCode.css
+++ b/src/data-explorer/webview/components/VectorSearch/CopyAsCode.css
@@ -1,0 +1,42 @@
+.copy-as-code {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.copy-as-code-btn {
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  border: 1px solid var(--vscode-button-border);
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  border-radius: 2px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.copy-as-code-btn:hover:not(:disabled) {
+  background-color: var(--vscode-button-hoverBackground);
+}
+
+.copy-as-code-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.copy-as-code-language {
+  padding: 6px 8px;
+  font-size: 12px;
+  border: 1px solid var(--vscode-input-border);
+  background-color: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+.copy-as-code-language:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/data-explorer/webview/components/VectorSearch/CopyAsCode.css
+++ b/src/data-explorer/webview/components/VectorSearch/CopyAsCode.css
@@ -2,7 +2,7 @@
   display: flex;
   gap: 8px;
   align-items: center;
-  margin-top: 12px;
+  margin-left: auto; /* push to the right within the secondary row */
 }
 
 .copy-as-code-btn {

--- a/src/data-explorer/webview/components/VectorSearch/CopyAsCode.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/CopyAsCode.tsx
@@ -1,0 +1,189 @@
+/**
+ * CopyAsCode - Generate and copy SDK code snippets for current search configuration
+ * Supports TypeScript and Python output
+ */
+
+import React, { useCallback, useState } from 'react';
+import type { MultiTargetPayload } from '../../../types';
+import type { VectorSearchParameters } from '../../context';
+import './CopyAsCode.css';
+
+interface CopyAsCodeProps {
+  collectionName: string;
+  searchMode: 'text' | 'object' | 'vector' | 'hybrid';
+  searchParams: VectorSearchParameters;
+  targetVector?: string | MultiTargetPayload;
+  disabled?: boolean;
+}
+
+type Language = 'typescript' | 'python';
+
+function generateTypeScriptSnippet(
+  collectionName: string,
+  searchMode: string,
+  searchParams: VectorSearchParameters,
+  targetVector?: string | MultiTargetPayload
+): string {
+  const lines: string[] = [];
+
+  lines.push('import weaviate from "weaviate-client";');
+  lines.push('');
+  lines.push('const client = weaviate.connectToLocal();');
+  lines.push(`const collection = client.collections.get("${collectionName}");`);
+  lines.push('');
+  lines.push('const results = await collection');
+
+  if (searchMode === 'text') {
+    lines.push(`  .query.nearText("${searchParams.query}", {`);
+  } else if (searchMode === 'hybrid') {
+    lines.push(`  .query.hybrid("${searchParams.query}", {`);
+    lines.push(`    alpha: ${searchParams.hybridAlpha},`);
+  } else if (searchMode === 'object') {
+    lines.push(`  .query.nearObject("${searchParams.objectId}", {`);
+  } else if (searchMode === 'vector') {
+    lines.push('  .query.nearVector([...], {');
+  }
+
+  if (targetVector && typeof targetVector === 'object') {
+    const payload = targetVector as MultiTargetPayload;
+    lines.push(
+      `    targetVectors: [${payload.targetVectors.map((v: string) => `"${v}"`).join(', ')}],`
+    );
+    lines.push(`    join: collection.multiTargetVector.${payload.combination}(),`);
+    if (payload.weights) {
+      const weightsStr = Object.entries(payload.weights)
+        .map(([v, w]) => `"${v}": ${w}`)
+        .join(', ');
+      lines.push(`    weights: { ${weightsStr} },`);
+    }
+  } else if (targetVector && typeof targetVector === 'string') {
+    lines.push(`    targetVector: "${targetVector}",`);
+  }
+
+  lines.push(`    limit: ${searchParams.limit},`);
+  if (searchParams.certainty) {
+    lines.push(`    certainty: ${searchParams.certainty},`);
+  }
+  lines.push('  })');
+  lines.push('  .withLimit(searchParams.limit)');
+  lines.push('  .do();');
+  lines.push('');
+  lines.push('console.log(results);');
+
+  return lines.join('\n');
+}
+
+function generatePythonSnippet(
+  collectionName: string,
+  searchMode: string,
+  searchParams: VectorSearchParameters,
+  targetVector?: string | MultiTargetPayload
+): string {
+  const lines: string[] = [];
+
+  lines.push('import weaviate');
+  lines.push('from weaviate.classes.query import Move');
+  lines.push('');
+  lines.push('client = weaviate.connect_to_local()');
+  lines.push(`collection = client.collections.get("${collectionName}")`);
+  lines.push('');
+
+  const queryParams: string[] = [];
+  queryParams.push(`limit=${searchParams.limit}`);
+
+  if (searchParams.certainty) {
+    queryParams.push(`certainty=${searchParams.certainty}`);
+  }
+
+  if (targetVector && typeof targetVector === 'object') {
+    const payload = targetVector as MultiTargetPayload;
+    const targetsStr = '[' + payload.targetVectors.map((v: string) => `"${v}"`).join(', ') + ']';
+    queryParams.push(`target_vectors=${targetsStr}`);
+    queryParams.push(`join_strategy="${payload.combination}"`);
+    if (payload.weights) {
+      const weightsStr =
+        '{' +
+        Object.entries(payload.weights)
+          .map(([v, w]) => `"${v}": ${w}`)
+          .join(', ') +
+        '}';
+      queryParams.push(`weights=${weightsStr}`);
+    }
+  } else if (targetVector && typeof targetVector === 'string') {
+    queryParams.push(`target_vector="${targetVector}"`);
+  }
+
+  if (searchMode === 'text') {
+    lines.push(`results = collection.query.near_text(`);
+    lines.push(`    "${searchParams.query}",`);
+  } else if (searchMode === 'hybrid') {
+    lines.push(`results = collection.query.hybrid(`);
+    lines.push(`    "${searchParams.query}",`);
+    queryParams.push(`alpha=${searchParams.hybridAlpha}`);
+  } else if (searchMode === 'object') {
+    lines.push(`results = collection.query.near_object(`);
+    lines.push(`    "${searchParams.objectId}",`);
+  }
+
+  lines.push(`    ${queryParams.join(',\n    ')}`);
+  lines.push(').objects');
+  lines.push('');
+  lines.push('for obj in results:');
+  lines.push('    print(obj)');
+
+  return lines.join('\n');
+}
+
+export function CopyAsCode({
+  collectionName,
+  searchMode,
+  searchParams,
+  targetVector,
+  disabled = false,
+}: CopyAsCodeProps) {
+  const [language, setLanguage] = useState<Language>('typescript');
+  const [copied, setCopied] = useState(false);
+
+  const generateSnippet = useCallback((): string => {
+    if (language === 'typescript') {
+      return generateTypeScriptSnippet(collectionName, searchMode, searchParams, targetVector);
+    } else {
+      return generatePythonSnippet(collectionName, searchMode, searchParams, targetVector);
+    }
+  }, [collectionName, searchMode, searchParams, targetVector, language]);
+
+  const handleCopyCode = useCallback(async () => {
+    try {
+      const snippet = generateSnippet();
+      await navigator.clipboard.writeText(snippet);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy code:', err);
+    }
+  }, [generateSnippet]);
+
+  return (
+    <div className="copy-as-code">
+      <button
+        className="copy-as-code-btn"
+        onClick={handleCopyCode}
+        disabled={disabled}
+        title="Copy generated code to clipboard"
+      >
+        {copied ? '✓ Copied!' : '📋 Copy as Code'}
+      </button>
+
+      <select
+        className="copy-as-code-language"
+        value={language}
+        onChange={(e) => setLanguage(e.target.value as Language)}
+        disabled={disabled}
+        aria-label="Select code language"
+      >
+        <option value="typescript">TypeScript</option>
+        <option value="python">Python</option>
+      </select>
+    </div>
+  );
+}

--- a/src/data-explorer/webview/components/VectorSearch/CopyAsCode.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/CopyAsCode.tsx
@@ -64,9 +64,7 @@ function generateTypeScriptSnippet(
   if (searchParams.certainty) {
     lines.push(`    certainty: ${searchParams.certainty},`);
   }
-  lines.push('  })');
-  lines.push('  .withLimit(searchParams.limit)');
-  lines.push('  .do();');
+  lines.push('  });');
   lines.push('');
   lines.push('console.log(results);');
 

--- a/src/data-explorer/webview/components/VectorSearch/JoinStrategySelector.css
+++ b/src/data-explorer/webview/components/VectorSearch/JoinStrategySelector.css
@@ -1,0 +1,45 @@
+.join-strategy-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.join-strategy-control {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.join-strategy-control label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--vscode-editor-foreground);
+}
+
+.join-strategy-select {
+  padding: 6px 8px;
+  font-size: 12px;
+  border: 1px solid var(--vscode-input-border);
+  background-color: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+.join-strategy-select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.join-strategy-unsupported {
+  padding: 12px;
+  background-color: var(--vscode-notebookStatusErrorBackground);
+  border: 1px solid var(--vscode-errorForeground);
+  border-radius: 2px;
+  color: var(--vscode-errorForeground);
+  font-size: 12px;
+}
+
+.join-strategy-unsupported p {
+  margin: 0;
+}

--- a/src/data-explorer/webview/components/VectorSearch/JoinStrategySelector.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/JoinStrategySelector.tsx
@@ -1,0 +1,98 @@
+/**
+ * JoinStrategySelector - Select join strategy for multi-target vector search
+ * Provides dropdown with strategies and conditionally renders weight editor
+ */
+
+import React, { useCallback } from 'react';
+import type { JoinStrategy } from '../../../types';
+import { WeightEditor } from './WeightEditor';
+import './JoinStrategySelector.css';
+
+interface JoinStrategySelectorProps {
+  selectedVectors: string[];
+  joinStrategy: JoinStrategy;
+  vectorWeights: Record<string, number>;
+  onStrategyChange: (strategy: JoinStrategy) => void;
+  onWeightChange: (vectorName: string, weight: number) => void;
+  onNormalize: () => void;
+  versionSupported: boolean;
+  disabled?: boolean;
+}
+
+const STRATEGY_DESCRIPTIONS: Record<JoinStrategy, string> = {
+  minimum: 'Default conservative merge',
+  sum: 'Sum of distances',
+  average: 'Average of distances',
+  'manual-weights': 'Weighted raw distances',
+  'relative-score': 'Weighted normalized distances',
+};
+
+export function JoinStrategySelector({
+  selectedVectors,
+  joinStrategy,
+  vectorWeights,
+  onStrategyChange,
+  onWeightChange,
+  onNormalize,
+  versionSupported,
+  disabled = false,
+}: JoinStrategySelectorProps) {
+  const handleStrategyChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      onStrategyChange(e.target.value as JoinStrategy);
+    },
+    [onStrategyChange]
+  );
+
+  const isWeightedStrategy = joinStrategy === 'manual-weights' || joinStrategy === 'relative-score';
+
+  // Ensure all selected vectors have weights initialized
+  const initializedWeights: Record<string, number> = {};
+  selectedVectors.forEach((vector) => {
+    initializedWeights[vector] = vectorWeights[vector] ?? 0.5;
+  });
+
+  if (!versionSupported) {
+    return (
+      <div className="join-strategy-unsupported">
+        <p>
+          Multi-target vector search requires Weaviate v1.26+ for near queries or v1.27+ for hybrid
+          search.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="join-strategy-selector">
+      <div className="join-strategy-control">
+        <label htmlFor="join-strategy-select">Join Strategy</label>
+        <select
+          id="join-strategy-select"
+          value={joinStrategy}
+          onChange={handleStrategyChange}
+          disabled={disabled || selectedVectors.length < 2}
+          className="join-strategy-select"
+          aria-label="Select join strategy for multi-target search"
+        >
+          {Object.entries(STRATEGY_DESCRIPTIONS).map(([strategy, description]) => (
+            <option key={strategy} value={strategy}>
+              {strategy.charAt(0).toUpperCase() + strategy.slice(1).replace('-', ' ')} -{' '}
+              {description}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {isWeightedStrategy && selectedVectors.length > 0 && (
+        <WeightEditor
+          selectedVectors={selectedVectors}
+          weights={initializedWeights}
+          onWeightChange={onWeightChange}
+          onNormalize={onNormalize}
+          disabled={disabled}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/data-explorer/webview/components/VectorSearch/MuveraBadge.css
+++ b/src/data-explorer/webview/components/VectorSearch/MuveraBadge.css
@@ -1,0 +1,11 @@
+.muvera-badge {
+  display: inline-block;
+  padding: 2px 6px;
+  background-color: var(--vscode-textCodeBlock-background);
+  color: var(--vscode-editor-foreground);
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: 600;
+  margin-left: 4px;
+  white-space: nowrap;
+}

--- a/src/data-explorer/webview/components/VectorSearch/MuveraBadge.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/MuveraBadge.tsx
@@ -1,0 +1,24 @@
+/**
+ * MuveraBadge - Display badge for MUVERA-encoded vectors
+ * Shows a small badge indicating MUVERA encoding with a tooltip
+ */
+
+import React from 'react';
+import './MuveraBadge.css';
+
+interface MuveraBadgeProp {
+  className?: string;
+}
+
+export function MuveraBadge({ className = '' }: MuveraBadgeProp) {
+  return (
+    <span
+      className={`muvera-badge ${className}`}
+      title="Uses MUVERA encoding for efficient multi-vector search"
+      role="img"
+      aria-label="MUVERA"
+    >
+      MUVERA
+    </span>
+  );
+}

--- a/src/data-explorer/webview/components/VectorSearch/TargetVectorList.css
+++ b/src/data-explorer/webview/components/VectorSearch/TargetVectorList.css
@@ -30,14 +30,23 @@
 .target-vector-items {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
+  max-height: 200px;
+  overflow-y: auto;
+  /* Thin scrollbar so it doesn't eat into the narrow panel */
+  scrollbar-width: thin;
 }
 
 .target-vector-item {
-  padding: 8px;
+  padding: 6px 8px;
   border: 1px solid var(--vscode-panel-border);
   border-radius: 2px;
   background-color: var(--vscode-dropdown-background);
+  /* single-line row: checkbox + name side by side */
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
 
 .target-vector-checkbox-label {
@@ -59,9 +68,9 @@
 
 .target-vector-metadata {
   display: flex;
-  gap: 8px;
-  margin-top: 4px;
-  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
 }
 
 .target-vector-vectorizer {

--- a/src/data-explorer/webview/components/VectorSearch/TargetVectorList.css
+++ b/src/data-explorer/webview/components/VectorSearch/TargetVectorList.css
@@ -1,0 +1,84 @@
+.target-vector-list {
+  margin-top: 8px;
+}
+
+.target-vector-controls {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.target-vector-action {
+  padding: 6px 12px;
+  font-size: 12px;
+  border: 1px solid var(--vscode-button-border);
+  background-color: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+.target-vector-action:hover:not(:disabled) {
+  background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
+.target-vector-action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.target-vector-items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.target-vector-item {
+  padding: 8px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 2px;
+  background-color: var(--vscode-dropdown-background);
+}
+
+.target-vector-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.target-vector-checkbox-label input {
+  cursor: pointer;
+}
+
+.target-vector-name {
+  font-weight: 500;
+  color: var(--vscode-editor-foreground);
+}
+
+.target-vector-metadata {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+.target-vector-vectorizer {
+  display: inline-block;
+  padding: 2px 6px;
+  background-color: var(--vscode-textCodeBlock-background);
+  color: var(--vscode-editor-foreground);
+  border-radius: 2px;
+  font-size: 11px;
+}
+
+.target-vector-muvera {
+  margin-left: 0;
+}
+
+.target-vector-list-empty {
+  color: var(--vscode-descriptionForeground);
+  font-size: 12px;
+  padding: 8px;
+}

--- a/src/data-explorer/webview/components/VectorSearch/TargetVectorList.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/TargetVectorList.tsx
@@ -1,0 +1,93 @@
+/**
+ * TargetVectorList - Checkbox list of available named vectors
+ * Allows user to select which vectors to target in multi-target search
+ */
+
+import React, { useCallback } from 'react';
+import type { CollectionConfig, NamedVectorInfo } from '../../../types';
+import { MuveraBadge } from './MuveraBadge';
+import './TargetVectorList.css';
+
+interface TargetVectorListProps {
+  availableVectors: NamedVectorInfo[];
+  selectedVectors: string[];
+  onSelectionChange: (vectors: string[]) => void;
+  disabled?: boolean;
+}
+
+export function TargetVectorList({
+  availableVectors,
+  selectedVectors,
+  onSelectionChange,
+  disabled = false,
+}: TargetVectorListProps) {
+  const handleCheckChange = useCallback(
+    (vectorName: string, checked: boolean) => {
+      if (checked) {
+        onSelectionChange([...selectedVectors, vectorName]);
+      } else {
+        onSelectionChange(selectedVectors.filter((v) => v !== vectorName));
+      }
+    },
+    [selectedVectors, onSelectionChange]
+  );
+
+  const handleSelectAll = useCallback(() => {
+    onSelectionChange(availableVectors.map((v) => v.name));
+  }, [availableVectors, onSelectionChange]);
+
+  const handleDeselectAll = useCallback(() => {
+    onSelectionChange([]);
+  }, [onSelectionChange]);
+
+  if (availableVectors.length === 0) {
+    return <div className="target-vector-list-empty">No named vectors available</div>;
+  }
+
+  return (
+    <div className="target-vector-list">
+      <div className="target-vector-controls">
+        <button
+          className="target-vector-action"
+          onClick={handleSelectAll}
+          disabled={disabled}
+          aria-label="Select all vectors"
+        >
+          Select All
+        </button>
+        <button
+          className="target-vector-action"
+          onClick={handleDeselectAll}
+          disabled={disabled}
+          aria-label="Deselect all vectors"
+        >
+          Deselect All
+        </button>
+      </div>
+
+      <div className="target-vector-items">
+        {availableVectors.map((vector) => (
+          <div key={vector.name} className="target-vector-item">
+            <label className="target-vector-checkbox-label">
+              <input
+                type="checkbox"
+                checked={selectedVectors.includes(vector.name)}
+                onChange={(e) => handleCheckChange(vector.name, e.target.checked)}
+                disabled={disabled}
+                aria-label={`Select ${vector.name} vector`}
+              />
+              <span className="target-vector-name">{vector.name}</span>
+            </label>
+
+            <div className="target-vector-metadata">
+              {vector.vectorizerName && (
+                <span className="target-vector-vectorizer">{vector.vectorizerName}</span>
+              )}
+              {vector.isMuvera && <MuveraBadge className="target-vector-muvera" />}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/data-explorer/webview/components/VectorSearch/VectorOptionsDrawer.css
+++ b/src/data-explorer/webview/components/VectorSearch/VectorOptionsDrawer.css
@@ -1,0 +1,78 @@
+.vector-options-drawer {
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 2px;
+  overflow: hidden;
+  margin: 12px 0;
+}
+
+.vector-options-header {
+  width: 100%;
+  padding: 12px;
+  background-color: var(--vscode-dropdown-background);
+  border: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--vscode-editor-foreground);
+  transition: background-color 0.2s;
+}
+
+.vector-options-header:hover:not(:disabled) {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.vector-options-header:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.vector-options-chevron {
+  display: inline-block;
+  font-size: 11px;
+  min-width: 16px;
+  text-align: center;
+}
+
+.vector-options-title {
+  flex: 1;
+}
+
+.vector-options-count {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  font-weight: normal;
+}
+
+.vector-options-content {
+  padding: 12px;
+  background-color: var(--vscode-editor-background);
+  border-top: 1px solid var(--vscode-panel-border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.vector-options-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.vector-options-section-title {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--vscode-editor-foreground);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.8;
+}
+
+.vector-options-divider {
+  height: 1px;
+  background-color: var(--vscode-panel-border);
+  margin: 0;
+}

--- a/src/data-explorer/webview/components/VectorSearch/VectorOptionsDrawer.css
+++ b/src/data-explorer/webview/components/VectorSearch/VectorOptionsDrawer.css
@@ -1,8 +1,8 @@
 .vector-options-drawer {
   border: 1px solid var(--vscode-panel-border);
   border-radius: 2px;
-  overflow: hidden;
-  margin: 12px 0;
+  /* do NOT set overflow: hidden — it clips the expanded vector list */
+  margin: 0 16px 12px;
 }
 
 .vector-options-header {
@@ -53,6 +53,8 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  /* Allow the drawer to grow; the outer body scrolls */
+  overflow: visible;
 }
 
 .vector-options-section {

--- a/src/data-explorer/webview/components/VectorSearch/VectorOptionsDrawer.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/VectorOptionsDrawer.tsx
@@ -1,0 +1,98 @@
+/**
+ * VectorOptionsDrawer - Main container for vector options (multi-target search)
+ * Collapsible drawer that appears only for multi-vector collections
+ */
+
+import React, { useCallback } from 'react';
+import type { CollectionConfig, JoinStrategy, NamedVectorInfo } from '../../../types';
+import { TargetVectorList } from './TargetVectorList';
+import { JoinStrategySelector } from './JoinStrategySelector';
+import './VectorOptionsDrawer.css';
+
+interface VectorOptionsDrawerProps {
+  availableVectors: NamedVectorInfo[];
+  expanded: boolean;
+  selectedVectors: string[];
+  joinStrategy: JoinStrategy;
+  vectorWeights: Record<string, number>;
+  onExpandedChange: (expanded: boolean) => void;
+  onSelectedVectorsChange: (vectors: string[]) => void;
+  onJoinStrategyChange: (strategy: JoinStrategy) => void;
+  onWeightChange: (vectorName: string, weight: number) => void;
+  onNormalize: () => void;
+  versionSupported: boolean;
+  disabled?: boolean;
+}
+
+export function VectorOptionsDrawer({
+  availableVectors,
+  expanded,
+  selectedVectors,
+  joinStrategy,
+  vectorWeights,
+  onExpandedChange,
+  onSelectedVectorsChange,
+  onJoinStrategyChange,
+  onWeightChange,
+  onNormalize,
+  versionSupported,
+  disabled = false,
+}: VectorOptionsDrawerProps) {
+  const handleToggle = useCallback(() => {
+    onExpandedChange(!expanded);
+  }, [expanded, onExpandedChange]);
+
+  // Only show drawer if there are multiple vectors
+  if (availableVectors.length < 2) {
+    return null;
+  }
+
+  return (
+    <div className="vector-options-drawer">
+      <button
+        className="vector-options-header"
+        onClick={handleToggle}
+        disabled={disabled}
+        aria-expanded={expanded}
+        aria-controls="vector-options-content"
+      >
+        <span className="vector-options-chevron">{expanded ? '▼' : '▸'}</span>
+        <span className="vector-options-title">Vector Options</span>
+        <span className="vector-options-count">({availableVectors.length} vectors)</span>
+      </button>
+
+      {expanded && (
+        <div id="vector-options-content" className="vector-options-content">
+          <div className="vector-options-section">
+            <h4 className="vector-options-section-title">Target Vectors</h4>
+            <TargetVectorList
+              availableVectors={availableVectors}
+              selectedVectors={selectedVectors}
+              onSelectionChange={onSelectedVectorsChange}
+              disabled={disabled}
+            />
+          </div>
+
+          {selectedVectors.length > 0 && (
+            <>
+              <div className="vector-options-divider"></div>
+              <div className="vector-options-section">
+                <h4 className="vector-options-section-title">Join Strategy</h4>
+                <JoinStrategySelector
+                  selectedVectors={selectedVectors}
+                  joinStrategy={joinStrategy}
+                  vectorWeights={vectorWeights}
+                  onStrategyChange={onJoinStrategyChange}
+                  onWeightChange={onWeightChange}
+                  onNormalize={onNormalize}
+                  versionSupported={versionSupported}
+                  disabled={disabled}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/data-explorer/webview/components/VectorSearch/VectorSearchPanel.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/VectorSearchPanel.tsx
@@ -67,7 +67,9 @@ export function VectorSearchPanel({
   // Check version support for multi-target features
   const versionSupported = useMemo(() => {
     const serverVersion = dataState.serverVersion;
-    if (!serverVersion) return false;
+    if (!serverVersion) {
+      return false;
+    }
 
     if (searchMode === 'hybrid') {
       return supportsMultiTargetHybrid(serverVersion);
@@ -286,6 +288,13 @@ export function VectorSearchPanel({
       return false;
     }
 
+    // If the server does not support multi-target, block searches with 2+ vectors.
+    // The UI already shows a version-gate warning; the Run button should also be
+    // disabled so users cannot submit a query they know will fail.
+    if (selectedTargetVectors.length > 1 && !versionSupported) {
+      return false;
+    }
+
     // If multi-target is active (2+ vectors), validate the join strategy config
     if (selectedTargetVectors.length > 1) {
       const validation = validateMultiTargetConfig(
@@ -302,6 +311,7 @@ export function VectorSearchPanel({
     searchParams,
     hasVectorizer,
     hasMultipleVectors,
+    versionSupported,
     isSearching,
     selectedTargetVectors,
     joinStrategy,

--- a/src/data-explorer/webview/components/VectorSearch/VectorSearchPanel.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/VectorSearchPanel.tsx
@@ -226,9 +226,15 @@ export function VectorSearchPanel({
     actions.normalizeWeights();
   }, [actions]);
 
-  // Update MUVERA flags when vectors change
+  // When a multi-vector collection loads, auto-select all vectors and update MUVERA flags.
+  // This prevents the "no target vectors were provided" error for first-time users who
+  // haven't interacted with the Target Vectors checkboxes yet.
   useEffect(() => {
-    if (hasMultipleVectors) {
+    if (hasMultipleVectors && namedVectors.length > 0) {
+      // Auto-select all vectors (user can deselect individually)
+      actions.setSelectedTargetVectors(namedVectors.map((v) => v.name));
+
+      // Update MUVERA flags
       const flags: Record<string, boolean> = {};
       namedVectors.forEach((vector) => {
         flags[vector.name] = vector.isMuvera;
@@ -275,8 +281,13 @@ export function VectorSearchPanel({
       return false;
     }
 
-    // If multi-target is active, validate it
-    if (selectedTargetVectors.length > 0) {
+    // Multi-vector collections MUST have at least one target vector selected
+    if (hasMultipleVectors && selectedTargetVectors.length === 0) {
+      return false;
+    }
+
+    // If multi-target is active (2+ vectors), validate the join strategy config
+    if (selectedTargetVectors.length > 1) {
       const validation = validateMultiTargetConfig(
         selectedTargetVectors,
         joinStrategy,
@@ -290,6 +301,7 @@ export function VectorSearchPanel({
     searchMode,
     searchParams,
     hasVectorizer,
+    hasMultipleVectors,
     isSearching,
     selectedTargetVectors,
     joinStrategy,
@@ -483,7 +495,12 @@ export function VectorSearchPanel({
               {/* Max Distance */}
               <div className="parameter-item">
                 <label htmlFor="max-distance">
-                  Max Distance: <strong>{searchParams.maxDistance.toFixed(2)}</strong>
+                  Max Distance:{' '}
+                  <strong>
+                    {searchParams.maxDistance >= 1.0
+                      ? `${searchParams.maxDistance.toFixed(2)} (no filter)`
+                      : searchParams.maxDistance.toFixed(2)}
+                  </strong>
                 </label>
                 <input
                   id="max-distance"
@@ -497,6 +514,7 @@ export function VectorSearchPanel({
                 />
                 <div className="range-labels">
                   <span>0 (exact)</span>
+                  <span>1.0 (no filter)</span>
                   <span>2 (distant)</span>
                 </div>
               </div>
@@ -541,34 +559,36 @@ export function VectorSearchPanel({
               )}
             </button>
 
-            {searchResults.length > 0 && (
-              <button
-                type="button"
-                className="clear-results-btn secondary"
-                onClick={() => actions.clearSearch()}
-                disabled={isSearching}
-              >
-                Clear Results
-              </button>
-            )}
+            <div className="search-action-secondary">
+              {searchResults.length > 0 && (
+                <button
+                  type="button"
+                  className="clear-results-btn secondary"
+                  onClick={() => actions.clearSearch()}
+                  disabled={isSearching}
+                >
+                  Clear Results
+                </button>
+              )}
 
-            <CopyAsCode
-              collectionName={schema?.name || ''}
-              searchMode={searchMode}
-              searchParams={searchParams}
-              targetVector={
-                selectedTargetVectors.length > 1
-                  ? {
-                      combination: joinStrategy,
-                      targetVectors: selectedTargetVectors,
-                      weights: Object.keys(vectorWeights).length > 0 ? vectorWeights : undefined,
-                    }
-                  : selectedTargetVectors.length === 1
-                    ? selectedTargetVectors[0]
-                    : undefined
-              }
-              disabled={isSearching}
-            />
+              <CopyAsCode
+                collectionName={schema?.name || ''}
+                searchMode={searchMode}
+                searchParams={searchParams}
+                targetVector={
+                  selectedTargetVectors.length > 1
+                    ? {
+                        combination: joinStrategy,
+                        targetVectors: selectedTargetVectors,
+                        weights: Object.keys(vectorWeights).length > 0 ? vectorWeights : undefined,
+                      }
+                    : selectedTargetVectors.length === 1
+                      ? selectedTargetVectors[0]
+                      : undefined
+                }
+                disabled={isSearching}
+              />
+            </div>
           </div>
 
           {/* Search Results */}

--- a/src/data-explorer/webview/components/VectorSearch/VectorSearchPanel.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/VectorSearchPanel.tsx
@@ -4,19 +4,30 @@
  */
 
 import React, { useCallback, useEffect, useMemo } from 'react';
-import type { CollectionConfig, WeaviateObject, PropertyConfig } from '../../../types';
+import type {
+  CollectionConfig,
+  WeaviateObject,
+  PropertyConfig,
+  JoinStrategy,
+} from '../../../types';
 import {
   useVectorSearchState,
   useVectorSearchActions,
   type VectorSearchMode,
   type DistanceMetric,
 } from '../../context';
+import { useDataState } from '../../context/DataContext';
 import { SearchModeSelector } from './SearchModeSelector';
 import { TextSearchInput } from './TextSearchInput';
 import { ObjectSearchInput } from './ObjectSearchInput';
 import { VectorInput } from './VectorInput';
 import { HybridSearchInput } from './HybridSearchInput';
 import { SearchResults } from './SearchResults';
+import { VectorOptionsDrawer } from './VectorOptionsDrawer';
+import { CopyAsCode } from './CopyAsCode';
+import { useNamedVectors } from '../../hooks/useNamedVectors';
+import { supportsMultiTargetNear, supportsMultiTargetHybrid } from '../../utils/versionCheck';
+import { validateMultiTargetConfig } from '../../utils/multiTargetBuilder';
 
 interface VectorSearchPanelProps {
   isOpen: boolean;
@@ -35,8 +46,35 @@ export function VectorSearchPanel({
 }: VectorSearchPanelProps) {
   const state = useVectorSearchState();
   const actions = useVectorSearchActions();
+  const dataState = useDataState();
 
-  const { searchMode, searchParams, searchResults, isSearching, searchError, hasSearched } = state;
+  const {
+    searchMode,
+    searchParams,
+    searchResults,
+    isSearching,
+    searchError,
+    hasSearched,
+    vectorOptionsExpanded,
+    selectedTargetVectors,
+    joinStrategy,
+    vectorWeights,
+  } = state;
+
+  // Get named vectors from schema
+  const { namedVectors, hasMultipleVectors } = useNamedVectors(schema);
+
+  // Check version support for multi-target features
+  const versionSupported = useMemo(() => {
+    const serverVersion = dataState.serverVersion;
+    if (!serverVersion) return false;
+
+    if (searchMode === 'hybrid') {
+      return supportsMultiTargetHybrid(serverVersion);
+    }
+    // For text, object, vector modes
+    return supportsMultiTargetNear(serverVersion);
+  }, [dataState.serverVersion, searchMode]);
 
   // Handle keyboard escape to close panel (only add listener when open)
   useEffect(() => {
@@ -152,33 +190,111 @@ export function VectorSearchPanel({
     actions.setSearchParams({ objectId: '' });
   }, [actions]);
 
+  // Multi-target vector search handlers
+  const handleToggleVectorOptions = useCallback(() => {
+    actions.toggleVectorOptions();
+  }, [actions]);
+
+  const handleSelectedVectorsChange = useCallback(
+    (vectors: string[]) => {
+      actions.setSelectedTargetVectors(vectors);
+      // Initialize weights for new vectors
+      vectors.forEach((vector) => {
+        if (!(vector in vectorWeights)) {
+          actions.setVectorWeight(vector, 0.5);
+        }
+      });
+    },
+    [actions, vectorWeights]
+  );
+
+  const handleJoinStrategyChange = useCallback(
+    (strategy: JoinStrategy) => {
+      actions.setJoinStrategy(strategy);
+    },
+    [actions]
+  );
+
+  const handleVectorWeightChange = useCallback(
+    (vectorName: string, weight: number) => {
+      actions.setVectorWeight(vectorName, weight);
+    },
+    [actions]
+  );
+
+  const handleNormalizeWeights = useCallback(() => {
+    actions.normalizeWeights();
+  }, [actions]);
+
+  // Update MUVERA flags when vectors change
+  useEffect(() => {
+    if (hasMultipleVectors) {
+      const flags: Record<string, boolean> = {};
+      namedVectors.forEach((vector) => {
+        flags[vector.name] = vector.isMuvera;
+      });
+      actions.setMuveraFlags(flags);
+    }
+  }, [namedVectors, hasMultipleVectors, actions]);
+
   // Validate search can be performed
   const canSearch = useMemo(() => {
     if (isSearching) {
       return false;
     }
 
+    // First check mode-specific validation
+    let modeValid = false;
     switch (searchMode) {
       case 'text':
-        return hasVectorizer && searchParams.query.trim().length > 0;
+        modeValid = hasVectorizer && searchParams.query.trim().length > 0;
+        break;
       case 'object':
-        return searchParams.objectId.trim().length > 0;
+        modeValid = searchParams.objectId.trim().length > 0;
+        break;
       case 'vector':
         try {
           const parsed = JSON.parse(searchParams.vector);
-          return (
-            Array.isArray(parsed) && parsed.length > 0 && parsed.every((n) => typeof n === 'number')
-          );
+          modeValid =
+            Array.isArray(parsed) &&
+            parsed.length > 0 &&
+            parsed.every((n) => typeof n === 'number');
         } catch {
-          return false;
+          modeValid = false;
         }
+        break;
       case 'hybrid':
         // Hybrid search requires vectorizer and a query
-        return hasVectorizer && searchParams.query.trim().length > 0;
+        modeValid = hasVectorizer && searchParams.query.trim().length > 0;
+        break;
       default:
-        return false;
+        modeValid = false;
     }
-  }, [searchMode, searchParams, hasVectorizer, isSearching]);
+
+    if (!modeValid) {
+      return false;
+    }
+
+    // If multi-target is active, validate it
+    if (selectedTargetVectors.length > 0) {
+      const validation = validateMultiTargetConfig(
+        selectedTargetVectors,
+        joinStrategy,
+        vectorWeights
+      );
+      return validation.valid;
+    }
+
+    return true;
+  }, [
+    searchMode,
+    searchParams,
+    hasVectorizer,
+    isSearching,
+    selectedTargetVectors,
+    joinStrategy,
+    vectorWeights,
+  ]);
 
   // Distance metric options
   const distanceMetrics: { value: DistanceMetric; label: string }[] = [
@@ -321,6 +437,24 @@ export function VectorSearchPanel({
             )}
           </div>
 
+          {/* Multi-target Vector Options */}
+          {hasMultipleVectors && (
+            <VectorOptionsDrawer
+              availableVectors={namedVectors}
+              expanded={vectorOptionsExpanded}
+              selectedVectors={selectedTargetVectors}
+              joinStrategy={joinStrategy}
+              vectorWeights={vectorWeights}
+              onExpandedChange={handleToggleVectorOptions}
+              onSelectedVectorsChange={handleSelectedVectorsChange}
+              onJoinStrategyChange={handleJoinStrategyChange}
+              onWeightChange={handleVectorWeightChange}
+              onNormalize={handleNormalizeWeights}
+              versionSupported={versionSupported}
+              disabled={isSearching}
+            />
+          )}
+
           {/* Search Parameters */}
           <div className="search-parameters">
             <h3 className="parameters-title">
@@ -386,7 +520,7 @@ export function VectorSearchPanel({
             </div>
           </div>
 
-          {/* Search Button */}
+          {/* Search Button and Actions */}
           <div className="search-action">
             <button
               type="button"
@@ -417,6 +551,24 @@ export function VectorSearchPanel({
                 Clear Results
               </button>
             )}
+
+            <CopyAsCode
+              collectionName={schema?.name || ''}
+              searchMode={searchMode}
+              searchParams={searchParams}
+              targetVector={
+                selectedTargetVectors.length > 1
+                  ? {
+                      combination: joinStrategy,
+                      targetVectors: selectedTargetVectors,
+                      weights: Object.keys(vectorWeights).length > 0 ? vectorWeights : undefined,
+                    }
+                  : selectedTargetVectors.length === 1
+                    ? selectedTargetVectors[0]
+                    : undefined
+              }
+              disabled={isSearching}
+            />
           </div>
 
           {/* Search Results */}

--- a/src/data-explorer/webview/components/VectorSearch/WeightEditor.css
+++ b/src/data-explorer/webview/components/VectorSearch/WeightEditor.css
@@ -1,0 +1,99 @@
+.weight-editor {
+  margin-top: 12px;
+  padding: 12px;
+  background-color: var(--vscode-editor-background);
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 2px;
+}
+
+.weight-editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.weight-editor-header h4 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--vscode-editor-foreground);
+}
+
+.weight-editor-normalize-btn {
+  padding: 4px 8px;
+  font-size: 11px;
+  border: 1px solid var(--vscode-button-border);
+  background-color: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+.weight-editor-normalize-btn:hover:not(:disabled) {
+  background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
+.weight-editor-normalize-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.weight-editor-items {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.weight-editor-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.weight-editor-item.invalid {
+  border-left: 2px solid var(--vscode-errorForeground);
+  padding-left: 8px;
+}
+
+.weight-editor-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--vscode-editor-foreground);
+}
+
+.weight-editor-controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.weight-editor-slider {
+  flex: 1;
+  min-width: 100px;
+}
+
+.weight-editor-input {
+  width: 60px;
+  padding: 4px;
+  font-size: 12px;
+  border: 1px solid var(--vscode-input-border);
+  background-color: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border-radius: 2px;
+}
+
+.weight-editor-warning {
+  font-size: 11px;
+  color: var(--vscode-errorForeground);
+}
+
+.weight-editor-stats {
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  border-top: 1px solid var(--vscode-panel-border);
+  padding-top: 8px;
+}

--- a/src/data-explorer/webview/components/VectorSearch/WeightEditor.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/WeightEditor.tsx
@@ -1,0 +1,114 @@
+/**
+ * WeightEditor - Edit weights for manual-weights and relative-score join strategies
+ * Provides sliders and numeric inputs for weight adjustment with normalize action
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import './WeightEditor.css';
+
+interface WeightEditorProps {
+  selectedVectors: string[];
+  weights: Record<string, number>;
+  onWeightChange: (vectorName: string, weight: number) => void;
+  onNormalize: () => void;
+  disabled?: boolean;
+}
+
+export function WeightEditor({
+  selectedVectors,
+  weights,
+  onWeightChange,
+  onNormalize,
+  disabled = false,
+}: WeightEditorProps) {
+  const totalWeight = useMemo(() => {
+    return Object.values(weights).reduce((sum, w) => sum + w, 0);
+  }, [weights]);
+
+  const handleSliderChange = useCallback(
+    (vectorName: string, value: number) => {
+      onWeightChange(vectorName, parseFloat(value.toFixed(2)));
+    },
+    [onWeightChange]
+  );
+
+  const handleInputChange = useCallback(
+    (vectorName: string, valueStr: string) => {
+      const value = parseFloat(valueStr);
+      if (!isNaN(value)) {
+        onWeightChange(vectorName, Math.max(0, Math.min(1, value)));
+      }
+    },
+    [onWeightChange]
+  );
+
+  const getVectorWeight = (vectorName: string): number => {
+    return weights[vectorName] ?? 0.5;
+  };
+
+  const isValidWeight = (weight: number) => weight > 0;
+
+  return (
+    <div className="weight-editor">
+      <div className="weight-editor-header">
+        <h4>Vector Weights</h4>
+        <button
+          className="weight-editor-normalize-btn"
+          onClick={onNormalize}
+          disabled={disabled || totalWeight === 0}
+          title="Normalize all weights to sum to 1.0"
+        >
+          Normalize
+        </button>
+      </div>
+
+      <div className="weight-editor-items">
+        {selectedVectors.map((vectorName) => {
+          const weight = getVectorWeight(vectorName);
+          const isValid = isValidWeight(weight);
+
+          return (
+            <div key={vectorName} className={`weight-editor-item ${!isValid ? 'invalid' : ''}`}>
+              <label className="weight-editor-label">{vectorName}</label>
+
+              <div className="weight-editor-controls">
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  value={weight}
+                  onChange={(e) => handleSliderChange(vectorName, parseFloat(e.target.value))}
+                  disabled={disabled}
+                  className="weight-editor-slider"
+                  aria-label={`Weight for ${vectorName}`}
+                />
+
+                <input
+                  type="number"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  value={weight.toFixed(2)}
+                  onChange={(e) => handleInputChange(vectorName, e.target.value)}
+                  disabled={disabled}
+                  className="weight-editor-input"
+                  aria-label={`Numeric weight input for ${vectorName}`}
+                />
+              </div>
+
+              {!isValid && <span className="weight-editor-warning">Weight must be &gt; 0</span>}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="weight-editor-stats">
+        <span>Total weight: {totalWeight.toFixed(2)}</span>
+        {totalWeight > 0 && selectedVectors.length > 0 && (
+          <span>Average: {(totalWeight / selectedVectors.length).toFixed(2)}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/data-explorer/webview/components/VectorSearch/index.ts
+++ b/src/data-explorer/webview/components/VectorSearch/index.ts
@@ -17,3 +17,11 @@ export { HybridSearchInput } from './HybridSearchInput';
 export { AlphaSlider } from './AlphaSlider';
 export { PropertySelector } from './PropertySelector';
 export { ScoreBreakdown } from './ScoreBreakdown';
+
+// Multi-target Vector Search Components
+export { VectorOptionsDrawer } from './VectorOptionsDrawer';
+export { TargetVectorList } from './TargetVectorList';
+export { JoinStrategySelector } from './JoinStrategySelector';
+export { WeightEditor } from './WeightEditor';
+export { MuveraBadge } from './MuveraBadge';
+export { CopyAsCode } from './CopyAsCode';

--- a/src/data-explorer/webview/context/DataContext.tsx
+++ b/src/data-explorer/webview/context/DataContext.tsx
@@ -24,6 +24,8 @@ export interface DataContextState {
   availableTenants: TenantInfo[];
   selectedTenant: string | null;
   isMultiTenant: boolean;
+  // Server metadata
+  serverVersion: string | null;
   // Data
   objects: WeaviateObject[];
   totalCount: number;
@@ -46,6 +48,7 @@ type DataAction =
   | { type: 'CLEAR_ERROR' }
   | { type: 'REFRESH' }
   | { type: 'SET_FETCHED_OBJECT_DETAIL'; object: WeaviateObject | null }
+  | { type: 'SET_SERVER_VERSION'; version: string | null }
   // Multi-tenancy actions
   | { type: 'SET_TENANTS'; tenants: TenantInfo[]; isMultiTenant: boolean }
   | { type: 'SET_SELECTED_TENANT'; tenant: string | null };
@@ -60,6 +63,7 @@ const initialState: DataContextState = {
   availableTenants: [],
   selectedTenant: null,
   isMultiTenant: false,
+  serverVersion: null,
   objects: [],
   totalCount: 0,
   unfilteredTotalCount: 0,
@@ -147,6 +151,12 @@ function dataReducer(state: DataContextState, action: DataAction): DataContextSt
         fetchedObjectDetail: null,
       };
 
+    case 'SET_SERVER_VERSION':
+      return {
+        ...state,
+        serverVersion: action.version,
+      };
+
     default:
       return state;
   }
@@ -165,6 +175,7 @@ export interface DataContextActions {
   clearError: () => void;
   refresh: () => void;
   setFetchedObjectDetail: (object: WeaviateObject | null) => void;
+  setServerVersion: (version: string | null) => void;
   // Multi-tenancy actions
   setTenants: (tenants: TenantInfo[], isMultiTenant: boolean) => void;
   setSelectedTenant: (tenant: string | null) => void;
@@ -229,6 +240,10 @@ export function DataProvider({ children, initialCollectionName = '' }: DataProvi
 
       setFetchedObjectDetail: (object: WeaviateObject | null) => {
         dispatch({ type: 'SET_FETCHED_OBJECT_DETAIL', object });
+      },
+
+      setServerVersion: (version: string | null) => {
+        dispatch({ type: 'SET_SERVER_VERSION', version });
       },
 
       setTenants: (tenants: TenantInfo[], isMultiTenant: boolean) => {

--- a/src/data-explorer/webview/context/VectorSearchContext.tsx
+++ b/src/data-explorer/webview/context/VectorSearchContext.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { createContext, useContext, useReducer, useMemo, useCallback } from 'react';
-import type { WeaviateObject } from '../../types';
+import type { WeaviateObject, JoinStrategy } from '../../types';
 
 // ============================================================================
 // Types
@@ -45,6 +45,8 @@ export interface VectorSearchParameters {
   maxDistance: number;
   limit: number;
   targetVector?: string; // For named vectors
+  certainty?: number; // Minimum certainty threshold (0-1)
+  distance?: number; // Maximum distance threshold
   // Hybrid search parameters
   hybridAlpha: number; // 0 = pure keyword (BM25), 1 = pure vector
   fusionType: FusionType;
@@ -67,6 +69,13 @@ export interface VectorSearchContextState {
   preSelectedObjectId: string | null;
   // Track if a search has been performed (for empty state messaging)
   hasSearched: boolean;
+  // Multi-target vector search state
+  vectorOptionsExpanded: boolean;
+  selectedTargetVectors: string[];
+  joinStrategy: JoinStrategy;
+  vectorWeights: Record<string, number>;
+  multiTargetActive: boolean;
+  muveraFlagsByVector: Record<string, boolean>;
 }
 
 // ============================================================================
@@ -84,7 +93,14 @@ type VectorSearchAction =
   | { type: 'SET_SEARCH_ERROR'; error: string | null }
   | { type: 'CLEAR_SEARCH' }
   | { type: 'FIND_SIMILAR'; objectId: string }
-  | { type: 'RESET_FOR_COLLECTION_CHANGE' };
+  | { type: 'RESET_FOR_COLLECTION_CHANGE' }
+  // Multi-target vector search actions
+  | { type: 'TOGGLE_VECTOR_OPTIONS' }
+  | { type: 'SET_SELECTED_TARGET_VECTORS'; vectors: string[] }
+  | { type: 'SET_JOIN_STRATEGY'; strategy: JoinStrategy }
+  | { type: 'SET_VECTOR_WEIGHT'; vectorName: string; weight: number }
+  | { type: 'NORMALIZE_WEIGHTS' }
+  | { type: 'SET_MUVERA_FLAGS'; flags: Record<string, boolean> };
 
 // ============================================================================
 // Initial State
@@ -114,6 +130,13 @@ const initialState: VectorSearchContextState = {
   searchError: null,
   preSelectedObjectId: null,
   hasSearched: false,
+  // Multi-target vector search state
+  vectorOptionsExpanded: false,
+  selectedTargetVectors: [],
+  joinStrategy: 'minimum',
+  vectorWeights: {},
+  multiTargetActive: false,
+  muveraFlagsByVector: {},
 };
 
 // ============================================================================
@@ -231,6 +254,54 @@ function vectorSearchReducer(
         showVectorSearchPanel: state.showVectorSearchPanel,
       };
 
+    case 'TOGGLE_VECTOR_OPTIONS':
+      return {
+        ...state,
+        vectorOptionsExpanded: !state.vectorOptionsExpanded,
+      };
+
+    case 'SET_SELECTED_TARGET_VECTORS':
+      return {
+        ...state,
+        selectedTargetVectors: action.vectors,
+        multiTargetActive: action.vectors.length > 1,
+      };
+
+    case 'SET_JOIN_STRATEGY':
+      return {
+        ...state,
+        joinStrategy: action.strategy,
+      };
+
+    case 'SET_VECTOR_WEIGHT': {
+      const newWeights = { ...state.vectorWeights, [action.vectorName]: action.weight };
+      return {
+        ...state,
+        vectorWeights: newWeights,
+      };
+    }
+
+    case 'NORMALIZE_WEIGHTS': {
+      const totalWeight = Object.values(state.vectorWeights).reduce((a, b) => a + b, 0);
+      if (totalWeight <= 0) {
+        return state;
+      }
+      const normalizedWeights: Record<string, number> = {};
+      Object.entries(state.vectorWeights).forEach(([vector, weight]) => {
+        normalizedWeights[vector] = weight / totalWeight;
+      });
+      return {
+        ...state,
+        vectorWeights: normalizedWeights,
+      };
+    }
+
+    case 'SET_MUVERA_FLAGS':
+      return {
+        ...state,
+        muveraFlagsByVector: action.flags,
+      };
+
     default:
       return state;
   }
@@ -252,6 +323,13 @@ export interface VectorSearchContextActions {
   clearSearch: () => void;
   findSimilar: (objectId: string) => void;
   resetForCollectionChange: () => void;
+  // Multi-target vector search actions
+  toggleVectorOptions: () => void;
+  setSelectedTargetVectors: (vectors: string[]) => void;
+  setJoinStrategy: (strategy: JoinStrategy) => void;
+  setVectorWeight: (vectorName: string, weight: number) => void;
+  normalizeWeights: () => void;
+  setMuveraFlags: (flags: Record<string, boolean>) => void;
 }
 
 // ============================================================================
@@ -321,6 +399,31 @@ export function VectorSearchProvider({ children }: VectorSearchProviderProps) {
 
       resetForCollectionChange: () => {
         dispatch({ type: 'RESET_FOR_COLLECTION_CHANGE' });
+      },
+
+      // Multi-target vector search actions
+      toggleVectorOptions: () => {
+        dispatch({ type: 'TOGGLE_VECTOR_OPTIONS' });
+      },
+
+      setSelectedTargetVectors: (vectors: string[]) => {
+        dispatch({ type: 'SET_SELECTED_TARGET_VECTORS', vectors });
+      },
+
+      setJoinStrategy: (strategy: JoinStrategy) => {
+        dispatch({ type: 'SET_JOIN_STRATEGY', strategy });
+      },
+
+      setVectorWeight: (vectorName: string, weight: number) => {
+        dispatch({ type: 'SET_VECTOR_WEIGHT', vectorName, weight });
+      },
+
+      normalizeWeights: () => {
+        dispatch({ type: 'NORMALIZE_WEIGHTS' });
+      },
+
+      setMuveraFlags: (flags: Record<string, boolean>) => {
+        dispatch({ type: 'SET_MUVERA_FLAGS', flags });
       },
     }),
     []

--- a/src/data-explorer/webview/context/VectorSearchContext.tsx
+++ b/src/data-explorer/webview/context/VectorSearchContext.tsx
@@ -112,7 +112,9 @@ const initialSearchParams: VectorSearchParameters = {
   objectId: '',
   vector: '',
   distanceMetric: 'cosine',
-  maxDistance: 0.5,
+  maxDistance: 1.0, // Permissive default: allows results up to cosine distance 1.0 (orthogonal).
+  // At 0.5 many valid results were silently dropped. Users can tighten the
+  // slider; the query omits the distance filter entirely when at default (1.0).
   limit: 25,
   // Hybrid search parameters
   hybridAlpha: 0.5, // Balanced by default

--- a/src/data-explorer/webview/context/__tests__/VectorSearchContext.test.tsx
+++ b/src/data-explorer/webview/context/__tests__/VectorSearchContext.test.tsx
@@ -812,7 +812,7 @@ describe('VectorSearchContext', () => {
         objectId: '',
         vector: '',
         distanceMetric: 'cosine',
-        maxDistance: 0.5,
+        maxDistance: 1.0,
         limit: 25,
         hybridAlpha: 0.5,
         fusionType: 'rankedFusion',

--- a/src/data-explorer/webview/hooks/useDataFetch.ts
+++ b/src/data-explorer/webview/hooks/useDataFetch.ts
@@ -83,6 +83,11 @@ export function useDataFetch() {
               dataActions.setCollection(message.collectionName);
               dataActions.setSchema(message.schema);
 
+              // Set server version for feature gating
+              if (message.serverVersion) {
+                dataActions.setServerVersion(message.serverVersion);
+              }
+
               // Check if multi-tenant
               const isMultiTenant =
                 message.isMultiTenant || !!(message.schema.multiTenancy as any)?.enabled;

--- a/src/data-explorer/webview/hooks/useNamedVectors.ts
+++ b/src/data-explorer/webview/hooks/useNamedVectors.ts
@@ -1,0 +1,86 @@
+/**
+ * Hook to extract named vector information from collection schema
+ * Detects MUVERA encoding, multi-vector flags, vectorizer names, etc.
+ */
+
+import { useMemo } from 'react';
+import type { CollectionConfig, NamedVectorInfo } from '../../types';
+
+interface UseNamedVectorsResult {
+  namedVectors: NamedVectorInfo[];
+  hasMultipleVectors: boolean;
+  vectorCount: number;
+}
+
+/**
+ * Extract and analyze named vector information from collection schema
+ * @param schema - Collection configuration from Weaviate
+ * @returns Object with named vectors list and utility flags
+ */
+export function useNamedVectors(schema: CollectionConfig | null): UseNamedVectorsResult {
+  return useMemo(() => {
+    if (!schema || !schema.vectorizerConfig) {
+      return {
+        namedVectors: [],
+        hasMultipleVectors: false,
+        vectorCount: 0,
+      };
+    }
+
+    const vectorizerConfig = schema.vectorizerConfig as Record<string, any>;
+    const namedVectors: NamedVectorInfo[] = [];
+
+    // Iterate through each named vector in the config
+    Object.entries(vectorizerConfig).forEach(([vectorName, vectorConfig]) => {
+      if (!vectorConfig || typeof vectorConfig !== 'object') {
+        return;
+      }
+
+      const config = vectorConfig as Record<string, any>;
+
+      // Extract vectorizer name/module.
+      // The weaviate-client returns vectorizer as a ModuleConfig object { name, config },
+      // not a plain string, so we must extract the .name property.
+      const vectorizerRaw = config.vectorizer;
+      const vectorizerName =
+        vectorizerRaw && typeof vectorizerRaw === 'object' && 'name' in vectorizerRaw
+          ? String((vectorizerRaw as { name: unknown }).name)
+          : typeof vectorizerRaw === 'string'
+            ? vectorizerRaw
+            : 'unknown';
+
+      // Extract index configuration
+      const indexType = config.indexType || 'unknown';
+      const indexConfig = config.indexConfig || {};
+
+      // Detect MUVERA encoding
+      // MUVERA is indicated by multiVector.encoding.type === 'muvera'
+      const multiVectorConfig = indexConfig.multiVector;
+      const isMuvera =
+        multiVectorConfig?.encoding?.type === 'muvera' || multiVectorConfig?.type === 'muvera';
+
+      // Detect if this is a multi-vector configuration
+      const isMultiVector = multiVectorConfig !== undefined;
+
+      // Extract properties if available
+      const properties = config.properties as string[] | undefined;
+
+      namedVectors.push({
+        name: vectorName,
+        vectorizerName,
+        vectorizerConfig: config,
+        indexType,
+        indexConfig,
+        isMuvera,
+        isMultiVector,
+        properties,
+      });
+    });
+
+    return {
+      namedVectors,
+      hasMultipleVectors: namedVectors.length > 1,
+      vectorCount: namedVectors.length,
+    };
+  }, [schema]);
+}

--- a/src/data-explorer/webview/hooks/useVectorSearch.ts
+++ b/src/data-explorer/webview/hooks/useVectorSearch.ts
@@ -179,7 +179,37 @@ export function useVectorSearch() {
 
   // Execute vector search based on current mode and params
   const executeSearch = useCallback(() => {
-    const { searchMode, searchParams } = searchState;
+    const { searchMode, searchParams, selectedTargetVectors, joinStrategy, vectorWeights } =
+      searchState;
+
+    // Build the targetVector field:
+    // - 0 selected  → undefined (let the server pick or error gracefully)
+    // - 1 selected  → plain string (single-target)
+    // - 2+ selected → multi-target object { combination, targetVectors, weights? }
+    let resolvedTargetVector:
+      | string
+      | { combination: string; targetVectors: string[]; weights?: Record<string, number> }
+      | undefined;
+
+    if (selectedTargetVectors.length === 1) {
+      resolvedTargetVector = selectedTargetVectors[0];
+    } else if (selectedTargetVectors.length > 1) {
+      resolvedTargetVector = {
+        combination: joinStrategy,
+        targetVectors: selectedTargetVectors,
+        weights: Object.keys(vectorWeights).length > 0 ? vectorWeights : undefined,
+      };
+    } else {
+      // No vectors selected — fall back to legacy single searchParams.targetVector
+      resolvedTargetVector = searchParams.targetVector || undefined;
+    }
+
+    // Only apply a distance filter when the user has explicitly tightened the
+    // slider below the default (1.0). At the default we omit the field entirely
+    // so Weaviate returns pure top-N results with no distance ceiling.
+    const DEFAULT_MAX_DISTANCE = 1.0;
+    const effectiveDistance =
+      searchParams.maxDistance < DEFAULT_MAX_DISTANCE ? searchParams.maxDistance : undefined;
 
     // Validate input based on mode
     let isValid = false;
@@ -191,7 +221,7 @@ export function useVectorSearch() {
       distance?: number;
       limit?: number;
       distanceMetric?: string;
-      targetVector?: string;
+      targetVector?: typeof resolvedTargetVector;
       // Hybrid-specific params
       alpha?: number;
       fusionType?: string;
@@ -205,10 +235,10 @@ export function useVectorSearch() {
           vectorSearchPayload = {
             type: 'nearText',
             text: searchParams.query.trim(),
-            distance: searchParams.maxDistance,
+            distance: effectiveDistance,
             limit: searchParams.limit,
             distanceMetric: searchParams.distanceMetric,
-            targetVector: searchParams.targetVector,
+            targetVector: resolvedTargetVector,
           };
         }
         break;
@@ -220,10 +250,10 @@ export function useVectorSearch() {
           vectorSearchPayload = {
             type: 'nearObject',
             objectId: searchParams.objectId.trim(),
-            distance: searchParams.maxDistance,
+            distance: effectiveDistance,
             limit: searchParams.limit,
             distanceMetric: searchParams.distanceMetric,
-            targetVector: searchParams.targetVector,
+            targetVector: resolvedTargetVector,
           };
         }
         break;
@@ -236,10 +266,10 @@ export function useVectorSearch() {
             vectorSearchPayload = {
               type: 'nearVector',
               vector: parsed,
-              distance: searchParams.maxDistance,
+              distance: effectiveDistance,
               limit: searchParams.limit,
               distanceMetric: searchParams.distanceMetric,
-              targetVector: searchParams.targetVector,
+              targetVector: resolvedTargetVector,
             };
           } else {
             searchActions.setSearchError(
@@ -267,7 +297,7 @@ export function useVectorSearch() {
             properties:
               searchParams.searchProperties.length > 0 ? searchParams.searchProperties : undefined, // undefined means all text properties
             limit: searchParams.limit,
-            targetVector: searchParams.targetVector,
+            targetVector: resolvedTargetVector,
           };
         }
         break;

--- a/src/data-explorer/webview/hooks/useVectorSearch.ts
+++ b/src/data-explorer/webview/hooks/useVectorSearch.ts
@@ -194,10 +194,21 @@ export function useVectorSearch() {
     if (selectedTargetVectors.length === 1) {
       resolvedTargetVector = selectedTargetVectors[0];
     } else if (selectedTargetVectors.length > 1) {
+      // Filter weights to only the currently selected vectors.
+      // Stale weights from previously-deselected vectors must not reach the API —
+      // in manual-weights / relative-score strategies, Weaviate derives participating
+      // target vectors from weight keys, so stale keys silently include deselected vectors.
+      const selectedWeights: Record<string, number> = {};
+      selectedTargetVectors.forEach((vec) => {
+        if (vectorWeights[vec] !== undefined) {
+          selectedWeights[vec] = vectorWeights[vec];
+        }
+      });
+
       resolvedTargetVector = {
         combination: joinStrategy,
         targetVectors: selectedTargetVectors,
-        weights: Object.keys(vectorWeights).length > 0 ? vectorWeights : undefined,
+        weights: Object.keys(selectedWeights).length > 0 ? selectedWeights : undefined,
       };
     } else {
       // No vectors selected — fall back to legacy single searchParams.targetVector

--- a/src/data-explorer/webview/styles.css
+++ b/src/data-explorer/webview/styles.css
@@ -2430,6 +2430,13 @@ input[type="checkbox"]:focus-visible {
     border-bottom: 1px solid var(--vscode-panel-border, #333);
 }
 
+/* Row that holds secondary buttons (Clear + Copy as Code) */
+.search-action-secondary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 .search-btn {
     display: flex;
     align-items: center;

--- a/src/data-explorer/webview/utils/codeGenerator.ts
+++ b/src/data-explorer/webview/utils/codeGenerator.ts
@@ -1,0 +1,217 @@
+/**
+ * Code generation utilities for multi-target vector search
+ * Generates TypeScript and Python SDK code snippets
+ */
+
+import type { MultiTargetPayload } from '../../types';
+import type { VectorSearchParameters } from '../context';
+
+/**
+ * Generate TypeScript code snippet for current search configuration
+ */
+export function generateTypeScriptSnippet(params: {
+  collectionName: string;
+  searchMode: string;
+  searchParams: VectorSearchParameters;
+  targetVector?: string | MultiTargetPayload;
+}): string {
+  const { collectionName, searchMode, searchParams, targetVector } = params;
+  const lines: string[] = [];
+
+  lines.push('import weaviate from "weaviate-client";');
+  lines.push('');
+  lines.push('const client = weaviate.connectToLocal();');
+  lines.push(`const collection = client.collections.get("${collectionName}");`);
+  lines.push('');
+  lines.push('const results = await collection.query');
+
+  // Query method and initial parameters
+  if (searchMode === 'text') {
+    lines.push(`  .nearText("${escapeString(searchParams.query)}", {`);
+  } else if (searchMode === 'hybrid') {
+    lines.push(`  .hybrid("${escapeString(searchParams.query)}", {`);
+  } else if (searchMode === 'object') {
+    lines.push(`  .nearObject("${searchParams.objectId}", {`);
+  } else if (searchMode === 'vector') {
+    lines.push('  .nearVector([/* vector values */], {');
+  } else {
+    lines.push('  .fetchObjects({');
+  }
+
+  // Build query options
+  const options: string[] = [];
+
+  // Add hybrid alpha if applicable
+  if (searchMode === 'hybrid') {
+    options.push(`    alpha: ${searchParams.hybridAlpha}`);
+  }
+
+  // Add target vector or multi-target configuration
+  if (targetVector) {
+    if (typeof targetVector === 'string') {
+      options.push(`    targetVector: "${targetVector}"`);
+    } else {
+      const mtPayload = targetVector as MultiTargetPayload;
+      const vectors = mtPayload.targetVectors.map((v: string) => `"${v}"`).join(', ');
+      options.push(`    targetVectors: [${vectors}]`);
+
+      // Add join strategy
+      const joinMethod = getJoinMethodName(mtPayload.combination);
+      options.push(`    joinStrategy: collection.multiTargetVector.${joinMethod}()`);
+
+      // Add weights if present
+      if (mtPayload.weights && Object.keys(mtPayload.weights).length > 0) {
+        const weightsStr = Object.entries(mtPayload.weights)
+          .map(([v, w]: [string, any]) => `"${v}": ${Number(w).toFixed(3)}`)
+          .join(', ');
+        options.push(`    weights: { ${weightsStr} }`);
+      }
+    }
+  }
+
+  // Add common options
+  if (searchParams.certainty) {
+    options.push(`    certainty: ${searchParams.certainty}`);
+  }
+  if (searchParams.distance) {
+    options.push(`    distance: ${searchParams.distance}`);
+  }
+  options.push(`    limit: ${searchParams.limit}`);
+
+  // Combine options
+  if (options.length > 0) {
+    lines.push(options.join(',\n') + ',');
+  }
+
+  lines.push('  })');
+  lines.push('  .withLimit(' + searchParams.limit + ')');
+  lines.push('  .do();');
+  lines.push('');
+  lines.push('console.log(results);');
+
+  return lines.join('\n');
+}
+
+/**
+ * Generate Python code snippet for current search configuration
+ */
+export function generatePythonSnippet(params: {
+  collectionName: string;
+  searchMode: string;
+  searchParams: VectorSearchParameters;
+  targetVector?: string | MultiTargetPayload;
+}): string {
+  const { collectionName, searchMode, searchParams, targetVector } = params;
+  const lines: string[] = [];
+
+  lines.push('import weaviate');
+  lines.push('');
+  lines.push('client = weaviate.connect_to_local()');
+  lines.push(`collection = client.collections.get("${collectionName}")`);
+  lines.push('');
+
+  // Query method
+  let queryCall = '';
+  const queryArgs: string[] = [];
+
+  if (searchMode === 'text') {
+    queryCall = 'near_text';
+    queryArgs.push(`"${escapeString(searchParams.query)}"`);
+  } else if (searchMode === 'hybrid') {
+    queryCall = 'hybrid';
+    queryArgs.push(`"${escapeString(searchParams.query)}"`);
+  } else if (searchMode === 'object') {
+    queryCall = 'near_object';
+    queryArgs.push(`"${searchParams.objectId}"`);
+  } else if (searchMode === 'vector') {
+    queryCall = 'near_vector';
+    queryArgs.push('[/* vector values */]');
+  } else {
+    queryCall = 'fetch_objects';
+  }
+
+  // Build query kwargs
+  const kwargs: string[] = [];
+
+  if (searchMode === 'hybrid') {
+    kwargs.push(`alpha=${searchParams.hybridAlpha}`);
+  }
+
+  if (targetVector) {
+    if (typeof targetVector === 'string') {
+      kwargs.push(`target_vector="${targetVector}"`);
+    } else {
+      const mtPayload = targetVector as MultiTargetPayload;
+      const vectors = '[' + mtPayload.targetVectors.map((v: string) => `"${v}"`).join(', ') + ']';
+      kwargs.push(`target_vectors=${vectors}`);
+      kwargs.push(`join_strategy="${mtPayload.combination}"`);
+
+      if (mtPayload.weights && Object.keys(mtPayload.weights).length > 0) {
+        const weightsStr =
+          '{' +
+          Object.entries(mtPayload.weights)
+            .map(([v, w]: [string, any]) => `"${v}": ${Number(w).toFixed(3)}`)
+            .join(', ') +
+          '}';
+        kwargs.push(`weights=${weightsStr}`);
+      }
+    }
+  }
+
+  if (searchParams.certainty) {
+    kwargs.push(`certainty=${searchParams.certainty}`);
+  }
+  if (searchParams.distance) {
+    kwargs.push(`distance=${searchParams.distance}`);
+  }
+  kwargs.push(`limit=${searchParams.limit}`);
+
+  // Build the query call
+  if (queryArgs.length > 0) {
+    lines.push(`results = collection.query.${queryCall}(`);
+    lines.push(`    ${queryArgs.join(',\n    ')},`);
+    if (kwargs.length > 0) {
+      lines.push(`    ${kwargs.join(',\n    ')}`);
+    }
+    lines.push(').objects');
+  } else {
+    lines.push(`results = collection.query.${queryCall}(`);
+    if (kwargs.length > 0) {
+      lines.push(`    ${kwargs.join(',\n    ')}`);
+    }
+    lines.push(').objects');
+  }
+
+  lines.push('');
+  lines.push('for obj in results:');
+  lines.push('    print(obj)');
+
+  return lines.join('\n');
+}
+
+/**
+ * Escape string for code generation
+ */
+function escapeString(str: string): string {
+  return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Map join strategy to SDK method name
+ */
+function getJoinMethodName(strategy: string): string {
+  switch (strategy) {
+    case 'minimum':
+      return 'minimum()';
+    case 'sum':
+      return 'sum()';
+    case 'average':
+      return 'average()';
+    case 'manual-weights':
+      return 'manualWeights()';
+    case 'relative-score':
+      return 'relativeScore()';
+    default:
+      return 'minimum()';
+  }
+}

--- a/src/data-explorer/webview/utils/multiTargetBuilder.ts
+++ b/src/data-explorer/webview/utils/multiTargetBuilder.ts
@@ -1,0 +1,104 @@
+/**
+ * Multi-target vector search payload builder
+ * Transforms UI state into SDK-compatible target vector payloads
+ */
+
+import type { JoinStrategy, MultiTargetPayload } from '../../types';
+
+/**
+ * Build target vector payload from multi-target UI state
+ * Returns a serializable payload that can be sent via message to extension
+ *
+ * @param selectedTargetVectors - List of selected vector names
+ * @param joinStrategy - Join strategy for combining results
+ * @param vectorWeights - Map of vector names to weights (for weighted strategies)
+ * @returns Single vector name, multi-target payload, or undefined (for default behavior)
+ * @throws If configuration is invalid
+ */
+export function buildTargetVectorPayload(
+  selectedTargetVectors: string[],
+  joinStrategy: JoinStrategy,
+  vectorWeights: Record<string, number>
+): string | MultiTargetPayload | undefined {
+  // No vectors selected - use default
+  if (!selectedTargetVectors || selectedTargetVectors.length === 0) {
+    return undefined;
+  }
+
+  // Single vector - return as string for single-target behavior
+  if (selectedTargetVectors.length === 1) {
+    return selectedTargetVectors[0];
+  }
+
+  // Multiple vectors - build multi-target payload
+  const payload: MultiTargetPayload = {
+    combination: joinStrategy,
+    targetVectors: selectedTargetVectors,
+  };
+
+  // Add weights for weighted strategies
+  if (joinStrategy === 'manual-weights' || joinStrategy === 'relative-score') {
+    // Validate that all selected vectors have weights
+    const weights: Record<string, number> = {};
+    let hasZeroWeight = false;
+
+    selectedTargetVectors.forEach((vector) => {
+      const weight = vectorWeights[vector] ?? 0.5;
+
+      // Validate weight is positive
+      if (weight <= 0) {
+        hasZeroWeight = true;
+      }
+
+      weights[vector] = weight;
+    });
+
+    if (hasZeroWeight) {
+      throw new Error('All vector weights must be greater than 0');
+    }
+
+    // Normalize weights to sum to 1.0 for manual-weights strategy
+    if (joinStrategy === 'manual-weights') {
+      const totalWeight = Object.values(weights).reduce((sum, w) => sum + w, 0);
+      if (totalWeight > 0) {
+        Object.keys(weights).forEach((vector) => {
+          weights[vector] = weights[vector] / totalWeight;
+        });
+      }
+    }
+
+    payload.weights = weights;
+  }
+
+  return payload;
+}
+
+/**
+ * Validate multi-target configuration for errors
+ * Used to disable search button when config is invalid
+ */
+export function validateMultiTargetConfig(
+  selectedTargetVectors: string[],
+  joinStrategy: JoinStrategy,
+  vectorWeights: Record<string, number>
+): { valid: boolean; error?: string } {
+  // At least one vector must be selected (if multi-target is active)
+  if (selectedTargetVectors.length === 0) {
+    return { valid: false, error: 'At least one target vector must be selected' };
+  }
+
+  // For weighted strategies, all weights must be positive
+  if (joinStrategy === 'manual-weights' || joinStrategy === 'relative-score') {
+    for (const vector of selectedTargetVectors) {
+      const weight = vectorWeights[vector];
+      if (weight === undefined || weight <= 0) {
+        return {
+          valid: false,
+          error: `Vector "${vector}" has invalid weight (must be > 0)`,
+        };
+      }
+    }
+  }
+
+  return { valid: true };
+}

--- a/src/data-explorer/webview/utils/versionCheck.ts
+++ b/src/data-explorer/webview/utils/versionCheck.ts
@@ -1,0 +1,94 @@
+/**
+ * Version checking utilities for feature gating multi-target vector search
+ * Multi-target support was introduced incrementally across Weaviate releases
+ */
+
+// Minimum version requirements for multi-target features
+export const MULTI_TARGET_NEAR_MIN = '1.26.0';
+export const MULTI_TARGET_HYBRID_MIN = '1.27.0';
+export const MUVERA_MIN = '1.31.0';
+
+/**
+ * Parse a semantic version string into [major, minor, patch]
+ * @param versionStr - Version string like "1.26.0" or "v1.26.0-rc1"
+ * @returns [major, minor, patch] tuple
+ * @throws If version string is invalid
+ */
+export function parseVersion(versionStr: string): [number, number, number] {
+  // Remove leading 'v' if present
+  const cleaned = versionStr.startsWith('v') ? versionStr.slice(1) : versionStr;
+
+  // Extract major.minor.patch (ignore pre-release/build metadata)
+  const match = cleaned.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    throw new Error(`Invalid version string: ${versionStr}`);
+  }
+
+  return [parseInt(match[1], 10), parseInt(match[2], 10), parseInt(match[3], 10)];
+}
+
+/**
+ * Compare two semantic versions
+ * @returns -1 if version1 < version2, 0 if equal, 1 if version1 > version2
+ */
+export function compareVersions(
+  version1: [number, number, number],
+  version2: [number, number, number]
+): -1 | 0 | 1 {
+  for (let i = 0; i < 3; i++) {
+    if (version1[i] < version2[i]) {
+      return -1;
+    }
+    if (version1[i] > version2[i]) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Check if a version is at least the required version
+ * @param versionStr - Version string (e.g., "1.26.0")
+ * @param major - Required major version
+ * @param minor - Required minor version
+ * @param patch - Required patch version (optional, defaults to 0)
+ */
+export function isVersionAtLeast(
+  versionStr: string,
+  major: number,
+  minor: number,
+  patch: number = 0
+): boolean {
+  try {
+    const parsed = parseVersion(versionStr);
+    const required: [number, number, number] = [major, minor, patch];
+    return compareVersions(parsed, required) >= 0;
+  } catch {
+    // If version parsing fails, assume it's not compatible
+    return false;
+  }
+}
+
+/**
+ * Check if multi-target vector search is supported for near_xxx queries
+ * Requires Weaviate v1.26.0+
+ */
+export function supportsMultiTargetNear(serverVersion: string): boolean {
+  return isVersionAtLeast(serverVersion, 1, 26, 0);
+}
+
+/**
+ * Check if multi-target vector search is supported for hybrid queries
+ * Requires Weaviate v1.27.0+
+ */
+export function supportsMultiTargetHybrid(serverVersion: string): boolean {
+  return isVersionAtLeast(serverVersion, 1, 27, 0);
+}
+
+/**
+ * Check if MUVERA encoding is supported
+ * Introduced in Weaviate v1.31.0+
+ */
+export function supportsMUVERA(serverVersion: string): boolean {
+  return isVersionAtLeast(serverVersion, 1, 31, 0);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,14 @@
+// Pin DNS result order to ipv4first at module load time — before any import
+// side-effects (weaviate-client, grpc-js) can open TCP sockets.  This suppresses
+// the Node 18.13+ "auto-select family attempt timeout to 1000ms" diagnostic that
+// fires when Happy Eyeballs (RFC 8305) probes both IPv4 and IPv6 simultaneously.
+import * as dns from 'dns';
+try {
+  dns.setDefaultResultOrder('ipv4first');
+} catch {
+  /* non-fatal */
+}
+
 import * as vscode from 'vscode';
 import weaviate from 'weaviate-client';
 import { WeaviateTreeDataProvider } from './WeaviateTreeDataProvider/WeaviateTreeDataProvider';
@@ -360,6 +371,20 @@ async function pushRoleListToOpenPanels(client: any, connectionId: string): Prom
 
 // This method is called when your extension is activated
 export function activate(context: vscode.ExtensionContext) {
+  // Suppress the Node.js 'auto-select family attempt timeout to 1000ms' diagnostic.
+  // Node 18.13+ probes both IPv4 and IPv6 simultaneously (Happy Eyeballs / RFC 8305)
+  // when no DNS result order is set.  For local Weaviate connections this adds an
+  // unnecessary 1 s delay before every TCP handshake.  Pinning to ipv4first avoids
+  // the probe and resolves addresses deterministically.
+  try {
+    const dns = require('dns');
+    if (typeof dns.setDefaultResultOrder === 'function') {
+      dns.setDefaultResultOrder('ipv4first');
+    }
+  } catch {
+    // dns module unavailable — safe to ignore
+  }
+
   // Initialize telemetry
   const telemetryService = getTelemetryService();
   const connectionString = vscode.workspace

--- a/src/services/ConnectionManager.ts
+++ b/src/services/ConnectionManager.ts
@@ -524,12 +524,18 @@ export class ConnectionManager {
           // Detect gRPC compatibility error
           console.log('Initial connection error:', error);
 
-          // Check for gRPC compatibility issues more comprehensively
+          // Check for gRPC compatibility issues more comprehensively.
+          // 'fetch failed' and ECONNRESET/ECONNREFUSED can occur during the gRPC
+          // health-check init when the server does not support gRPC, so treat
+          // those as gRPC errors and fall back to HTTP-only.
           const isGrpcError =
             error.message.includes('gRPC') ||
             error.message.includes('is not supported') ||
             error.message.includes('v1.26.7') ||
             error.message.includes('v1.27.0') ||
+            error.message.includes('fetch failed') ||
+            error.message.includes('ECONNRESET') ||
+            error.message.includes('ECONNREFUSED') ||
             (error.name === 'WeaviateStartUpError' && error.message.includes('gRPC'));
 
           if (isGrpcError) {


### PR DESCRIPTION

## Summary
This PR implements full support for **Multi-Vector Search (Muvera)** within the Data Explorer, allowing users to perform semantic searches across multiple named vectors simultaneously. It also resolves critical compatibility issues with the `weaviate-client` v4 SDK and improves the default vector search experience.

## ✨ Key Features: Multi-Vector Search (Muvera)
*   **Target Vector Selection**: Added a "Vector Options" drawer in the Data Explorer to select one or more named vectors for search.
*   **Auto-Selection**: Named vectors are automatically pre-selected when a collection loads, preventing common "no target vectors provided" errors.
*   **Join Strategies**: Full support for Weaviate's multi-target merge strategies:
    *   `Minimum` (Default), `Sum`, `Average`.
    *   `Manual Weights` & `Relative Score` with an integrated **Weight Editor**.
*   **Weight Editor**: Precision sliders for per-vector weighting with a one-click "Normalize" tool.
*   **Version Gating**: UI now correctly identifies and enforces version requirements (v1.26+ for Near queries, v1.27+ for Hybrid) with user-friendly notices.
*   **Copy as Code**: Updated code generators to produce valid TypeScript and Python snippets for `multiTargetVector` configurations.

## 🐛 Critical Bug Fixes
*   **v4 SDK Version Detection**: Fixed `getServerVersion()` which was using a deprecated v3 API (`misc.metaGetter()`) that returned `null` in v4 environments. This was causing the extension to incorrectly report that modern servers were "too old."
*   **Payload Construction**: Fixed a critical bug in `useVectorSearch.ts` where the search payload completely ignored selected target vectors and join strategies, leading to "class has multiple vectors" server errors.

## 🎨 UX & Aesthetic Improvements
*   **Distance Semantic Shift**: Changed default `maxDistance` from `0.5` to `1.0`.
    *   *Rationale*: 0.5 was too strict for cosine distance, silently dropping valid results.
    *   *Implementation*: At 1.0, the distance filter is omitted entirely ("No Filter" mode), returning the top-N results unconditionally.
*   **Slider Guidance**: Added semantic markers to the distance slider: `0 (exact)`, `1.0 (no filter)`, and `2 (distant)`.
*   **Validation Guard**: The "Run Search" button is now disabled when no vectors are selected, providing a clear visual cue instead of failing with a cryptic error message.

## 🛠️ Testing & Tooling
*   **Cloud Test Fixtures**: Added `sandbox/populate_cloud_muvera.py` to quickly spin up a Muvera-ready collection using Weaviate's built-in `text2vec-weaviate` module (no external API keys required).
*   **Module Checker**: Added `sandbox/check_modules.py` to inspect available vectorizers on remote instances.
*   **Testing Guide**: Updated `TESTING_GUIDE.md` with a 15-point checklist specifically for Multi-Vector scenarios.

## Files Modified
- `src/data-explorer/extension/DataExplorerAPI.ts`: Fixes version detection and gRPC payload construction.
- `src/data-explorer/webview/hooks/useVectorSearch.ts`: Fixed state serialization for multi-target queries.
- `src/data-explorer/webview/components/VectorSearch/VectorSearchPanel.tsx`: UI logic for auto-selection, validation, and distance defaults.
- `src/data-explorer/webview/context/VectorSearchContext.tsx`: Updated initial state and action types.
- `CHANGELOG.md`: Updated for v1.6.2.
- `TESTING_GUIDE.md`: Added Muvera test cases.