### PR TITLE
Feat/empty replicated shard/collection ratio check

### DIFF
--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -24,6 +24,8 @@ import {
   findEmptyShards,
   findEmptyShardRatios,
   findReplicationImbalances,
+  findCollectionsWithoutAsyncReplication,
+  buildAsyncReplicationMap,
   computeCandidatesDismissKey,
   MtCandidateGroup,
   ChecksResult,
@@ -3551,14 +3553,17 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
     const mtCollections = new Set(
       collections.filter((c) => c.schema?.multiTenancy?.enabled).map((c) => c.label)
     );
+    const asyncReplicationByCollection = buildAsyncReplicationMap(collections);
 
     // All checks are independent — run them in parallel.
-    const [groups, emptyShardEntries, emptyShardRatios, replicationImbalances] = await Promise.all([
-      Promise.resolve(findMultiTenantCandidates(collections, objectCounts)),
-      Promise.resolve(findEmptyShards(nodes as any, mtCollections)),
-      Promise.resolve(findEmptyShardRatios(nodes as any, mtCollections)),
-      Promise.resolve(findReplicationImbalances(nodes as any)),
-    ]);
+    const [groups, emptyShardEntries, emptyShardRatios, replicationImbalances, asyncDisabled] =
+      await Promise.all([
+        Promise.resolve(findMultiTenantCandidates(collections, objectCounts)),
+        Promise.resolve(findEmptyShards(nodes as any, mtCollections)),
+        Promise.resolve(findEmptyShardRatios(nodes as any, mtCollections)),
+        Promise.resolve(findReplicationImbalances(nodes as any, asyncReplicationByCollection)),
+        Promise.resolve(findCollectionsWithoutAsyncReplication(collections)),
+      ]);
 
     const result: ChecksResult = {
       timestamp: new Date().toISOString(),
@@ -3566,7 +3571,8 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
         groups.length > 0 ||
         emptyShardEntries.length > 0 ||
         emptyShardRatios.length > 0 ||
-        replicationImbalances.length > 0,
+        replicationImbalances.length > 0 ||
+        asyncDisabled.length > 0,
       multiTenancy: { groups, hasIssues: groups.length > 0 },
       emptyShards: { entries: emptyShardEntries, hasIssues: emptyShardEntries.length > 0 },
       emptyShardRatio: { entries: emptyShardRatios, hasIssues: emptyShardRatios.length > 0 },
@@ -3574,6 +3580,7 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
         collections: replicationImbalances,
         hasIssues: replicationImbalances.length > 0,
       },
+      asyncReplicationDisabled: { entries: asyncDisabled, hasIssues: asyncDisabled.length > 0 },
     };
 
     // Persist so the result survives panel close/reopen
@@ -3585,7 +3592,8 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       (groups.length > 0 ? 1 : 0) +
       (emptyShardEntries.length > 0 ? 1 : 0) +
       (emptyShardRatios.length > 0 ? 1 : 0) +
-      (replicationImbalances.length > 0 ? 1 : 0);
+      (replicationImbalances.length > 0 ? 1 : 0) +
+      (asyncDisabled.length > 0 ? 1 : 0);
     this.refresh();
 
     return result;
@@ -4451,14 +4459,16 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
     const mtCollections = new Set(
       collections.filter((c) => c.schema?.multiTenancy?.enabled).map((c) => c.label)
     );
+    const asyncReplicationByCollection = buildAsyncReplicationMap(collections);
 
     // All checks are independent — run them in parallel.
-    const [candidates, emptyShardEntries, emptyShardRatios, replicationImbalances] =
+    const [candidates, emptyShardEntries, emptyShardRatios, replicationImbalances, asyncDisabled] =
       await Promise.all([
         Promise.resolve(findMultiTenantCandidates(collections, objectCounts)),
         Promise.resolve(findEmptyShards(nodes as any, mtCollections)),
         Promise.resolve(findEmptyShardRatios(nodes as any, mtCollections)),
-        Promise.resolve(findReplicationImbalances(nodes as any)),
+        Promise.resolve(findReplicationImbalances(nodes as any, asyncReplicationByCollection)),
+        Promise.resolve(findCollectionsWithoutAsyncReplication(collections)),
       ]);
     this.mtCandidates[connectionId] = candidates;
 
@@ -4468,7 +4478,8 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
         candidates.length > 0 ||
         emptyShardEntries.length > 0 ||
         emptyShardRatios.length > 0 ||
-        replicationImbalances.length > 0,
+        replicationImbalances.length > 0 ||
+        asyncDisabled.length > 0,
       multiTenancy: { groups: candidates, hasIssues: candidates.length > 0 },
       emptyShards: { entries: emptyShardEntries, hasIssues: emptyShardEntries.length > 0 },
       emptyShardRatio: { entries: emptyShardRatios, hasIssues: emptyShardRatios.length > 0 },
@@ -4476,13 +4487,15 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
         collections: replicationImbalances,
         hasIssues: replicationImbalances.length > 0,
       },
+      asyncReplicationDisabled: { entries: asyncDisabled, hasIssues: asyncDisabled.length > 0 },
     };
 
     this.checksIssueSectionCount[connectionId] =
       (candidates.length > 0 ? 1 : 0) +
       (emptyShardEntries.length > 0 ? 1 : 0) +
       (emptyShardRatios.length > 0 ? 1 : 0) +
-      (replicationImbalances.length > 0 ? 1 : 0);
+      (replicationImbalances.length > 0 ? 1 : 0) +
+      (asyncDisabled.length > 0 ? 1 : 0);
 
     await this.context.globalState.update(`checksResults.${connectionId}`, result);
     ClusterPanel.getPanel(connectionId)?.postMessage({ command: 'checksResult', result });

--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -3400,6 +3400,13 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       const clusterNodes = await client.cluster.nodes({ output: 'verbose' });
       this.clusterNodesCache[connectionId] = clusterNodes;
 
+      // Node data drives the empty-shard, empty-shard-ratio, and replication-imbalance
+      // checks. On a large cluster this fetch can complete well after the parallel
+      // collections fetch (which also triggers a recompute) — that earlier recompute
+      // ran with no node data, so re-run now that the shard data has arrived. The
+      // recompute is serialized so this late run wins over the earlier partial one.
+      await this._recomputeChecksAndSend(connectionId);
+
       // Refresh the tree view
       this.refresh();
     } catch (error: unknown) {
@@ -3968,12 +3975,10 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       // Refresh the tree view
       this.refresh();
 
-      // Refresh node cache first, then update the panel and recompute checks in parallel.
+      // Refresh node cache (which recomputes the checks once shards are loaded),
+      // then update the panel.
       await this.fetchNodes(connectionId);
-      await Promise.all([
-        this.updateClusterPanelIfOpen(connectionId),
-        this._recomputeChecksAndSend(connectionId),
-      ]);
+      await this.updateClusterPanelIfOpen(connectionId);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error('Error in deleteCollection:', error);
@@ -4013,12 +4018,10 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       // Refresh the tree view
       this.refresh();
 
-      // Refresh node cache first, then update the panel and recompute checks in parallel.
+      // Refresh node cache (which recomputes the checks once shards are loaded),
+      // then update the panel.
       await this.fetchNodes(connectionId);
-      await Promise.all([
-        this.updateClusterPanelIfOpen(connectionId),
-        this._recomputeChecksAndSend(connectionId),
-      ]);
+      await this.updateClusterPanelIfOpen(connectionId);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error('Error in deleteAllCollections:', error);
@@ -4414,8 +4417,26 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
    *
    * Call this whenever collections or node shards change (fetch, delete, etc.) so the
    * Checks tab and tree badges stay in sync without requiring a manual "Run Checks".
+   *
+   * Recomputes are serialized per connection: collections and nodes are fetched in
+   * parallel (see {@link fetchData}) and each triggers a recompute, but on a large
+   * cluster the verbose node fetch can finish long after collections. Serializing
+   * guarantees the recompute triggered by the slower fetch runs last — with BOTH
+   * caches populated — so its result wins instead of being clobbered by an earlier,
+   * partial recompute that ran before node data had arrived.
    */
-  private async _recomputeChecksAndSend(connectionId: string): Promise<void> {
+  private _recomputeChecksChain: Record<string, Promise<void>> = {};
+
+  private _recomputeChecksAndSend(connectionId: string): Promise<void> {
+    const prev = this._recomputeChecksChain[connectionId] ?? Promise.resolve();
+    const next = prev
+      .catch(() => undefined)
+      .then(() => this._recomputeChecksAndSendInner(connectionId));
+    this._recomputeChecksChain[connectionId] = next;
+    return next;
+  }
+
+  private async _recomputeChecksAndSendInner(connectionId: string): Promise<void> {
     const collections = this.collections[connectionId] ?? [];
     const objectCounts = this._getObjectCountsFromNodes(connectionId);
 

--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -22,6 +22,7 @@ import { getTelemetryService, TELEMETRY_EVENTS } from '../telemetry';
 import {
   findMultiTenantCandidates,
   findEmptyShards,
+  findEmptyShardRatios,
   findReplicationImbalances,
   computeCandidatesDismissKey,
   MtCandidateGroup,
@@ -3544,19 +3545,24 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       collections.filter((c) => c.schema?.multiTenancy?.enabled).map((c) => c.label)
     );
 
-    // All three checks are independent — run them in parallel.
-    const [groups, emptyShardEntries, replicationImbalances] = await Promise.all([
+    // All checks are independent — run them in parallel.
+    const [groups, emptyShardEntries, emptyShardRatios, replicationImbalances] = await Promise.all([
       Promise.resolve(findMultiTenantCandidates(collections, objectCounts)),
       Promise.resolve(findEmptyShards(nodes as any, mtCollections)),
+      Promise.resolve(findEmptyShardRatios(nodes as any, mtCollections)),
       Promise.resolve(findReplicationImbalances(nodes as any)),
     ]);
 
     const result: ChecksResult = {
       timestamp: new Date().toISOString(),
       hasIssues:
-        groups.length > 0 || emptyShardEntries.length > 0 || replicationImbalances.length > 0,
+        groups.length > 0 ||
+        emptyShardEntries.length > 0 ||
+        emptyShardRatios.length > 0 ||
+        replicationImbalances.length > 0,
       multiTenancy: { groups, hasIssues: groups.length > 0 },
       emptyShards: { entries: emptyShardEntries, hasIssues: emptyShardEntries.length > 0 },
+      emptyShardRatio: { entries: emptyShardRatios, hasIssues: emptyShardRatios.length > 0 },
       replicationImbalance: {
         collections: replicationImbalances,
         hasIssues: replicationImbalances.length > 0,
@@ -3571,6 +3577,7 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
     this.checksIssueSectionCount[connectionId] =
       (groups.length > 0 ? 1 : 0) +
       (emptyShardEntries.length > 0 ? 1 : 0) +
+      (emptyShardRatios.length > 0 ? 1 : 0) +
       (replicationImbalances.length > 0 ? 1 : 0);
     this.refresh();
 
@@ -4424,20 +4431,26 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       collections.filter((c) => c.schema?.multiTenancy?.enabled).map((c) => c.label)
     );
 
-    // All three checks are independent — run them in parallel.
-    const [candidates, emptyShardEntries, replicationImbalances] = await Promise.all([
-      Promise.resolve(findMultiTenantCandidates(collections, objectCounts)),
-      Promise.resolve(findEmptyShards(nodes as any, mtCollections)),
-      Promise.resolve(findReplicationImbalances(nodes as any)),
-    ]);
+    // All checks are independent — run them in parallel.
+    const [candidates, emptyShardEntries, emptyShardRatios, replicationImbalances] =
+      await Promise.all([
+        Promise.resolve(findMultiTenantCandidates(collections, objectCounts)),
+        Promise.resolve(findEmptyShards(nodes as any, mtCollections)),
+        Promise.resolve(findEmptyShardRatios(nodes as any, mtCollections)),
+        Promise.resolve(findReplicationImbalances(nodes as any)),
+      ]);
     this.mtCandidates[connectionId] = candidates;
 
     const result: ChecksResult = {
       timestamp: new Date().toISOString(),
       hasIssues:
-        candidates.length > 0 || emptyShardEntries.length > 0 || replicationImbalances.length > 0,
+        candidates.length > 0 ||
+        emptyShardEntries.length > 0 ||
+        emptyShardRatios.length > 0 ||
+        replicationImbalances.length > 0,
       multiTenancy: { groups: candidates, hasIssues: candidates.length > 0 },
       emptyShards: { entries: emptyShardEntries, hasIssues: emptyShardEntries.length > 0 },
+      emptyShardRatio: { entries: emptyShardRatios, hasIssues: emptyShardRatios.length > 0 },
       replicationImbalance: {
         collections: replicationImbalances,
         hasIssues: replicationImbalances.length > 0,
@@ -4447,6 +4460,7 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
     this.checksIssueSectionCount[connectionId] =
       (candidates.length > 0 ? 1 : 0) +
       (emptyShardEntries.length > 0 ? 1 : 0) +
+      (emptyShardRatios.length > 0 ? 1 : 0) +
       (replicationImbalances.length > 0 ? 1 : 0);
 
     await this.context.globalState.update(`checksResults.${connectionId}`, result);

--- a/src/WeaviateTreeDataProvider/__tests__/DataFetch.test.ts
+++ b/src/WeaviateTreeDataProvider/__tests__/DataFetch.test.ts
@@ -363,6 +363,27 @@ describe('fetchNodes', () => {
     expect((provider as any).clusterNodesCache['c1']).toEqual(nodes);
   });
 
+  it('recomputes checks once node shards arrive (fixes slow-cluster race)', async () => {
+    // Collections already loaded, but node data lands later (large-cluster case).
+    // fetchNodes must trigger a recompute so the checks reflect the shard data.
+    mockGetClient.mockReturnValue(mockClient);
+    (provider as any).collections['c1'] = [
+      { label: 'Article', collectionName: 'Article', schema: { multiTenancy: { enabled: false } } },
+    ];
+    mockClusterNodes.mockResolvedValue([
+      { name: 'node-1', shards: [{ class: 'Article', name: 'shard-1', objectCount: 0 }] },
+    ]);
+
+    await provider.fetchNodes('c1');
+
+    const saved = (mockCtx.globalState.update as jest.Mock).mock.calls.find(
+      (call: any[]) => call[0] === 'checksResults.c1'
+    );
+    expect(saved).toBeDefined();
+    expect(saved[1].emptyShards.hasIssues).toBe(true);
+    expect(saved[1].emptyShards.entries[0].collectionName).toBe('Article');
+  });
+
   it('shows error when client not found', async () => {
     mockGetClient.mockReturnValue(null);
 

--- a/src/WeaviateTreeDataProvider/__tests__/DataFetch.test.ts
+++ b/src/WeaviateTreeDataProvider/__tests__/DataFetch.test.ts
@@ -687,8 +687,9 @@ describe('runChecks', () => {
 
     await provider.runChecks('c1');
 
-    // Empty shards issue detected → count should be 1
-    expect((provider as any).checksIssueSectionCount['c1']).toBe(1);
+    // The single shard is empty → trips both the empty-shards list and the
+    // empty-shard-ratio check (100% empty → critical) → 2 sections.
+    expect((provider as any).checksIssueSectionCount['c1']).toBe(2);
   });
 
   it('detects replication imbalance when same shard has different counts across nodes', async () => {
@@ -831,7 +832,9 @@ describe('_recomputeChecksAndSend', () => {
 
     await (provider as any)._recomputeChecksAndSend('c1');
 
-    expect((provider as any).checksIssueSectionCount['c1']).toBe(1);
+    // The single shard is empty → trips both the empty-shards list and the
+    // empty-shard-ratio check (100% empty → critical) → 2 sections.
+    expect((provider as any).checksIssueSectionCount['c1']).toBe(2);
   });
 
   it('persists result to globalState', async () => {

--- a/src/utils/__tests__/multiTenancyCheck.test.ts
+++ b/src/utils/__tests__/multiTenancyCheck.test.ts
@@ -5,11 +5,27 @@ import {
   findEmptyShards,
   findEmptyShardRatios,
   findReplicationImbalances,
+  findCollectionsWithoutAsyncReplication,
+  buildAsyncReplicationMap,
   EMPTY_SHARD_RATIO_THRESHOLDS,
   MtCandidateGroup,
   NodeLike,
   PropertyLike,
 } from '../multiTenancyCheck';
+
+/** Builds a collection whose schema carries a replication config. */
+function makeReplicatedCollection(
+  name: string,
+  factor: number,
+  asyncEnabled: boolean
+): CollectionWithSchema {
+  return {
+    label: name,
+    collapsibleState: 0,
+    itemType: 'collection',
+    schema: { name, replication: { factor, asyncEnabled } } as any,
+  } as unknown as CollectionWithSchema;
+}
 import { CollectionWithSchema } from '../../types';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -797,5 +813,72 @@ describe('findReplicationImbalances', () => {
     expect(result[0].shards).toHaveLength(1); // only shard-a is imbalanced
     expect(result[0]).toMatchObject({ expectedObjects: 300, actualObjects: 290 });
     expect(result[0].replicationRatio).toBeCloseTo(290 / 300);
+  });
+
+  it('annotates each imbalanced collection with its async replication status', () => {
+    const nodes = [
+      makeNode('node-1', [{ class: 'Article', name: 'shard-1', objectCount: 100 }]),
+      makeNode('node-2', [{ class: 'Article', name: 'shard-1', objectCount: 90 }]),
+    ];
+    const asyncMap = { Article: false };
+    const result = findReplicationImbalances(nodes, asyncMap);
+    expect(result[0].asyncReplicationEnabled).toBe(false);
+  });
+
+  it('leaves asyncReplicationEnabled undefined when no map is provided', () => {
+    const nodes = [
+      makeNode('node-1', [{ class: 'Article', name: 'shard-1', objectCount: 100 }]),
+      makeNode('node-2', [{ class: 'Article', name: 'shard-1', objectCount: 90 }]),
+    ];
+    expect(findReplicationImbalances(nodes)[0].asyncReplicationEnabled).toBeUndefined();
+  });
+});
+
+// ─── findCollectionsWithoutAsyncReplication ───────────────────────────────────
+
+describe('findCollectionsWithoutAsyncReplication', () => {
+  it('returns empty array when there are no collections', () => {
+    expect(findCollectionsWithoutAsyncReplication([])).toHaveLength(0);
+  });
+
+  it('flags replicated collections with async replication disabled', () => {
+    const result = findCollectionsWithoutAsyncReplication([
+      makeReplicatedCollection('Replicated', 3, false),
+    ]);
+    expect(result).toEqual([{ collectionName: 'Replicated', replicationFactor: 3 }]);
+  });
+
+  it('does not flag replicated collections with async replication enabled', () => {
+    expect(
+      findCollectionsWithoutAsyncReplication([makeReplicatedCollection('Async', 3, true)])
+    ).toHaveLength(0);
+  });
+
+  it('ignores non-replicated collections (factor ≤ 1)', () => {
+    expect(
+      findCollectionsWithoutAsyncReplication([makeReplicatedCollection('Single', 1, false)])
+    ).toHaveLength(0);
+  });
+
+  it('treats a missing replication config as non-replicated', () => {
+    // makeCollection has no replication config at all → factor defaults to 1.
+    expect(findCollectionsWithoutAsyncReplication([makeCollection('NoRep')])).toHaveLength(0);
+  });
+});
+
+// ─── buildAsyncReplicationMap ─────────────────────────────────────────────────
+
+describe('buildAsyncReplicationMap', () => {
+  it('maps collection names to their async replication flag', () => {
+    const map = buildAsyncReplicationMap([
+      makeReplicatedCollection('A', 3, true),
+      makeReplicatedCollection('B', 3, false),
+    ]);
+    expect(map).toEqual({ A: true, B: false });
+  });
+
+  it('omits collections without a replication config', () => {
+    const map = buildAsyncReplicationMap([makeCollection('NoRep')]);
+    expect(map).toEqual({});
   });
 });

--- a/src/utils/__tests__/multiTenancyCheck.test.ts
+++ b/src/utils/__tests__/multiTenancyCheck.test.ts
@@ -3,7 +3,9 @@ import {
   computeCandidatesDismissKey,
   findMultiTenantCandidates,
   findEmptyShards,
+  findEmptyShardRatios,
   findReplicationImbalances,
+  EMPTY_SHARD_RATIO_THRESHOLDS,
   MtCandidateGroup,
   NodeLike,
   PropertyLike,
@@ -529,6 +531,137 @@ describe('findEmptyShards', () => {
     const nodes: NodeLike[] = [{ name: 'node-1', shards: null }];
     expect(() => findEmptyShards(nodes)).not.toThrow();
     expect(findEmptyShards(nodes)).toHaveLength(0);
+  });
+});
+
+// ─── findEmptyShardRatios ─────────────────────────────────────────────────────
+
+describe('findEmptyShardRatios', () => {
+  it('returns empty array when there are no nodes', () => {
+    expect(findEmptyShardRatios([])).toHaveLength(0);
+  });
+
+  it('does not flag a collection below the warning threshold', () => {
+    // 1 of 20 empty = 5% < 10%
+    const shards = Array.from({ length: 20 }, (_, i) => ({
+      class: 'Article',
+      name: `shard-${i}`,
+      objectCount: i === 0 ? 0 : 100,
+    }));
+    expect(findEmptyShardRatios([makeNode('node-1', shards)])).toHaveLength(0);
+  });
+
+  it('flags a collection as warning at the 10% threshold', () => {
+    // 2 of 20 empty = 10%
+    const shards = Array.from({ length: 20 }, (_, i) => ({
+      class: 'Article',
+      name: `shard-${i}`,
+      objectCount: i < 2 ? 0 : 100,
+    }));
+    const result = findEmptyShardRatios([makeNode('node-1', shards)]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      collectionName: 'Article',
+      isMultiTenant: false,
+      totalShards: 20,
+      emptyShards: 2,
+      severity: 'warning',
+    });
+    expect(result[0].ratio).toBeCloseTo(0.1);
+  });
+
+  it('escalates to critical at the 50% threshold', () => {
+    const shards = Array.from({ length: 10 }, (_, i) => ({
+      class: 'Article',
+      name: `shard-${i}`,
+      objectCount: i < 5 ? 0 : 100,
+    }));
+    const result = findEmptyShardRatios([makeNode('node-1', shards)]);
+    expect(result).toHaveLength(1);
+    expect(result[0].severity).toBe('critical');
+    expect(result[0].ratio).toBeCloseTo(0.5);
+  });
+
+  it('applies to multi-tenant collections and labels them', () => {
+    const shards = Array.from({ length: 4 }, (_, i) => ({
+      class: 'MTCollection',
+      name: `tenant-${i}`,
+      objectCount: i < 3 ? 0 : 100,
+    }));
+    const result = findEmptyShardRatios([makeNode('node-1', shards)], new Set(['MTCollection']));
+    expect(result).toHaveLength(1);
+    expect(result[0].isMultiTenant).toBe(true);
+    expect(result[0].severity).toBe('critical'); // 75% empty
+  });
+
+  it('collapses replicas by shard name and treats a shard empty only when all replicas are empty', () => {
+    // Same shard "s1" on three nodes: empty on two, populated on one → NOT empty.
+    // "s2" empty on all three → empty. 1 of 2 distinct shards empty = 50% → critical.
+    const nodes = [
+      makeNode('node-1', [
+        { class: 'Article', name: 's1', objectCount: 0 },
+        { class: 'Article', name: 's2', objectCount: 0 },
+      ]),
+      makeNode('node-2', [
+        { class: 'Article', name: 's1', objectCount: 0 },
+        { class: 'Article', name: 's2', objectCount: 0 },
+      ]),
+      makeNode('node-3', [
+        { class: 'Article', name: 's1', objectCount: 42 },
+        { class: 'Article', name: 's2', objectCount: 0 },
+      ]),
+    ];
+    const result = findEmptyShardRatios(nodes);
+    expect(result).toHaveLength(1);
+    expect(result[0].totalShards).toBe(2);
+    expect(result[0].emptyShards).toBe(1);
+    expect(result[0].severity).toBe('critical');
+  });
+
+  it('sorts critical entries before warnings, then by ratio descending', () => {
+    const nodes = [
+      makeNode('node-1', [
+        // Warn: 2 of 10 = 20%
+        ...Array.from({ length: 10 }, (_, i) => ({
+          class: 'WarnCol',
+          name: `w-${i}`,
+          objectCount: i < 2 ? 0 : 5,
+        })),
+        // Critical: 9 of 10 = 90%
+        ...Array.from({ length: 10 }, (_, i) => ({
+          class: 'CritCol',
+          name: `c-${i}`,
+          objectCount: i < 9 ? 0 : 5,
+        })),
+      ]),
+    ];
+    const result = findEmptyShardRatios(nodes);
+    expect(result.map((r) => r.collectionName)).toEqual(['CritCol', 'WarnCol']);
+  });
+
+  it('honours custom thresholds', () => {
+    const shards = Array.from({ length: 10 }, (_, i) => ({
+      class: 'Article',
+      name: `shard-${i}`,
+      objectCount: i < 3 ? 0 : 100,
+    }));
+    // 30% empty: below default critical(50%) → warning; with custom critical(25%) → critical
+    const result = findEmptyShardRatios([makeNode('node-1', shards)], undefined, {
+      warning: 0.1,
+      critical: 0.25,
+    });
+    expect(result[0].severity).toBe('critical');
+  });
+
+  it('exposes configurable default thresholds', () => {
+    expect(EMPTY_SHARD_RATIO_THRESHOLDS.warning).toBe(0.1);
+    expect(EMPTY_SHARD_RATIO_THRESHOLDS.critical).toBe(0.5);
+  });
+
+  it('handles nodes with null/undefined shards gracefully', () => {
+    const nodes: NodeLike[] = [{ name: 'node-1', shards: null }];
+    expect(() => findEmptyShardRatios(nodes)).not.toThrow();
+    expect(findEmptyShardRatios(nodes)).toHaveLength(0);
   });
 });
 

--- a/src/utils/__tests__/multiTenancyCheck.test.ts
+++ b/src/utils/__tests__/multiTenancyCheck.test.ts
@@ -739,4 +739,63 @@ describe('findReplicationImbalances', () => {
     expect(() => findReplicationImbalances(nodes)).not.toThrow();
     expect(findReplicationImbalances(nodes)).toHaveLength(0);
   });
+
+  it('computes the replication ratio per shard from the most complete replica × replica count', () => {
+    // One shard replicated 12 / 12 / 10 → expected = 12 × 3 = 36, actual = 34.
+    const nodes = [
+      makeNode('node-1', [{ class: 'SemanticConversation', name: 'Bhagwan', objectCount: 12 }]),
+      makeNode('node-2', [{ class: 'SemanticConversation', name: 'Bhagwan', objectCount: 12 }]),
+      makeNode('node-3', [{ class: 'SemanticConversation', name: 'Bhagwan', objectCount: 10 }]),
+    ];
+    const result = findReplicationImbalances(nodes);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ expectedObjects: 36, actualObjects: 34 });
+    expect(result[0].replicationRatio).toBeCloseTo(34 / 36);
+    // Per-shard breakdown is also exposed on the imbalanced shard itself.
+    expect(result[0].shards[0]).toMatchObject({
+      shardName: 'Bhagwan',
+      expectedObjects: 36,
+      actualObjects: 34,
+    });
+    expect(result[0].shards[0].replicationRatio).toBeCloseTo(34 / 36);
+  });
+
+  it('is computed per shard, not from per-node totals (regression)', () => {
+    // Each node holds 100 objects total, so per-node totals are all equal (would
+    // wrongly report 100% replicated). But each shard's complete replica lives on a
+    // different node, so each shard is only half replicated → 50% overall.
+    const nodes = [
+      makeNode('node-1', [
+        { class: 'Article', name: 'shard-a', objectCount: 100 },
+        { class: 'Article', name: 'shard-b', objectCount: 0 },
+      ]),
+      makeNode('node-2', [
+        { class: 'Article', name: 'shard-a', objectCount: 0 },
+        { class: 'Article', name: 'shard-b', objectCount: 100 },
+      ]),
+    ];
+    const result = findReplicationImbalances(nodes);
+    // shard-a: max 100 × 2 = 200 expected, 100 actual; shard-b: same → 400 / 200.
+    expect(result[0]).toMatchObject({ expectedObjects: 400, actualObjects: 200 });
+    expect(result[0].replicationRatio).toBeCloseTo(0.5);
+  });
+
+  it('counts balanced shards as fully replicated in the collection ratio', () => {
+    // shard-a imbalanced (100/90), shard-b perfectly replicated (50/50).
+    // expected = 100×2 + 50×2 = 300, actual = 190 + 100 = 290.
+    const nodes = [
+      makeNode('node-1', [
+        { class: 'Article', name: 'shard-a', objectCount: 100 },
+        { class: 'Article', name: 'shard-b', objectCount: 50 },
+      ]),
+      makeNode('node-2', [
+        { class: 'Article', name: 'shard-a', objectCount: 90 },
+        { class: 'Article', name: 'shard-b', objectCount: 50 },
+      ]),
+    ];
+    const result = findReplicationImbalances(nodes);
+    expect(result[0].shards).toHaveLength(1); // only shard-a is imbalanced
+    expect(result[0]).toMatchObject({ expectedObjects: 300, actualObjects: 290 });
+    expect(result[0].replicationRatio).toBeCloseTo(290 / 300);
+  });
 });

--- a/src/utils/multiTenancyCheck.ts
+++ b/src/utils/multiTenancyCheck.ts
@@ -63,6 +63,43 @@ export interface EmptyShardEntry {
   shardName: string;
 }
 
+// ─── Empty shard ratio check ─────────────────────────────────────────────────
+
+/**
+ * Severity assigned to a collection based on the fraction of its shards/tenants
+ * that are empty (zero objects).
+ */
+export type EmptyShardRatioSeverity = 'warning' | 'critical';
+
+/**
+ * Configurable thresholds for the empty-shard-ratio check, expressed as a
+ * fraction (0–1) of a collection's shards/tenants that report zero objects.
+ *
+ * - At or above `warning`  → severity "warning".
+ * - At or above `critical` → severity "critical" (takes precedence).
+ *
+ * These are intentionally defined as code-level constants so they can be tuned
+ * in one place without a settings UI. The `critical` value must be ≥ `warning`.
+ */
+export const EMPTY_SHARD_RATIO_THRESHOLDS: { warning: number; critical: number } = {
+  warning: 0.1, // 10% of shards/tenants empty
+  critical: 0.5, // 50% of shards/tenants empty
+};
+
+/** A collection flagged because a significant fraction of its shards are empty. */
+export interface EmptyShardRatioEntry {
+  collectionName: string;
+  /** True when the collection has multi-tenancy enabled (shards are tenants). */
+  isMultiTenant: boolean;
+  /** Number of distinct shards/tenants (replicas collapsed by shard name). */
+  totalShards: number;
+  /** Number of distinct shards/tenants that are empty on every replica. */
+  emptyShards: number;
+  /** emptyShards / totalShards, in the range 0–1. */
+  ratio: number;
+  severity: EmptyShardRatioSeverity;
+}
+
 // ─── Replication imbalance check ─────────────────────────────────────────────
 
 /** Object-count breakdown for one replica of a shard. */
@@ -100,6 +137,10 @@ export interface ChecksResult {
   };
   emptyShards: {
     entries: EmptyShardEntry[];
+    hasIssues: boolean;
+  };
+  emptyShardRatio: {
+    entries: EmptyShardRatioEntry[];
     hasIssues: boolean;
   };
   replicationImbalance: {
@@ -271,6 +312,96 @@ export function findEmptyShards(
       }
     }
   }
+  return result;
+}
+
+/**
+ * Flags collections in which a significant fraction of shards/tenants are empty.
+ *
+ * Unlike {@link findEmptyShards}, this check applies to BOTH single-tenant and
+ * multi-tenant collections — for multi-tenant collections each shard is a tenant,
+ * so this surfaces "mostly-empty" collections (e.g. many provisioned-but-unused
+ * tenants) that the per-shard check intentionally suppresses.
+ *
+ * Replicas are collapsed by shard name: a shard counts as empty only when every
+ * replica reports zero objects (max object count across replicas === 0), so a
+ * replica that is merely lagging is not mistaken for an empty shard — that case
+ * is handled by {@link findReplicationImbalances}.
+ *
+ * A collection is flagged when its empty ratio reaches `thresholds.warning`,
+ * and escalated to "critical" at `thresholds.critical`.
+ *
+ * @param nodes         Verbose cluster node data.
+ * @param mtCollections Names of multi-tenant collections (used only to label
+ *                      each entry's `isMultiTenant` flag — nothing is skipped).
+ * @param thresholds    Warning/critical fractions; defaults to
+ *                      {@link EMPTY_SHARD_RATIO_THRESHOLDS}.
+ * @returns Flagged collections, sorted critical-first then by ratio descending.
+ */
+export function findEmptyShardRatios(
+  nodes: NodeLike[],
+  mtCollections?: Set<string>,
+  thresholds: { warning: number; critical: number } = EMPTY_SHARD_RATIO_THRESHOLDS
+): EmptyShardRatioEntry[] {
+  // collectionName → shardName → max objectCount seen across replicas
+  const byCollection = new Map<string, Map<string, number>>();
+
+  for (const node of nodes) {
+    for (const shard of node.shards ?? []) {
+      let byShardName = byCollection.get(shard.class);
+      if (!byShardName) {
+        byShardName = new Map();
+        byCollection.set(shard.class, byShardName);
+      }
+      const prev = byShardName.get(shard.name) ?? 0;
+      byShardName.set(shard.name, Math.max(prev, shard.objectCount ?? 0));
+    }
+  }
+
+  const result: EmptyShardRatioEntry[] = [];
+
+  for (const [collectionName, byShardName] of byCollection) {
+    const totalShards = byShardName.size;
+    if (totalShards === 0) {
+      continue;
+    }
+    let emptyShards = 0;
+    for (const maxObjects of byShardName.values()) {
+      if (maxObjects === 0) {
+        emptyShards++;
+      }
+    }
+    const ratio = emptyShards / totalShards;
+
+    let severity: EmptyShardRatioSeverity | null = null;
+    if (ratio >= thresholds.critical) {
+      severity = 'critical';
+    } else if (ratio >= thresholds.warning) {
+      severity = 'warning';
+    }
+    if (!severity) {
+      continue;
+    }
+
+    result.push({
+      collectionName,
+      isMultiTenant: mtCollections?.has(collectionName) ?? false,
+      totalShards,
+      emptyShards,
+      ratio,
+      severity,
+    });
+  }
+
+  // Critical entries first; within the same severity, higher ratio first.
+  const severityRank: Record<EmptyShardRatioSeverity, number> = { critical: 0, warning: 1 };
+  result.sort((a, b) => {
+    if (a.severity !== b.severity) {
+      return severityRank[a.severity] - severityRank[b.severity];
+    }
+    return b.ratio - a.ratio;
+  });
+
   return result;
 }
 

--- a/src/utils/multiTenancyCheck.ts
+++ b/src/utils/multiTenancyCheck.ts
@@ -154,6 +154,21 @@ export interface ReplicationImbalanceCollection {
   expectedObjects: number;
   /** Actual object total summed across every shard/replica of this collection. */
   actualObjects: number;
+  /**
+   * Whether async replication is enabled for this collection (from its schema).
+   * `undefined` when the schema was unavailable. When `false`, replica drift will
+   * not self-heal — this is the likely cause of a persistent imbalance.
+   */
+  asyncReplicationEnabled?: boolean;
+}
+
+// ─── Async replication check ─────────────────────────────────────────────────
+
+/** A replicated collection that does not have async replication enabled. */
+export interface AsyncReplicationDisabledEntry {
+  collectionName: string;
+  /** Replication factor (always > 1 for flagged collections). */
+  replicationFactor: number;
 }
 
 // ─── Combined result ──────────────────────────────────────────────────────────
@@ -181,6 +196,10 @@ export interface ChecksResult {
   };
   replicationImbalance: {
     collections: ReplicationImbalanceCollection[];
+    hasIssues: boolean;
+  };
+  asyncReplicationDisabled: {
+    entries: AsyncReplicationDisabledEntry[];
     hasIssues: boolean;
   };
 }
@@ -454,7 +473,54 @@ export function findEmptyShardRatios(
  * Each flagged collection also carries a {@link ReplicationImbalanceCollection.replicationRatio}
  * quantifying how complete replication is across nodes.
  */
-export function findReplicationImbalances(nodes: NodeLike[]): ReplicationImbalanceCollection[] {
+/**
+ * Finds replicated collections (replication factor > 1) that do NOT have async
+ * replication enabled.
+ *
+ * Without async replication, replicas that drift apart (e.g. a write that lands
+ * on a subset of replicas) are never reconciled automatically, so imbalances
+ * become permanent. Non-replicated collections (factor ≤ 1) are ignored — async
+ * replication is meaningless there.
+ *
+ * @param collections All collections for a connection, with their schema.
+ */
+export function findCollectionsWithoutAsyncReplication(
+  collections: CollectionWithSchema[]
+): AsyncReplicationDisabledEntry[] {
+  const result: AsyncReplicationDisabledEntry[] = [];
+  for (const col of collections) {
+    const replication = (
+      col.schema as { replication?: { factor?: number; asyncEnabled?: boolean } }
+    )?.replication;
+    const factor = replication?.factor ?? 1;
+    if (factor > 1 && replication?.asyncEnabled !== true) {
+      result.push({ collectionName: col.label, replicationFactor: factor });
+    }
+  }
+  return result;
+}
+
+/**
+ * Builds a `collectionName → asyncReplicationEnabled` lookup from collection
+ * schemas, for annotating replication-imbalance entries.
+ */
+export function buildAsyncReplicationMap(
+  collections: CollectionWithSchema[]
+): Record<string, boolean> {
+  const map: Record<string, boolean> = {};
+  for (const col of collections) {
+    const replication = (col.schema as { replication?: { asyncEnabled?: boolean } })?.replication;
+    if (replication) {
+      map[col.label] = replication.asyncEnabled === true;
+    }
+  }
+  return map;
+}
+
+export function findReplicationImbalances(
+  nodes: NodeLike[],
+  asyncReplicationByCollection?: Record<string, boolean>
+): ReplicationImbalanceCollection[] {
   // collectionName → shardName → replicas
   const byCollection = new Map<string, Map<string, ShardReplica[]>>();
 
@@ -512,6 +578,7 @@ export function findReplicationImbalances(nodes: NodeLike[]): ReplicationImbalan
         replicationRatio,
         expectedObjects,
         actualObjects,
+        asyncReplicationEnabled: asyncReplicationByCollection?.[collectionName],
       });
     }
   }

--- a/src/utils/multiTenancyCheck.ts
+++ b/src/utils/multiTenancyCheck.ts
@@ -112,12 +112,48 @@ export interface ShardReplica {
 export interface ImbalancedShard {
   shardName: string;
   replicas: ShardReplica[];
+  /**
+   * Per-shard replication completeness in the range 0–1:
+   * `sum(replicas) / (maxReplica × replicaCount)`.
+   *
+   * Example — replicas 12 / 12 / 10 → `34 / (12 × 3)` ≈ 0.94.
+   */
+  replicationRatio: number;
+  /** Fully-replicated expectation for this shard: `maxReplica × replicaCount`. */
+  expectedObjects: number;
+  /** Actual objects stored across this shard's replicas: `sum(replicas)`. */
+  actualObjects: number;
 }
 
 /** A collection that contains at least one imbalanced shard. */
 export interface ReplicationImbalanceCollection {
   collectionName: string;
   shards: ImbalancedShard[];
+  /**
+   * Replication completeness ratio in the range 0–1, computed **per shard**.
+   *
+   * For each shard the most complete replica (the max object count across its
+   * replicas) is taken as the shard's true object count, and the fully-replicated
+   * expectation is `max × replicaCount`. These are summed across every shard of
+   * the collection to give `expectedObjects`, and the actual stored objects across
+   * all replicas are summed to give `actualObjects`. The ratio is
+   * `actualObjects / expectedObjects`.
+   *
+   * Example — a shard with replicas 12 / 12 / 10 contributes `expected = 12 × 3 = 36`
+   * and `actual = 34`, so it is 34/36 ≈ 94% replicated.
+   *
+   * `1` means every replica of every shard is complete; a value below `1` means
+   * some replicas are missing or lagging behind. Computing per shard (rather than
+   * from per-node totals) is essential: a shard whose most complete replica lives
+   * on a different node than another shard's would otherwise be masked.
+   */
+  replicationRatio: number;
+  /**
+   * Fully-replicated expectation: `Σ over shards (maxReplica × replicaCount)`.
+   */
+  expectedObjects: number;
+  /** Actual object total summed across every shard/replica of this collection. */
+  actualObjects: number;
 }
 
 // ─── Combined result ──────────────────────────────────────────────────────────
@@ -414,6 +450,9 @@ export function findEmptyShardRatios(
  *
  * Note: object counts in node status are not immediately synchronised and may
  * be slightly delayed, so small short-lived discrepancies are expected.
+ *
+ * Each flagged collection also carries a {@link ReplicationImbalanceCollection.replicationRatio}
+ * quantifying how complete replication is across nodes.
  */
 export function findReplicationImbalances(nodes: NodeLike[]): ReplicationImbalanceCollection[] {
   // collectionName → shardName → replicas
@@ -436,17 +475,44 @@ export function findReplicationImbalances(nodes: NodeLike[]): ReplicationImbalan
 
   for (const [collectionName, byShardName] of byCollection) {
     const imbalanced: ImbalancedShard[] = [];
+    // Per-shard replication accounting (see ReplicationImbalanceCollection.replicationRatio).
+    let expectedObjects = 0;
+    let actualObjects = 0;
+
     for (const [shardName, replicas] of byShardName) {
+      const counts = replicas.map((r) => r.objectCount ?? 0);
+      const maxReplica = Math.max(...counts);
+      const sumReplicas = counts.reduce((sum, c) => sum + c, 0);
+      // The most complete replica is the shard's true size; every replica should
+      // match it, so a fully-replicated shard holds maxReplica × replicaCount.
+      expectedObjects += maxReplica * replicas.length;
+      actualObjects += sumReplicas;
+
       if (replicas.length < 2) {
-        continue; // single replica — nothing to compare
+        continue; // single replica — nothing to compare for imbalance
       }
-      const first = replicas[0].objectCount;
-      if (replicas.some((r) => r.objectCount !== first)) {
-        imbalanced.push({ shardName, replicas });
+      const first = counts[0];
+      if (counts.some((c) => c !== first)) {
+        const shardExpected = maxReplica * replicas.length;
+        imbalanced.push({
+          shardName,
+          replicas,
+          replicationRatio: shardExpected > 0 ? sumReplicas / shardExpected : 1,
+          expectedObjects: shardExpected,
+          actualObjects: sumReplicas,
+        });
       }
     }
+
     if (imbalanced.length > 0) {
-      result.push({ collectionName, shards: imbalanced });
+      const replicationRatio = expectedObjects > 0 ? actualObjects / expectedObjects : 1;
+      result.push({
+        collectionName,
+        shards: imbalanced,
+        replicationRatio,
+        expectedObjects,
+        actualObjects,
+      });
     }
   }
 

--- a/src/webview/Cluster.css
+++ b/src/webview/Cluster.css
@@ -970,6 +970,18 @@
   gap: 8px;
 }
 
+.checks-async-badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--vscode-charts-green, #89d185);
+  background: color-mix(in srgb, var(--vscode-charts-green, #89d185) 15%, transparent);
+}
+
 .checks-section-desc {
   margin: 0 0 12px 0;
   font-size: 13px;

--- a/src/webview/Cluster.css
+++ b/src/webview/Cluster.css
@@ -924,6 +924,40 @@
   line-height: 1;
 }
 
+.checks-section--critical {
+  border-left: 3px solid var(--vscode-editorError-foreground, #f14c4c);
+  padding-left: 12px;
+}
+
+.checks-section--critical .checks-section-title {
+  color: var(--vscode-editorError-foreground, #f14c4c);
+}
+
+.checks-section-critical-icon {
+  font-size: 15px;
+  line-height: 1;
+}
+
+.checks-severity-badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.checks-severity-warning {
+  color: var(--vscode-editorWarning-foreground, #cca700);
+  background: color-mix(in srgb, var(--vscode-editorWarning-foreground, #cca700) 15%, transparent);
+}
+
+.checks-severity-critical {
+  color: var(--vscode-editorError-foreground, #f14c4c);
+  background: color-mix(in srgb, var(--vscode-editorError-foreground, #f14c4c) 15%, transparent);
+}
+
 .checks-section-desc {
   margin: 0 0 12px 0;
   font-size: 13px;

--- a/src/webview/Cluster.css
+++ b/src/webview/Cluster.css
@@ -958,6 +958,18 @@
   background: color-mix(in srgb, var(--vscode-editorError-foreground, #f14c4c) 15%, transparent);
 }
 
+.checks-ratio-detail {
+  margin: 4px 0 8px 0;
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.checks-imbalance-shard-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .checks-section-desc {
   margin: 0 0 12px 0;
   font-size: 13px;

--- a/src/webview/ClusterPanel.tsx
+++ b/src/webview/ClusterPanel.tsx
@@ -84,6 +84,17 @@ interface EmptyShardEntry {
   shardName: string;
 }
 
+type EmptyShardRatioSeverity = 'warning' | 'critical';
+
+interface EmptyShardRatioEntry {
+  collectionName: string;
+  isMultiTenant: boolean;
+  totalShards: number;
+  emptyShards: number;
+  ratio: number;
+  severity: EmptyShardRatioSeverity;
+}
+
 interface ShardReplica {
   nodeName: string;
   objectCount: number;
@@ -109,6 +120,10 @@ interface ChecksResult {
   };
   emptyShards?: {
     entries: EmptyShardEntry[];
+    hasIssues: boolean;
+  };
+  emptyShardRatio?: {
+    entries: EmptyShardRatioEntry[];
     hasIssues: boolean;
   };
   replicationImbalance?: {
@@ -147,6 +162,7 @@ function openExternalLink(url: string) {
 function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
   const groups = checksResult?.multiTenancy.groups ?? [];
   const emptyShardEntries = checksResult?.emptyShards?.entries ?? [];
+  const emptyShardRatioEntries = checksResult?.emptyShardRatio?.entries ?? [];
   const replicationCollections = checksResult?.replicationImbalance?.collections ?? [];
   const timestamp = checksResult?.timestamp
     ? new Date(checksResult.timestamp).toLocaleString()
@@ -304,6 +320,82 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
               </>
             )}
           </div>
+
+          {/* ── Empty Shard Ratio ─────────────────────────────────────── */}
+          {(() => {
+            const hasCritical = emptyShardRatioEntries.some((e) => e.severity === 'critical');
+            const hasWarning = emptyShardRatioEntries.length > 0;
+            const sectionSeverityClass = hasCritical
+              ? ' checks-section--critical'
+              : hasWarning
+                ? ' checks-section--warning'
+                : '';
+            return (
+              <div className={`checks-section${sectionSeverityClass}`}>
+                <h3 className="checks-section-title">
+                  {hasCritical ? (
+                    <span className="checks-section-critical-icon">⛔</span>
+                  ) : hasWarning ? (
+                    <span className="checks-section-warning-icon">⚠</span>
+                  ) : null}
+                  Empty Shard Ratio
+                </h3>
+                {emptyShardRatioEntries.length === 0 ? (
+                  <div className="checks-ok">
+                    <span className="checks-ok-icon">✓</span>
+                    No collections exceed the empty-shard thresholds.
+                  </div>
+                ) : (
+                  <>
+                    <p className="checks-section-desc">
+                      The following collections have a high proportion of empty shards/tenants. A
+                      collection is flagged as <strong>warning</strong> when at least 10% of its
+                      shards are empty, and <strong>critical</strong> when at least 50% are empty.
+                      Many empty shards/tenants add overhead — consider removing unused tenants or
+                      collections.
+                    </p>
+                    <div className="checks-info-callout">
+                      <span className="checks-info-callout-icon">ℹ️</span>
+                      Object counts reported by node status are not immediately synchronized and may
+                      be slightly delayed — only act on shards that consistently show zero over
+                      time.
+                    </div>
+                    <table className="checks-table">
+                      <thead>
+                        <tr>
+                          <th>Collection</th>
+                          <th>Type</th>
+                          <th>Empty</th>
+                          <th>Ratio</th>
+                          <th>Severity</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {emptyShardRatioEntries.map((entry) => (
+                          <tr key={entry.collectionName}>
+                            <td className="checks-col-name">{entry.collectionName}</td>
+                            <td>{entry.isMultiTenant ? 'Multi-tenant' : 'Single-tenant'}</td>
+                            <td>
+                              {entry.emptyShards.toLocaleString()} /{' '}
+                              {entry.totalShards.toLocaleString()}
+                            </td>
+                            <td>{Math.round(entry.ratio * 100)}%</td>
+                            <td>
+                              <span
+                                className={`checks-severity-badge checks-severity-${entry.severity}`}
+                              >
+                                {entry.severity === 'critical' ? 'Critical' : 'Warning'}
+                              </span>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </>
+                )}
+              </div>
+            );
+          })()}
 
           {/* ── Replication Imbalance ─────────────────────────────────── */}
           <div

--- a/src/webview/ClusterPanel.tsx
+++ b/src/webview/ClusterPanel.tsx
@@ -116,6 +116,13 @@ interface ReplicationImbalanceCollection {
   replicationRatio?: number;
   expectedObjects?: number;
   actualObjects?: number;
+  /** Whether async replication is enabled for this collection. */
+  asyncReplicationEnabled?: boolean;
+}
+
+interface AsyncReplicationDisabledEntry {
+  collectionName: string;
+  replicationFactor: number;
 }
 
 interface ChecksResult {
@@ -136,6 +143,10 @@ interface ChecksResult {
   };
   replicationImbalance?: {
     collections: ReplicationImbalanceCollection[];
+    hasIssues: boolean;
+  };
+  asyncReplicationDisabled?: {
+    entries: AsyncReplicationDisabledEntry[];
     hasIssues: boolean;
   };
 }
@@ -192,6 +203,7 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
   const emptyShardEntries = checksResult?.emptyShards?.entries ?? [];
   const emptyShardRatioEntries = checksResult?.emptyShardRatio?.entries ?? [];
   const replicationCollections = checksResult?.replicationImbalance?.collections ?? [];
+  const asyncDisabledEntries = checksResult?.asyncReplicationDisabled?.entries ?? [];
   const timestamp = checksResult?.timestamp
     ? new Date(checksResult.timestamp).toLocaleString()
     : null;
@@ -494,6 +506,17 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
                             {formatReplicationPct(ratio)} replicated
                           </span>
                         )}
+                        {col.asyncReplicationEnabled === false && (
+                          <span
+                            className="checks-severity-badge checks-severity-warning"
+                            title="Async replication is disabled — replica drift will not self-heal"
+                          >
+                            Async replication off
+                          </span>
+                        )}
+                        {col.asyncReplicationEnabled === true && (
+                          <span className="checks-async-badge">Async replication on</span>
+                        )}
                         <span className="checks-group-count">
                           {col.shards.length} imbalanced shard{col.shards.length !== 1 ? 's' : ''}
                         </span>
@@ -539,6 +562,58 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
                     </div>
                   );
                 })}
+              </>
+            )}
+          </div>
+
+          {/* ── Async Replication Disabled ────────────────────────────── */}
+          <div
+            className={`checks-section${asyncDisabledEntries.length > 0 ? ' checks-section--warning' : ''}`}
+          >
+            <h3 className="checks-section-title">
+              {asyncDisabledEntries.length > 0 && (
+                <span className="checks-section-warning-icon">⚠</span>
+              )}
+              Async Replication Disabled
+            </h3>
+            {asyncDisabledEntries.length === 0 ? (
+              <div className="checks-ok">
+                <span className="checks-ok-icon">✓</span>
+                All replicated collections have async replication enabled.
+              </div>
+            ) : (
+              <>
+                <p className="checks-section-desc">
+                  The following replicated collections do not have async replication enabled.
+                  Without it, replicas that drift apart are never reconciled automatically, so
+                  imbalances become permanent.{' '}
+                  <a
+                    href="https://docs.weaviate.io/deploy/configuration/async-rep"
+                    className="checks-link"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      openExternalLink('https://docs.weaviate.io/deploy/configuration/async-rep');
+                    }}
+                  >
+                    Enable async replication ↗
+                  </a>
+                </p>
+                <table className="checks-table">
+                  <thead>
+                    <tr>
+                      <th>Collection</th>
+                      <th>Replication factor</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {asyncDisabledEntries.map((entry) => (
+                      <tr key={entry.collectionName}>
+                        <td className="checks-col-name">{entry.collectionName}</td>
+                        <td>{entry.replicationFactor}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </>
             )}
           </div>

--- a/src/webview/ClusterPanel.tsx
+++ b/src/webview/ClusterPanel.tsx
@@ -103,11 +103,19 @@ interface ShardReplica {
 interface ImbalancedShard {
   shardName: string;
   replicas: ShardReplica[];
+  /** Per-shard replication ratio (0–1). Optional for backward compat. */
+  replicationRatio?: number;
+  expectedObjects?: number;
+  actualObjects?: number;
 }
 
 interface ReplicationImbalanceCollection {
   collectionName: string;
   shards: ImbalancedShard[];
+  /** Replication completeness ratio (0–1). Optional for backward compat. */
+  replicationRatio?: number;
+  expectedObjects?: number;
+  actualObjects?: number;
 }
 
 interface ChecksResult {
@@ -157,6 +165,26 @@ function SpinnerIcon() {
 
 function openExternalLink(url: string) {
   vscode.postMessage({ command: 'openExternal', url });
+}
+
+/**
+ * Formats a replication ratio (0–1) as a percentage string.
+ *
+ * A ratio that is not exactly 1 is never rounded up to "100%" — that would
+ * contradict the imbalanced shards listed alongside it. Values above 99% show
+ * one floored decimal (e.g. 99.7%) so a barely-incomplete collection never
+ * reads as fully replicated.
+ */
+function formatReplicationPct(ratio: number): string {
+  if (ratio >= 1) {
+    return '100%';
+  }
+  const pct = ratio * 100;
+  if (pct > 99) {
+    // Floor to one decimal so e.g. 99.96% shows 99.9%, never 100%.
+    return `${(Math.floor(pct * 10) / 10).toFixed(1)}%`;
+  }
+  return `${Math.floor(pct)}%`;
 }
 
 function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
@@ -266,19 +294,22 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
               {emptyShardEntries.length > 0 && (
                 <span className="checks-section-warning-icon">⚠</span>
               )}
-              Empty Shards
+              Empty Shards (Single-Tenant Collections)
             </h3>
             {emptyShardEntries.length === 0 ? (
               <div className="checks-ok">
                 <span className="checks-ok-icon">✓</span>
-                No empty shards detected across the cluster.
+                No empty shards detected in single-tenant collections.
               </div>
             ) : (
               <>
                 <p className="checks-section-desc">
-                  The following shards contain zero objects. Empty shards may indicate incomplete
-                  data ingestion or collections that are no longer in use. Even without any objects,
-                  an empty collection adds overhead to your cluster — consider deleting collections
+                  This check runs only against <strong>single-tenant collections</strong> —
+                  multi-tenant collections are evaluated by the <em>Empty Shard Ratio</em> check
+                  below, since individual tenant shards start empty by design. The following
+                  single-tenant shards contain zero objects, which may indicate incomplete data
+                  ingestion or collections that are no longer in use. Even without any objects, an
+                  empty collection adds overhead to your cluster — consider deleting collections
                   that are no longer needed.
                 </p>
                 <div className="checks-info-callout">
@@ -429,6 +460,14 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
                     Enable async replication ↗
                   </a>
                 </p>
+                <p className="checks-section-desc">
+                  The <strong>replication ratio</strong> estimates how complete replication is,
+                  computed per shard: each shard's most complete replica is taken as its true size,
+                  so a fully-replicated shard should hold that size × the replica count (e.g. 12 × 3
+                  = 36). These are summed across the collection and compared to the objects actually
+                  stored. <strong>100%</strong> means every replica of every shard is complete;
+                  lower values mean some replicas are missing or lagging.
+                </p>
                 <div className="checks-info-callout">
                   <span className="checks-info-callout-icon">ℹ️</span>
                   If you are actively ingesting data, this is normal — replicas sync asynchronously
@@ -439,31 +478,67 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
                   Object counts reported by node status are not immediately synchronized and may be
                   slightly delayed — only act on imbalances that persist over time.
                 </div>
-                {replicationCollections.map((col) => (
-                  <div key={col.collectionName} className="checks-group">
-                    <div className="checks-group-header">
-                      <span className="checks-group-label">{col.collectionName}</span>
-                      <span className="checks-group-count">
-                        {col.shards.length} imbalanced shard{col.shards.length !== 1 ? 's' : ''}
-                      </span>
-                    </div>
-                    {col.shards.map((shard) => (
-                      <div key={shard.shardName} className="checks-imbalance-shard">
-                        <span className="checks-shard-name">{shard.shardName}</span>
-                        <ul className="checks-replica-list">
-                          {shard.replicas.map((replica) => (
-                            <li key={replica.nodeName} className="checks-replica-item">
-                              <span className="checks-replica-node">{replica.nodeName}</span>
-                              <span className="checks-replica-count">
-                                {replica.objectCount.toLocaleString()} objects
-                              </span>
-                            </li>
-                          ))}
-                        </ul>
+                {replicationCollections.map((col) => {
+                  const ratio = col.replicationRatio;
+                  // Below 50% replicated → critical, otherwise warning.
+                  const ratioSeverity =
+                    typeof ratio === 'number' && ratio < 0.5 ? 'critical' : 'warning';
+                  return (
+                    <div key={col.collectionName} className="checks-group">
+                      <div className="checks-group-header">
+                        <span className="checks-group-label">{col.collectionName}</span>
+                        {typeof ratio === 'number' && (
+                          <span
+                            className={`checks-severity-badge checks-severity-${ratioSeverity}`}
+                          >
+                            {formatReplicationPct(ratio)} replicated
+                          </span>
+                        )}
+                        <span className="checks-group-count">
+                          {col.shards.length} imbalanced shard{col.shards.length !== 1 ? 's' : ''}
+                        </span>
                       </div>
-                    ))}
-                  </div>
-                ))}
+                      {typeof ratio === 'number' && (
+                        <p className="checks-ratio-detail">
+                          Actual {(col.actualObjects ?? 0).toLocaleString()} objects vs{' '}
+                          {(col.expectedObjects ?? 0).toLocaleString()} expected if every replica of
+                          every shard were complete.
+                        </p>
+                      )}
+                      {col.shards.map((shard) => {
+                        const shardRatio = shard.replicationRatio;
+                        const shardSeverity =
+                          typeof shardRatio === 'number' && shardRatio < 0.5
+                            ? 'critical'
+                            : 'warning';
+                        return (
+                          <div key={shard.shardName} className="checks-imbalance-shard">
+                            <div className="checks-imbalance-shard-header">
+                              <span className="checks-shard-name">{shard.shardName}</span>
+                              {typeof shardRatio === 'number' && (
+                                <span
+                                  className={`checks-severity-badge checks-severity-${shardSeverity}`}
+                                >
+                                  {formatReplicationPct(shardRatio as number)} replicated
+                                </span>
+                              )}
+                            </div>
+                            <ul className="checks-replica-list">
+                              {shard.replicas.map((replica) => (
+                                <li key={replica.nodeName} className="checks-replica-item">
+                                  <span className="checks-replica-node">{replica.nodeName}</span>
+                                  <span className="checks-replica-count">
+                                    {replica.objectCount.toLocaleString()} objects
+                                  </span>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
               </>
             )}
           </div>


### PR DESCRIPTION

## Cluster Checks: empty-shard ratio & replication ratio

- Empty Shard Ratio check — flags collections (single- and multi-tenant) where too many shards/tenants are empty: ≥10% → Warning, ≥50% → Critical (configurable in code).
- Empty Shards renamed to "Empty Shards (Single-Tenant Collections)" to make its scope explicit.
- Replication ratio — per-shard and collection-wide replication completeness (e.g. 12/12/10 → 94%), shown as a badge per imbalanced shard and collection.
- Race-condition fix — on large clusters the verbose node fetch finishes after collections, so checks ran against empty node data and never re-ran. fetchNodes now recomputes checks once shards arrive, and recomputes are serialized per connection so the late, complete run wins.
- Replication Async disabled is also a new check

<img width="1157" height="913" alt="image" src="https://github.com/user-attachments/assets/1df56c9d-037d-44a7-828c-85f676eb4b27" />
