### PR TITLE
fix: register weaviate.cancelBackup command

### DIFF
--- a/src/__tests__/readonly-command-guards.test.ts
+++ b/src/__tests__/readonly-command-guards.test.ts
@@ -97,10 +97,13 @@ describe('readonly guard — RBAC write operations', () => {
 // ---------------------------------------------------------------------------
 
 describe('readonly guard — backup write operations', () => {
-  describe.each([['weaviate.createBackup'], ['weaviate.restoreBackup']])('%s', (_command) => {
-    itBlocksWhenReadOnly('ProductionCluster');
-    itAllowsWhenNotReadOnly();
-  });
+  describe.each([['weaviate.createBackup'], ['weaviate.restoreBackup'], ['weaviate.cancelBackup']])(
+    '%s',
+    (_command) => {
+      itBlocksWhenReadOnly('ProductionCluster');
+      itAllowsWhenNotReadOnly();
+    }
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2614,6 +2614,67 @@ export function activate(context: vscode.ExtensionContext) {
       }
     }),
 
+    // Cancel an in-progress backup
+    vscode.commands.registerCommand('weaviate.cancelBackup', async (item) => {
+      if (!item?.connectionId || !item?.itemId) {
+        vscode.window.showErrorMessage('Missing connection or backup information');
+        return;
+      }
+      {
+        const conn = weaviateTreeDataProvider
+          .getConnectionManager()
+          .getConnection(item.connectionId);
+        if (conn?.readOnly === true) {
+          vscode.window.showErrorMessage(`Connection "${conn.name}" is in read-only mode`);
+          return;
+        }
+      }
+
+      try {
+        const connectionManager = weaviateTreeDataProvider.getConnectionManager();
+        const client = await connectionManager.getClient(item.connectionId);
+
+        if (!client) {
+          vscode.window.showErrorMessage('Failed to get Weaviate client');
+          return;
+        }
+
+        // Get backup details from cache to resolve the backend
+        const backupDetails = weaviateTreeDataProvider.getBackupDetails(
+          item.connectionId,
+          item.itemId
+        );
+
+        if (!backupDetails) {
+          vscode.window.showErrorMessage('Backup details not found');
+          return;
+        }
+
+        const confirm = await vscode.window.showWarningMessage(
+          `Cancel backup "${item.itemId}"?`,
+          { modal: true },
+          'Cancel Backup'
+        );
+        if (confirm !== 'Cancel Backup') {
+          return;
+        }
+
+        await client.backup.cancel({
+          backupId: item.itemId,
+          backend: backupDetails.backend,
+        });
+
+        vscode.window.showInformationMessage(`Backup "${item.itemId}" cancellation requested.`);
+
+        // Refresh the tree view backups
+        await weaviateTreeDataProvider.refreshBackups(item.connectionId);
+      } catch (error) {
+        vscode.window.showErrorMessage(
+          `Failed to cancel backup: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }),
+
     // Refresh collections command
     vscode.commands.registerCommand('weaviate.refreshCollections', async (item) => {
       if (!item?.connectionId) {


### PR DESCRIPTION
## Problem

Invoking **Cancel Backup** on an in-progress backup in the tree view failed with:

> command 'weaviate.cancelBackup' not found

`weaviate.cancelBackup` was declared in `package.json` — both as a command and in the in-progress backup tree-view context menus (`viewItem == weaviateBackupInProgress`) — but was **never registered** via `vscode.commands.registerCommand`. Only a webview message handler for the `cancelBackup` message existed, so the tree-view command had no implementation to dispatch to.

## Fix

Register `weaviate.cancelBackup` alongside the other backup commands. The handler:

- Validates `connectionId` + `itemId` and enforces the same read-only connection guard used by other write commands.
- Resolves the `backend` from the cached backup details (`getBackupDetails`), since the tree item carries the backup id but not the backend.
- Confirms via a modal dialog, calls `client.backup.cancel({ backupId, backend })`, and refreshes the backups tree.

Also adds `weaviate.cancelBackup` to the read-only guard test coverage.

## Note

`weaviate.retryBackup` is in the **same situation** (declared in the failed-backup context menu but not registered) and will throw the same error — left out of this PR to keep it focused, happy to follow up.