### PR TITLE
Feat/mt management

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,11 @@
         "icon": "$(arrow-swap)"
       },
       {
+        "command": "weaviate.manageTenants",
+        "title": "Manage Tenants",
+        "icon": "$(list-selection)"
+      },
+      {
         "command": "weaviate.refreshBackups",
         "title": "Refresh Backups",
         "icon": "$(refresh)"
@@ -635,6 +640,16 @@
           "command": "weaviate.editMultiTenancy",
           "when": "view == weaviateConnectionsView && (viewItem == weaviateMultiTenancy || viewItem == weaviateMultiTenancyWarning)",
           "group": "1_modification@1"
+        },
+        {
+          "command": "weaviate.manageTenants",
+          "when": "view == weaviateConnectionsView && (viewItem == weaviateMultiTenancy || viewItem == weaviateMultiTenancyWarning)",
+          "group": "inline@2"
+        },
+        {
+          "command": "weaviate.manageTenants",
+          "when": "view == weaviateConnectionsView && (viewItem == weaviateMultiTenancy || viewItem == weaviateMultiTenancyWarning)",
+          "group": "1_modification@2"
         },
         {
           "command": "weaviate.toggleAutoTenantFlag",

--- a/package.json
+++ b/package.json
@@ -207,6 +207,21 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "weaviate.runChecks",
+        "title": "Run Checks",
+        "icon": "$(checklist)"
+      },
+      {
+        "command": "weaviate.editMultiTenancy",
+        "title": "Edit Multi-Tenancy",
+        "icon": "$(edit)"
+      },
+      {
+        "command": "weaviate.toggleAutoTenantFlag",
+        "title": "Toggle",
+        "icon": "$(arrow-swap)"
+      },
+      {
         "command": "weaviate.refreshBackups",
         "title": "Refresh Backups",
         "icon": "$(refresh)"
@@ -597,9 +612,39 @@
           "group": "inline@1"
         },
         {
+          "command": "weaviate.runChecks",
+          "when": "view == weaviateConnectionsView && viewItem == weaviateConnectionActive",
+          "group": "inline@2"
+        },
+        {
           "command": "weaviate.refreshConnection",
           "when": "view == weaviateConnectionsView && (viewItem == weaviateConnectionActive || viewItem == weaviateServerInfo || viewItem == weaviateClusterHealth)",
           "group": "navigation@1"
+        },
+        {
+          "command": "weaviate.runChecks",
+          "when": "view == weaviateConnectionsView && (viewItem == weaviateConnectionActive || viewItem == weaviateServerInfo || viewItem == weaviateClusterHealth)",
+          "group": "navigation@2"
+        },
+        {
+          "command": "weaviate.editMultiTenancy",
+          "when": "view == weaviateConnectionsView && (viewItem == weaviateMultiTenancy || viewItem == weaviateMultiTenancyWarning)",
+          "group": "inline@1"
+        },
+        {
+          "command": "weaviate.editMultiTenancy",
+          "when": "view == weaviateConnectionsView && (viewItem == weaviateMultiTenancy || viewItem == weaviateMultiTenancyWarning)",
+          "group": "1_modification@1"
+        },
+        {
+          "command": "weaviate.toggleAutoTenantFlag",
+          "when": "view == weaviateConnectionsView && (viewItem == weaviateAutoTenantFlagOn || viewItem == weaviateAutoTenantFlagOff)",
+          "group": "inline@1"
+        },
+        {
+          "command": "weaviate.toggleAutoTenantFlag",
+          "when": "view == weaviateConnectionsView && (viewItem == weaviateAutoTenantFlagOn || viewItem == weaviateAutoTenantFlagOff)",
+          "group": "1_modification@1"
         },
         {
           "command": "weaviate.refreshStatistics",

--- a/sandbox/populate_mt_empty_tenants.py
+++ b/sandbox/populate_mt_empty_tenants.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Weaviate Studio Sandbox – Multi-Tenant "Empty Tenants" Test Fixture
+
+Creates a single multi-tenant collection and populates it with a large number of
+tenants, most of which are intentionally left EMPTY. This is the fixture for
+manually testing the two multi-tenancy features in Weaviate Studio:
+
+  1. "Edit multi-tenancy options" — the collection is created with
+     autoTenantCreation and autoTenantActivation set to False, so it shows up in
+     the "auto-tenant flags off" check and can be toggled from the tree.
+
+  2. "Delete empty tenants to free memory" — every tenant is created ACTIVE
+     (loaded into memory), but only a fraction receive objects. The rest are
+     empty ACTIVE tenants, which is exactly what the empty-tenants check flags.
+
+By default: 1000 tenants, 20% filled with 100 objects each, 80% left empty.
+
+The collection uses `Vectorizer.none()` so no embedding sidecar is required and
+inserts are fast (self-provided/no vectors — fine for this structural fixture).
+
+Usage:
+    python3 populate_mt_empty_tenants.py
+    python3 populate_mt_empty_tenants.py --tenants 1000 --fill-ratio 0.2 \
+        --objects-per-tenant 100 --collection MultiTenantDocs
+    python3 populate_mt_empty_tenants.py --drop           # delete the collection
+    python3 populate_mt_empty_tenants.py --verify-only    # just report counts
+
+Requires the sandbox Weaviate running (see docker-compose.yml in this folder):
+    docker compose up -d
+"""
+
+import argparse
+import os
+import sys
+import time
+
+import weaviate
+import weaviate.classes as wvc
+from weaviate.classes.config import Configure, Property, DataType
+from weaviate.classes.tenants import Tenant
+
+# ──────────────────────────────────────────────────────────────
+# Connection — matches populate.py / docker-compose.yml
+# ──────────────────────────────────────────────────────────────
+WEAVIATE_HOST = os.environ.get("WEAVIATE_HOST", "localhost")
+WEAVIATE_PORT = int(os.environ.get("WEAVIATE_PORT", "8080"))
+# Optional — leave unset for a server with anonymous access enabled. Sending an
+# Authorization header to an anonymous server returns 401, so we only pass
+# credentials when an API key is explicitly provided.
+WEAVIATE_API_KEY = os.environ.get("WEAVIATE_API_KEY", "")
+
+TENANT_CHUNK = 100   # tenants created per API call
+INSERT_CHUNK = 200   # objects inserted per insert_many call
+
+
+def connect_to_weaviate():
+    """Connect to the local sandbox Weaviate, waiting for readiness."""
+    client = weaviate.connect_to_local(
+        host=WEAVIATE_HOST,
+        port=WEAVIATE_PORT,
+        auth_credentials=(
+            weaviate.auth.AuthApiKey(WEAVIATE_API_KEY) if WEAVIATE_API_KEY else None
+        ),
+        skip_init_checks=True,
+        additional_config=weaviate.config.AdditionalConfig(
+            timeout=weaviate.config.Timeout(init=30, query=60, insert=180)
+        ),
+    )
+    for attempt in range(10):
+        try:
+            client.collections.list_all()
+            print("✓ Connected to Weaviate")
+            return client
+        except Exception:
+            print(f"  waiting for Weaviate… ({attempt + 1}/10)")
+            time.sleep(2)
+    print("✗ Weaviate not ready — is `docker compose up -d` running?")
+    client.close()
+    return None
+
+
+def create_collection(client, name):
+    """(Re)create the multi-tenant collection with auto-tenant flags OFF."""
+    if client.collections.exists(name):
+        print(f"• Collection '{name}' already exists — deleting it first")
+        client.collections.delete(name)
+
+    client.collections.create(
+        name=name,
+        description="Multi-tenant fixture with many empty ACTIVE tenants",
+        # auto_tenant_* intentionally OFF so the collection is flagged by the
+        # "auto-tenant flags off" check and tenants must be created explicitly.
+        multi_tenancy_config=Configure.multi_tenancy(
+            enabled=True,
+            auto_tenant_creation=False,
+            auto_tenant_activation=False,
+        ),
+        vector_config=Configure.Vectors.self_provided(),
+        properties=[
+            Property(name="title", data_type=DataType.TEXT),
+            Property(name="body", data_type=DataType.TEXT),
+        ],
+    )
+    print(f"✓ Created multi-tenant collection '{name}' (auto-tenant flags OFF)")
+
+
+def create_tenants(collection, count):
+    """Create `count` ACTIVE tenants named tenant-0000 … tenant-NNNN."""
+    names = [f"tenant-{i:04d}" for i in range(count)]
+    created = 0
+    for start in range(0, count, TENANT_CHUNK):
+        chunk = names[start : start + TENANT_CHUNK]
+        collection.tenants.create([Tenant(name=n) for n in chunk])
+        created += len(chunk)
+        print(f"  tenants: {created}/{count}", end="\r", flush=True)
+    print(f"\n✓ Created {created} ACTIVE tenants")
+    return names
+
+
+def populate_tenants(collection, tenant_names, fill_ratio, objects_per_tenant):
+    """Insert objects into the first `fill_ratio` share of tenants; leave the rest empty.
+
+    Selection is deterministic (every Nth tenant) so re-runs are reproducible.
+    """
+    total = len(tenant_names)
+    fill_every = max(1, round(1 / fill_ratio)) if fill_ratio > 0 else 0
+    filled = 0
+    empty = 0
+
+    for idx, tenant_name in enumerate(tenant_names):
+        should_fill = fill_every and (idx % fill_every == 0)
+        if not should_fill:
+            empty += 1
+            continue
+
+        tenant = collection.with_tenant(tenant_name)
+        objs = [
+            {"title": f"{tenant_name} doc {j}", "body": f"Body text for object {j}"}
+            for j in range(objects_per_tenant)
+        ]
+        for start in range(0, len(objs), INSERT_CHUNK):
+            tenant.data.insert_many(objs[start : start + INSERT_CHUNK])
+        filled += 1
+        print(
+            f"  filled tenants: {filled} (empty so far: {empty})",
+            end="\r",
+            flush=True,
+        )
+
+    print(
+        f"\n✓ Populated {filled} tenants with {objects_per_tenant} objects each; "
+        f"left {empty} tenants empty"
+    )
+    return filled, empty
+
+
+def verify(collection, name):
+    """Report tenant count and how many tenants are empty."""
+    tenants = collection.tenants.get()
+    empty = 0
+    filled = 0
+    for tenant_name in tenants:
+        count = collection.with_tenant(tenant_name).aggregate.over_all(
+            total_count=True
+        ).total_count
+        if count == 0:
+            empty += 1
+        else:
+            filled += 1
+    print(f"\nCollection '{name}':")
+    print(f"  tenants total : {len(tenants)}")
+    print(f"  with objects  : {filled}")
+    print(f"  empty         : {empty}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--collection", default="MultiTenantDocs")
+    parser.add_argument("--tenants", type=int, default=1000)
+    parser.add_argument("--fill-ratio", type=float, default=0.2,
+                        help="Fraction of tenants that receive objects (0–1)")
+    parser.add_argument("--objects-per-tenant", type=int, default=100)
+    parser.add_argument("--drop", action="store_true",
+                        help="Delete the collection and exit")
+    parser.add_argument("--verify-only", action="store_true",
+                        help="Only report tenant/object counts")
+    args = parser.parse_args()
+
+    client = connect_to_weaviate()
+    if client is None:
+        sys.exit(1)
+
+    try:
+        if args.drop:
+            if client.collections.exists(args.collection):
+                client.collections.delete(args.collection)
+                print(f"✓ Deleted collection '{args.collection}'")
+            else:
+                print(f"• Collection '{args.collection}' does not exist")
+            return
+
+        if args.verify_only:
+            if not client.collections.exists(args.collection):
+                print(f"✗ Collection '{args.collection}' does not exist")
+                sys.exit(1)
+            verify(client.collections.get(args.collection), args.collection)
+            return
+
+        create_collection(client, args.collection)
+        collection = client.collections.get(args.collection)
+        tenant_names = create_tenants(collection, args.tenants)
+        populate_tenants(
+            collection, tenant_names, args.fill_ratio, args.objects_per_tenant
+        )
+        verify(collection, args.collection)
+        print("\n✓ Done. Open Weaviate Studio and run the cluster checks.")
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
+++ b/src/WeaviateTreeDataProvider/WeaviateTreeDataProvider.ts
@@ -25,6 +25,8 @@ import {
   findEmptyShardRatios,
   findReplicationImbalances,
   findCollectionsWithoutAsyncReplication,
+  findAutoTenantConfigIssues,
+  findEmptyTenants,
   buildAsyncReplicationMap,
   computeCandidatesDismissKey,
   MtCandidateGroup,
@@ -1514,6 +1516,17 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       const vectorizers = collection.vectorizers;
       let configured_vectors_count = vectorizers ? Object.keys(vectorizers).length : 0;
       const multi_tenancy_enabled = collection?.multiTenancy.enabled;
+      // Warn when auto-tenant creation/activation are not both enabled — these are
+      // a common source of "tenant not found"/"tenant inactive" errors.
+      const autoTenantFlagsOff =
+        multi_tenancy_enabled === true &&
+        (collection?.multiTenancy?.autoTenantCreation !== true ||
+          collection?.multiTenancy?.autoTenantActivation !== true);
+      const multiTenancyContextValue = multi_tenancy_enabled
+        ? autoTenantFlagsOff
+          ? 'weaviateMultiTenancyWarning'
+          : 'weaviateMultiTenancy'
+        : 'weaviateMultiTenancyDisabled';
       const items = [
         new WeaviateTreeItem(
           `Properties (${property_count})`,
@@ -1600,7 +1613,12 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
           element.connectionId,
           element.label,
           'multiTenancy',
-          new vscode.ThemeIcon('organization')
+          new vscode.ThemeIcon(
+            'organization',
+            autoTenantFlagsOff ? new vscode.ThemeColor('list.warningForeground') : undefined
+          ),
+          multiTenancyContextValue,
+          autoTenantFlagsOff ? 'auto-tenant off' : undefined
         ),
         new WeaviateTreeItem(
           'Statistics',
@@ -2654,7 +2672,22 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
       const schema = collection?.schema;
       // Multi-tenancy
       if (schema?.multiTenancy) {
+        const toggleableFlags = new Set(['autoTenantCreation', 'autoTenantActivation']);
         for (const [key, value] of Object.entries(schema.multiTenancy)) {
+          // The two auto-tenant flags get a distinct context value so a right-click
+          // "Toggle" action can flip them directly from the tree.
+          const isToggleable = toggleableFlags.has(key);
+          const contextValue = isToggleable
+            ? value === true
+              ? 'weaviateAutoTenantFlagOn'
+              : 'weaviateAutoTenantFlagOff'
+            : 'MultiTenancy';
+          const icon = isToggleable
+            ? new vscode.ThemeIcon(
+                value === true ? 'check' : 'circle-slash',
+                value === true ? undefined : new vscode.ThemeColor('list.warningForeground')
+              )
+            : new vscode.ThemeIcon('organization');
           MultiTenancyItems.push(
             new WeaviateTreeItem(
               `${key}: ${value}`,
@@ -2663,8 +2696,8 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
               element.connectionId,
               element.collectionName,
               key,
-              new vscode.ThemeIcon('organization'),
-              'MultiTenancy'
+              icon,
+              contextValue
             )
           );
         }
@@ -3556,24 +3589,37 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
     const asyncReplicationByCollection = buildAsyncReplicationMap(collections);
 
     // All checks are independent — run them in parallel.
-    const [groups, emptyShardEntries, emptyShardRatios, replicationImbalances, asyncDisabled] =
-      await Promise.all([
-        Promise.resolve(findMultiTenantCandidates(collections, objectCounts)),
-        Promise.resolve(findEmptyShards(nodes as any, mtCollections)),
-        Promise.resolve(findEmptyShardRatios(nodes as any, mtCollections)),
-        Promise.resolve(findReplicationImbalances(nodes as any, asyncReplicationByCollection)),
-        Promise.resolve(findCollectionsWithoutAsyncReplication(collections)),
-      ]);
+    const [
+      groups,
+      autoTenantIssues,
+      emptyTenants,
+      emptyShardEntries,
+      emptyShardRatios,
+      replicationImbalances,
+      asyncDisabled,
+    ] = await Promise.all([
+      Promise.resolve(findMultiTenantCandidates(collections, objectCounts)),
+      Promise.resolve(findAutoTenantConfigIssues(collections)),
+      Promise.resolve(findEmptyTenants(nodes as any, mtCollections)),
+      Promise.resolve(findEmptyShards(nodes as any, mtCollections)),
+      Promise.resolve(findEmptyShardRatios(nodes as any, mtCollections)),
+      Promise.resolve(findReplicationImbalances(nodes as any, asyncReplicationByCollection)),
+      Promise.resolve(findCollectionsWithoutAsyncReplication(collections)),
+    ]);
 
     const result: ChecksResult = {
       timestamp: new Date().toISOString(),
       hasIssues:
         groups.length > 0 ||
+        autoTenantIssues.length > 0 ||
+        emptyTenants.length > 0 ||
         emptyShardEntries.length > 0 ||
         emptyShardRatios.length > 0 ||
         replicationImbalances.length > 0 ||
         asyncDisabled.length > 0,
       multiTenancy: { groups, hasIssues: groups.length > 0 },
+      autoTenantConfig: { issues: autoTenantIssues, hasIssues: autoTenantIssues.length > 0 },
+      emptyTenants: { collections: emptyTenants, hasIssues: emptyTenants.length > 0 },
       emptyShards: { entries: emptyShardEntries, hasIssues: emptyShardEntries.length > 0 },
       emptyShardRatio: { entries: emptyShardRatios, hasIssues: emptyShardRatios.length > 0 },
       replicationImbalance: {
@@ -3590,6 +3636,8 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
     this.mtCandidates[connectionId] = groups;
     this.checksIssueSectionCount[connectionId] =
       (groups.length > 0 ? 1 : 0) +
+      (autoTenantIssues.length > 0 ? 1 : 0) +
+      (emptyTenants.length > 0 ? 1 : 0) +
       (emptyShardEntries.length > 0 ? 1 : 0) +
       (emptyShardRatios.length > 0 ? 1 : 0) +
       (replicationImbalances.length > 0 ? 1 : 0) +
@@ -4462,25 +4510,38 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
     const asyncReplicationByCollection = buildAsyncReplicationMap(collections);
 
     // All checks are independent — run them in parallel.
-    const [candidates, emptyShardEntries, emptyShardRatios, replicationImbalances, asyncDisabled] =
-      await Promise.all([
-        Promise.resolve(findMultiTenantCandidates(collections, objectCounts)),
-        Promise.resolve(findEmptyShards(nodes as any, mtCollections)),
-        Promise.resolve(findEmptyShardRatios(nodes as any, mtCollections)),
-        Promise.resolve(findReplicationImbalances(nodes as any, asyncReplicationByCollection)),
-        Promise.resolve(findCollectionsWithoutAsyncReplication(collections)),
-      ]);
+    const [
+      candidates,
+      autoTenantIssues,
+      emptyTenants,
+      emptyShardEntries,
+      emptyShardRatios,
+      replicationImbalances,
+      asyncDisabled,
+    ] = await Promise.all([
+      Promise.resolve(findMultiTenantCandidates(collections, objectCounts)),
+      Promise.resolve(findAutoTenantConfigIssues(collections)),
+      Promise.resolve(findEmptyTenants(nodes as any, mtCollections)),
+      Promise.resolve(findEmptyShards(nodes as any, mtCollections)),
+      Promise.resolve(findEmptyShardRatios(nodes as any, mtCollections)),
+      Promise.resolve(findReplicationImbalances(nodes as any, asyncReplicationByCollection)),
+      Promise.resolve(findCollectionsWithoutAsyncReplication(collections)),
+    ]);
     this.mtCandidates[connectionId] = candidates;
 
     const result: ChecksResult = {
       timestamp: new Date().toISOString(),
       hasIssues:
         candidates.length > 0 ||
+        autoTenantIssues.length > 0 ||
+        emptyTenants.length > 0 ||
         emptyShardEntries.length > 0 ||
         emptyShardRatios.length > 0 ||
         replicationImbalances.length > 0 ||
         asyncDisabled.length > 0,
       multiTenancy: { groups: candidates, hasIssues: candidates.length > 0 },
+      autoTenantConfig: { issues: autoTenantIssues, hasIssues: autoTenantIssues.length > 0 },
+      emptyTenants: { collections: emptyTenants, hasIssues: emptyTenants.length > 0 },
       emptyShards: { entries: emptyShardEntries, hasIssues: emptyShardEntries.length > 0 },
       emptyShardRatio: { entries: emptyShardRatios, hasIssues: emptyShardRatios.length > 0 },
       replicationImbalance: {
@@ -4492,6 +4553,8 @@ export class WeaviateTreeDataProvider implements vscode.TreeDataProvider<Weaviat
 
     this.checksIssueSectionCount[connectionId] =
       (candidates.length > 0 ? 1 : 0) +
+      (autoTenantIssues.length > 0 ? 1 : 0) +
+      (emptyTenants.length > 0 ? 1 : 0) +
       (emptyShardEntries.length > 0 ? 1 : 0) +
       (emptyShardRatios.length > 0 ? 1 : 0) +
       (replicationImbalances.length > 0 ? 1 : 0) +

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { DataExplorerPanel } from './data-explorer/extension/DataExplorerPanel';
 import { RagChatPanel } from './rag-chat/extension/RagChatPanel';
 import type { FilterCondition, FilterMatchMode } from './data-explorer/types';
 import { AliasPanel } from './views/AliasPanel';
+import { EditMultiTenancyPanel } from './views/EditMultiTenancyPanel';
 import { RbacRolePanel } from './views/RbacRolePanel';
 import { RbacUserPanel } from './views/RbacUserPanel';
 import { RbacGroupPanel } from './views/RbacGroupPanel';
@@ -1870,6 +1871,104 @@ export function activate(context: vscode.ExtensionContext) {
                 vscode.window.showErrorMessage(`Failed to run checks: ${errorMessage}`);
                 postMessage({ command: 'checksResult', result: null });
               }
+            } else if (message.command === 'enableAutoTenantAll') {
+              // Enable autoTenantCreation + autoTenantActivation on every collection
+              // flagged by the Auto-Tenant Configuration check.
+              try {
+                const conn = connectionManager.getConnection(item.connectionId);
+                if (conn?.readOnly === true) {
+                  vscode.window.showWarningMessage(
+                    'This connection is read-only. Enable write access to modify multi-tenancy settings.'
+                  );
+                  return;
+                }
+                const lastChecks = weaviateTreeDataProvider.getLastChecksResult(item.connectionId);
+                const issues = lastChecks?.autoTenantConfig?.issues ?? [];
+                if (issues.length === 0) {
+                  vscode.window.showInformationMessage('No collections need auto-tenant changes.');
+                  return;
+                }
+                const confirm = await vscode.window.showWarningMessage(
+                  `Enable autoTenantCreation and autoTenantActivation on ${issues.length} collection(s)?`,
+                  { modal: true },
+                  'Enable'
+                );
+                if (confirm !== 'Enable') {
+                  return;
+                }
+                const failures: string[] = [];
+                for (const issue of issues) {
+                  try {
+                    await client.collections.get(issue.collectionName).config.update({
+                      multiTenancy: { autoTenantCreation: true, autoTenantActivation: true },
+                    });
+                  } catch (err) {
+                    failures.push(
+                      `${issue.collectionName}: ${err instanceof Error ? err.message : 'error'}`
+                    );
+                  }
+                }
+                // Refresh collection schemas so the new flag values are picked up.
+                await weaviateTreeDataProvider.refreshCollections(item.connectionId);
+                if (failures.length > 0) {
+                  vscode.window.showErrorMessage(
+                    `Enabled auto-tenant on ${issues.length - failures.length}/${issues.length} collection(s). Failed: ${failures.join('; ')}`
+                  );
+                } else {
+                  vscode.window.showInformationMessage(
+                    `Enabled auto-tenant on ${issues.length} collection(s).`
+                  );
+                }
+                const result = await weaviateTreeDataProvider.runChecks(item.connectionId);
+                postMessage({ command: 'checksResult', result });
+              } catch (error: unknown) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                vscode.window.showErrorMessage(`Failed to enable auto-tenant: ${errorMessage}`);
+              }
+            } else if (message.command === 'deleteEmptyTenants') {
+              // Delete the empty ACTIVE tenants of a single collection.
+              try {
+                const conn = connectionManager.getConnection(item.connectionId);
+                if (conn?.readOnly === true) {
+                  vscode.window.showWarningMessage(
+                    'This connection is read-only. Enable write access to delete tenants.'
+                  );
+                  return;
+                }
+                const lastChecks = weaviateTreeDataProvider.getLastChecksResult(item.connectionId);
+                const entry = lastChecks?.emptyTenants?.collections.find(
+                  (c) => c.collectionName === message.collectionName
+                );
+                const tenantNames = entry?.tenants ?? [];
+                if (tenantNames.length === 0) {
+                  vscode.window.showInformationMessage(
+                    `No empty tenants to delete in ${message.collectionName}.`
+                  );
+                  return;
+                }
+                const confirm = await vscode.window.showWarningMessage(
+                  `Delete ${tenantNames.length} empty tenant(s) from "${message.collectionName}"? This cannot be undone.`,
+                  { modal: true },
+                  'Delete'
+                );
+                if (confirm !== 'Delete') {
+                  return;
+                }
+                await client.collections.get(message.collectionName).tenants.remove(tenantNames);
+                vscode.window.showInformationMessage(
+                  `Deleted ${tenantNames.length} empty tenant(s) from "${message.collectionName}".`
+                );
+                // Refresh node status so the tenants no longer appear, then re-run checks.
+                await weaviateTreeDataProvider.fetchNodes(item.connectionId);
+                const freshNodes =
+                  weaviateTreeDataProvider.getCachedClusterNodes(item.connectionId) ?? [];
+                postMessage({ command: 'updateData', nodeStatusData: freshNodes });
+                const result = await weaviateTreeDataProvider.runChecks(item.connectionId);
+                postMessage({ command: 'checksResult', result });
+              } catch (error: unknown) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                vscode.window.showErrorMessage(`Failed to delete empty tenants: ${errorMessage}`);
+              }
             } else if (message.command === 'openExternal') {
               vscode.env.openExternal(vscode.Uri.parse(message.url));
             }
@@ -1896,6 +1995,138 @@ export function activate(context: vscode.ExtensionContext) {
           connectionId,
           openTab: 'checks',
         });
+      }
+    }),
+
+    // Run all cluster checks and open the Cluster panel on the Checks tab.
+    vscode.commands.registerCommand('weaviate.runChecks', async (item) => {
+      const connectionId = item?.connectionId;
+      if (!connectionId) {
+        vscode.window.showErrorMessage('Missing connection information');
+        return;
+      }
+      try {
+        const result = await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: 'Running cluster checks…',
+          },
+          async () => {
+            // Refresh node status first so checks use up-to-date data.
+            await weaviateTreeDataProvider.fetchNodes(connectionId);
+            return weaviateTreeDataProvider.runChecks(connectionId);
+          }
+        );
+        // Open (or focus) the Cluster panel on the Checks tab. The init payload
+        // carries the freshly-persisted result for a not-yet-open panel.
+        await vscode.commands.executeCommand('weaviate.viewClusterInfo', {
+          connectionId,
+          openTab: 'checks',
+        });
+        // If the panel was already open, push the fresh nodes + result to it.
+        const panel = ClusterPanel.getPanel(connectionId);
+        if (panel) {
+          const freshNodes = weaviateTreeDataProvider.getCachedClusterNodes(connectionId) ?? [];
+          panel.postMessage({ command: 'updateData', nodeStatusData: freshNodes });
+          panel.postMessage({ command: 'checksResult', result });
+        }
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Failed to run checks: ${errorMessage}`);
+      }
+    }),
+
+    // Open the "Edit Multi-Tenancy" form for a collection.
+    vscode.commands.registerCommand('weaviate.editMultiTenancy', async (item) => {
+      const connectionId = item?.connectionId;
+      const collectionName = item?.collectionName;
+      if (!connectionId || !collectionName) {
+        vscode.window.showErrorMessage('Missing collection information');
+        return;
+      }
+      try {
+        const connectionManager = weaviateTreeDataProvider.getConnectionManager();
+        const client = await connectionManager.getClient(connectionId);
+        if (!client) {
+          vscode.window.showErrorMessage('Failed to get Weaviate client');
+          return;
+        }
+        const conn = connectionManager.getConnection(connectionId);
+        // Read fresh config so the form shows current values.
+        const config = await client.collections.get(collectionName).config.get();
+        const mt = (config as any)?.multiTenancy ?? {};
+        EditMultiTenancyPanel.createOrShow(
+          context.extensionUri,
+          connectionId,
+          collectionName,
+          {
+            enabled: mt.enabled === true,
+            autoTenantCreation: mt.autoTenantCreation === true,
+            autoTenantActivation: mt.autoTenantActivation === true,
+            readOnly: conn?.readOnly === true,
+          },
+          async (data) => {
+            if (conn?.readOnly === true) {
+              throw new Error('This connection is read-only.');
+            }
+            await client.collections.get(collectionName).config.update({
+              multiTenancy: {
+                autoTenantCreation: data.autoTenantCreation,
+                autoTenantActivation: data.autoTenantActivation,
+              },
+            });
+            vscode.window.showInformationMessage(
+              `Updated multi-tenancy settings for "${collectionName}".`
+            );
+            await weaviateTreeDataProvider.refreshCollections(connectionId);
+          }
+        );
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Failed to open multi-tenancy editor: ${errorMessage}`);
+      }
+    }),
+
+    // Toggle a single auto-tenant flag (autoTenantCreation / autoTenantActivation)
+    // directly from its tree row.
+    vscode.commands.registerCommand('weaviate.toggleAutoTenantFlag', async (item) => {
+      const connectionId = item?.connectionId;
+      const collectionName = item?.collectionName;
+      const flag = item?.itemId as string | undefined;
+      if (!connectionId || !collectionName || !flag) {
+        vscode.window.showErrorMessage('Missing multi-tenancy information');
+        return;
+      }
+      if (flag !== 'autoTenantCreation' && flag !== 'autoTenantActivation') {
+        return;
+      }
+      try {
+        const connectionManager = weaviateTreeDataProvider.getConnectionManager();
+        const conn = connectionManager.getConnection(connectionId);
+        if (conn?.readOnly === true) {
+          vscode.window.showWarningMessage(
+            'This connection is read-only. Enable write access to modify multi-tenancy settings.'
+          );
+          return;
+        }
+        const client = await connectionManager.getClient(connectionId);
+        if (!client) {
+          vscode.window.showErrorMessage('Failed to get Weaviate client');
+          return;
+        }
+        const config = await client.collections.get(collectionName).config.get();
+        const current = (config as any)?.multiTenancy?.[flag] === true;
+        const newValue = !current;
+        await client.collections.get(collectionName).config.update({
+          multiTenancy: { [flag]: newValue },
+        });
+        vscode.window.showInformationMessage(
+          `${flag} ${newValue ? 'enabled' : 'disabled'} for "${collectionName}".`
+        );
+        await weaviateTreeDataProvider.refreshCollections(connectionId);
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Failed to toggle ${flag}: ${errorMessage}`);
       }
     }),
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,8 @@ import { RagChatPanel } from './rag-chat/extension/RagChatPanel';
 import type { FilterCondition, FilterMatchMode } from './data-explorer/types';
 import { AliasPanel } from './views/AliasPanel';
 import { EditMultiTenancyPanel } from './views/EditMultiTenancyPanel';
+import { ManageTenantsPanel, TenantEntry } from './views/ManageTenantsPanel';
+import { isVersionAtLeast } from './data-explorer/webview/utils/versionCheck';
 import { RbacRolePanel } from './views/RbacRolePanel';
 import { RbacUserPanel } from './views/RbacUserPanel';
 import { RbacGroupPanel } from './views/RbacGroupPanel';
@@ -1969,6 +1971,57 @@ export function activate(context: vscode.ExtensionContext) {
                 const errorMessage = error instanceof Error ? error.message : 'Unknown error';
                 vscode.window.showErrorMessage(`Failed to delete empty tenants: ${errorMessage}`);
               }
+            } else if (message.command === 'deactivateEmptyTenants') {
+              // Set the empty ACTIVE tenants of a collection to INACTIVE — frees
+              // memory (offloads to disk) without deleting the tenant.
+              try {
+                const conn = connectionManager.getConnection(item.connectionId);
+                if (conn?.readOnly === true) {
+                  vscode.window.showWarningMessage(
+                    'This connection is read-only. Enable write access to deactivate tenants.'
+                  );
+                  return;
+                }
+                const lastChecks = weaviateTreeDataProvider.getLastChecksResult(item.connectionId);
+                const entry = lastChecks?.emptyTenants?.collections.find(
+                  (c) => c.collectionName === message.collectionName
+                );
+                const tenantNames = entry?.tenants ?? [];
+                if (tenantNames.length === 0) {
+                  vscode.window.showInformationMessage(
+                    `No empty tenants to deactivate in ${message.collectionName}.`
+                  );
+                  return;
+                }
+                const confirm = await vscode.window.showWarningMessage(
+                  `Set ${tenantNames.length} empty tenant(s) in "${message.collectionName}" to INACTIVE?`,
+                  { modal: true },
+                  'Inactivate'
+                );
+                if (confirm !== 'Inactivate') {
+                  return;
+                }
+                await client.collections
+                  .get(message.collectionName)
+                  .tenants.update(
+                    tenantNames.map((name) => ({ name, activityStatus: 'INACTIVE' as const }))
+                  );
+                vscode.window.showInformationMessage(
+                  `Set ${tenantNames.length} empty tenant(s) to INACTIVE in "${message.collectionName}".`
+                );
+                // Refresh node status so the now-inactive tenants no longer count, then re-run checks.
+                await weaviateTreeDataProvider.fetchNodes(item.connectionId);
+                const freshNodes =
+                  weaviateTreeDataProvider.getCachedClusterNodes(item.connectionId) ?? [];
+                postMessage({ command: 'updateData', nodeStatusData: freshNodes });
+                const result = await weaviateTreeDataProvider.runChecks(item.connectionId);
+                postMessage({ command: 'checksResult', result });
+              } catch (error: unknown) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                vscode.window.showErrorMessage(
+                  `Failed to deactivate empty tenants: ${errorMessage}`
+                );
+              }
             } else if (message.command === 'openExternal') {
               vscode.env.openExternal(vscode.Uri.parse(message.url));
             }
@@ -2127,6 +2180,139 @@ export function activate(context: vscode.ExtensionContext) {
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`Failed to toggle ${flag}: ${errorMessage}`);
+      }
+    }),
+
+    // Open the "Manage Tenants" panel to activate/deactivate/offload tenants.
+    vscode.commands.registerCommand('weaviate.manageTenants', async (item) => {
+      const connectionId = item?.connectionId;
+      const collectionName = item?.collectionName;
+      if (!connectionId || !collectionName) {
+        vscode.window.showErrorMessage('Missing collection information');
+        return;
+      }
+      const OFFLOAD_MIN_VERSION = '1.26.0';
+      try {
+        const connectionManager = weaviateTreeDataProvider.getConnectionManager();
+        const client = await connectionManager.getClient(connectionId);
+        if (!client) {
+          vscode.window.showErrorMessage('Failed to get Weaviate client');
+          return;
+        }
+        const conn = connectionManager.getConnection(connectionId);
+
+        const fetchTenants = async (): Promise<TenantEntry[]> => {
+          const map = await client.collections.get(collectionName).tenants.get();
+          // Per-tenant object counts come from verbose node status: for a
+          // multi-tenant collection each loaded shard's name is the tenant name.
+          // Only ACTIVE (loaded) tenants appear, so INACTIVE/OFFLOADED tenants
+          // have an unknown (null) count.
+          await weaviateTreeDataProvider.fetchNodes(connectionId).catch(() => {});
+          const nodes = weaviateTreeDataProvider.getCachedClusterNodes(connectionId) ?? [];
+          const countByTenant = new Map<string, number>();
+          for (const node of nodes) {
+            for (const shard of (node as any).shards ?? []) {
+              if (shard.class !== collectionName) {
+                continue;
+              }
+              const prev = countByTenant.get(shard.name) ?? 0;
+              countByTenant.set(shard.name, Math.max(prev, shard.objectCount ?? 0));
+            }
+          }
+          return (
+            Object.values(map)
+              .map((t: any) => ({
+                name: t.name,
+                activityStatus: t.activityStatus,
+                objectCount: countByTenant.has(t.name) ? countByTenant.get(t.name)! : null,
+              }))
+              // Natural, deterministic ordering (tenant-2 before tenant-10).
+              .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
+          );
+        };
+
+        const tenants = await fetchTenants();
+
+        // Offload gating: requires Weaviate >= 1.26.0 AND the offload-s3 module.
+        let serverVersion = '';
+        let offloadModuleAvailable = false;
+        try {
+          const meta: any = await client.getMeta();
+          serverVersion = meta?.version ?? '';
+          offloadModuleAvailable = !!meta?.modules?.['offload-s3'];
+        } catch {
+          // Meta is best-effort; if unavailable, offload stays disabled.
+        }
+        const offloadSupported =
+          offloadModuleAvailable && isVersionAtLeast(serverVersion, 1, 26, 0);
+
+        ManageTenantsPanel.createOrShow(
+          context.extensionUri,
+          connectionId,
+          collectionName,
+          {
+            readOnly: conn?.readOnly === true,
+            serverVersion,
+            offloadModuleAvailable,
+            offloadSupported,
+            offloadMinVersion: OFFLOAD_MIN_VERSION,
+            tenants,
+          },
+          async ({ status, names }) => {
+            if (conn?.readOnly === true) {
+              throw new Error('This connection is read-only.');
+            }
+            if (status === 'OFFLOADED' && !offloadSupported) {
+              throw new Error(
+                `Offloading requires Weaviate >= ${OFFLOAD_MIN_VERSION} and the offload-s3 module to be enabled.`
+              );
+            }
+            if (names.length === 0) {
+              return fetchTenants();
+            }
+            const confirm = await vscode.window.showWarningMessage(
+              `Set ${names.length} tenant(s) in "${collectionName}" to ${status}?`,
+              { modal: true },
+              'Apply'
+            );
+            if (confirm !== 'Apply') {
+              return fetchTenants();
+            }
+            await client.collections
+              .get(collectionName)
+              .tenants.update(names.map((name) => ({ name, activityStatus: status })));
+            vscode.window.showInformationMessage(
+              `Set ${names.length} tenant(s) to ${status} in "${collectionName}".`
+            );
+            await weaviateTreeDataProvider.refreshCollections(connectionId);
+            return fetchTenants();
+          },
+          async (names) => {
+            if (conn?.readOnly === true) {
+              throw new Error('This connection is read-only.');
+            }
+            if (names.length === 0) {
+              return fetchTenants();
+            }
+            const confirm = await vscode.window.showWarningMessage(
+              `Delete ${names.length} tenant(s) from "${collectionName}"? This permanently removes their data and cannot be undone.`,
+              { modal: true },
+              'Delete'
+            );
+            if (confirm !== 'Delete') {
+              return fetchTenants();
+            }
+            await client.collections.get(collectionName).tenants.remove(names);
+            vscode.window.showInformationMessage(
+              `Deleted ${names.length} tenant(s) from "${collectionName}".`
+            );
+            await weaviateTreeDataProvider.refreshCollections(connectionId);
+            return fetchTenants();
+          }
+        );
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Failed to open tenant manager: ${errorMessage}`);
       }
     }),
 

--- a/src/utils/__tests__/countFilter.test.ts
+++ b/src/utils/__tests__/countFilter.test.ts
@@ -1,0 +1,104 @@
+import { parseCountFilter } from '../countFilter';
+
+describe('parseCountFilter', () => {
+  it('matches everything for an empty expression (including unknown counts)', () => {
+    const p = parseCountFilter('');
+    expect(p(0)).toBe(true);
+    expect(p(100)).toBe(true);
+    expect(p(null)).toBe(true);
+    expect(parseCountFilter('   ')(null)).toBe(true);
+  });
+
+  it('excludes unknown counts for any non-empty expression', () => {
+    expect(parseCountFilter('count>=0')(null)).toBe(false);
+    expect(parseCountFilter('count=0')(null)).toBe(false);
+  });
+
+  describe('equality', () => {
+    it('count=0', () => {
+      const p = parseCountFilter('count=0');
+      expect(p(0)).toBe(true);
+      expect(p(1)).toBe(false);
+    });
+    it('count==0 is equivalent', () => {
+      expect(parseCountFilter('count==0')(0)).toBe(true);
+    });
+    it('count!=0', () => {
+      const p = parseCountFilter('count!=0');
+      expect(p(0)).toBe(false);
+      expect(p(3)).toBe(true);
+    });
+  });
+
+  describe('comparisons', () => {
+    it('count>1', () => {
+      const p = parseCountFilter('count>1');
+      expect(p(1)).toBe(false);
+      expect(p(2)).toBe(true);
+    });
+    it('count>=10', () => {
+      const p = parseCountFilter('count>=10');
+      expect(p(9)).toBe(false);
+      expect(p(10)).toBe(true);
+    });
+    it('count<50', () => {
+      const p = parseCountFilter('count<50');
+      expect(p(49)).toBe(true);
+      expect(p(50)).toBe(false);
+    });
+    it('count<=50', () => {
+      expect(parseCountFilter('count<=50')(50)).toBe(true);
+    });
+  });
+
+  describe('reversed (number on the left)', () => {
+    it('5<count means count>5', () => {
+      const p = parseCountFilter('5<count');
+      expect(p(5)).toBe(false);
+      expect(p(6)).toBe(true);
+    });
+    it('0=count', () => {
+      expect(parseCountFilter('0=count')(0)).toBe(true);
+    });
+  });
+
+  describe('range', () => {
+    it('10<count<50 (exclusive)', () => {
+      const p = parseCountFilter('10<count<50');
+      expect(p(10)).toBe(false);
+      expect(p(11)).toBe(true);
+      expect(p(49)).toBe(true);
+      expect(p(50)).toBe(false);
+    });
+    it('10<=count<=50 (inclusive)', () => {
+      const p = parseCountFilter('10<=count<=50');
+      expect(p(10)).toBe(true);
+      expect(p(50)).toBe(true);
+      expect(p(9)).toBe(false);
+    });
+    it('50>count>10 (descending form)', () => {
+      const p = parseCountFilter('50>count>10');
+      expect(p(11)).toBe(true);
+      expect(p(10)).toBe(false);
+      expect(p(50)).toBe(false);
+    });
+  });
+
+  describe('whitespace and case', () => {
+    it('ignores spaces', () => {
+      expect(parseCountFilter(' 10 < count < 50 ')(30)).toBe(true);
+    });
+    it('is case-insensitive on the keyword', () => {
+      expect(parseCountFilter('COUNT=0')(0)).toBe(true);
+    });
+  });
+
+  describe('invalid expressions throw', () => {
+    it.each(['count', 'foo', 'count=abc', 'count><5', '=5', 'count=', '<count<'])(
+      'throws on "%s"',
+      (expr) => {
+        expect(() => parseCountFilter(expr)).toThrow();
+      }
+    );
+  });
+});

--- a/src/utils/__tests__/multiTenancyCheck.test.ts
+++ b/src/utils/__tests__/multiTenancyCheck.test.ts
@@ -6,6 +6,8 @@ import {
   findEmptyShardRatios,
   findReplicationImbalances,
   findCollectionsWithoutAsyncReplication,
+  findAutoTenantConfigIssues,
+  findEmptyTenants,
   buildAsyncReplicationMap,
   EMPTY_SHARD_RATIO_THRESHOLDS,
   MtCandidateGroup,
@@ -49,6 +51,26 @@ function makeCollection(
 
 function groupNames(group: MtCandidateGroup): string[] {
   return group.collections.map((c) => c.name);
+}
+
+/** Builds a multi-tenant collection with explicit auto-tenant flags. */
+function makeMtCollection(
+  name: string,
+  opts: { enabled?: boolean; creation?: boolean; activation?: boolean } = {}
+): CollectionWithSchema {
+  return {
+    label: name,
+    collapsibleState: 0,
+    itemType: 'collection',
+    schema: {
+      name,
+      multiTenancy: {
+        enabled: opts.enabled ?? true,
+        autoTenantCreation: opts.creation ?? false,
+        autoTenantActivation: opts.activation ?? false,
+      },
+    } as any,
+  } as unknown as CollectionWithSchema;
 }
 
 // ─── computeCollectionHash ────────────────────────────────────────────────────
@@ -880,5 +902,156 @@ describe('buildAsyncReplicationMap', () => {
   it('omits collections without a replication config', () => {
     const map = buildAsyncReplicationMap([makeCollection('NoRep')]);
     expect(map).toEqual({});
+  });
+});
+
+// ─── findAutoTenantConfigIssues ────────────────────────────────────────────────
+
+describe('findAutoTenantConfigIssues', () => {
+  it('returns empty array when there are no collections', () => {
+    expect(findAutoTenantConfigIssues([])).toHaveLength(0);
+  });
+
+  it('ignores non-multi-tenant collections', () => {
+    const cols = [makeCollection('Article', [], false)];
+    expect(findAutoTenantConfigIssues(cols)).toHaveLength(0);
+  });
+
+  it('does not flag a collection with both flags enabled', () => {
+    const cols = [makeMtCollection('Docs', { creation: true, activation: true })];
+    expect(findAutoTenantConfigIssues(cols)).toHaveLength(0);
+  });
+
+  it('flags a collection with autoTenantCreation off', () => {
+    const cols = [makeMtCollection('Docs', { creation: false, activation: true })];
+    const result = findAutoTenantConfigIssues(cols);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      collectionName: 'Docs',
+      autoTenantCreation: false,
+      autoTenantActivation: true,
+    });
+  });
+
+  it('flags a collection with autoTenantActivation off', () => {
+    const cols = [makeMtCollection('Docs', { creation: true, activation: false })];
+    const result = findAutoTenantConfigIssues(cols);
+    expect(result).toHaveLength(1);
+    expect(result[0].autoTenantActivation).toBe(false);
+    expect(result[0].autoTenantCreation).toBe(true);
+  });
+
+  it('flags a collection with both flags off', () => {
+    const cols = [makeMtCollection('Docs', { creation: false, activation: false })];
+    const result = findAutoTenantConfigIssues(cols);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      collectionName: 'Docs',
+      autoTenantCreation: false,
+      autoTenantActivation: false,
+    });
+  });
+
+  it('treats missing flags as false (disabled)', () => {
+    const cols = [
+      {
+        label: 'Docs',
+        collapsibleState: 0,
+        itemType: 'collection',
+        schema: { name: 'Docs', multiTenancy: { enabled: true } },
+      } as unknown as CollectionWithSchema,
+    ];
+    const result = findAutoTenantConfigIssues(cols);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      collectionName: 'Docs',
+      autoTenantCreation: false,
+      autoTenantActivation: false,
+    });
+  });
+
+  it('reports only the collections that have an issue', () => {
+    const cols = [
+      makeMtCollection('Good', { creation: true, activation: true }),
+      makeMtCollection('Bad', { creation: false, activation: true }),
+      makeCollection('SingleTenant', [], false),
+    ];
+    const result = findAutoTenantConfigIssues(cols);
+    expect(result).toHaveLength(1);
+    expect(result[0].collectionName).toBe('Bad');
+  });
+});
+
+// ─── findEmptyTenants ──────────────────────────────────────────────────────────
+
+describe('findEmptyTenants', () => {
+  it('returns empty array when there are no nodes', () => {
+    expect(findEmptyTenants([], new Set(['Docs']))).toHaveLength(0);
+  });
+
+  it('only scans collections in the multi-tenant set', () => {
+    const nodes = [
+      makeNode('node-1', [
+        { class: 'Docs', name: 'tenant-a', objectCount: 0 },
+        { class: 'Article', name: 'shard-1', objectCount: 0 },
+      ]),
+    ];
+    const result = findEmptyTenants(nodes, new Set(['Docs']));
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ collectionName: 'Docs', tenants: ['tenant-a'] });
+  });
+
+  it('does not flag tenants that have objects', () => {
+    const nodes = [makeNode('node-1', [{ class: 'Docs', name: 'tenant-a', objectCount: 100 }])];
+    expect(findEmptyTenants(nodes, new Set(['Docs']))).toHaveLength(0);
+  });
+
+  it('reports multiple empty tenants sorted by name', () => {
+    const nodes = [
+      makeNode('node-1', [
+        { class: 'Docs', name: 'tenant-c', objectCount: 0 },
+        { class: 'Docs', name: 'tenant-a', objectCount: 0 },
+        { class: 'Docs', name: 'tenant-b', objectCount: 5 },
+      ]),
+    ];
+    const result = findEmptyTenants(nodes, new Set(['Docs']));
+    expect(result).toHaveLength(1);
+    expect(result[0].tenants).toEqual(['tenant-a', 'tenant-c']);
+  });
+
+  it('treats a tenant as empty only when every replica is empty', () => {
+    // tenant-a has objects on one replica → not empty; tenant-b empty on all.
+    const nodes = [
+      makeNode('node-1', [
+        { class: 'Docs', name: 'tenant-a', objectCount: 0 },
+        { class: 'Docs', name: 'tenant-b', objectCount: 0 },
+      ]),
+      makeNode('node-2', [
+        { class: 'Docs', name: 'tenant-a', objectCount: 50 },
+        { class: 'Docs', name: 'tenant-b', objectCount: 0 },
+      ]),
+    ];
+    const result = findEmptyTenants(nodes, new Set(['Docs']));
+    expect(result).toHaveLength(1);
+    expect(result[0].tenants).toEqual(['tenant-b']);
+  });
+
+  it('sorts collections by empty-tenant count descending', () => {
+    const nodes = [
+      makeNode('node-1', [
+        { class: 'Few', name: 't1', objectCount: 0 },
+        { class: 'Many', name: 't1', objectCount: 0 },
+        { class: 'Many', name: 't2', objectCount: 0 },
+        { class: 'Many', name: 't3', objectCount: 0 },
+      ]),
+    ];
+    const result = findEmptyTenants(nodes, new Set(['Few', 'Many']));
+    expect(result.map((r) => r.collectionName)).toEqual(['Many', 'Few']);
+  });
+
+  it('tolerates null shards on a node', () => {
+    const nodes: NodeLike[] = [{ name: 'node-1', shards: null }];
+    expect(() => findEmptyTenants(nodes, new Set(['Docs']))).not.toThrow();
+    expect(findEmptyTenants(nodes, new Set(['Docs']))).toHaveLength(0);
   });
 });

--- a/src/utils/__tests__/tenantMatch.test.ts
+++ b/src/utils/__tests__/tenantMatch.test.ts
@@ -1,0 +1,79 @@
+import { matchTenantNames, wildcardToRegExp, buildTenantMatcher } from '../tenantMatch';
+
+describe('wildcardToRegExp', () => {
+  it('anchors the pattern (full-name match)', () => {
+    const re = wildcardToRegExp('acme');
+    expect(re.test('acme')).toBe(true);
+    expect(re.test('acme-corp')).toBe(false);
+  });
+
+  it('translates * to any run of characters', () => {
+    const re = wildcardToRegExp('*acme*');
+    expect(re.test('acme')).toBe(true);
+    expect(re.test('the-acme-corp')).toBe(true);
+    expect(re.test('nope')).toBe(false);
+  });
+
+  it('translates ? to a single character', () => {
+    const re = wildcardToRegExp('tenant-?');
+    expect(re.test('tenant-1')).toBe(true);
+    expect(re.test('tenant-42')).toBe(false);
+  });
+
+  it('escapes regex metacharacters in the literal parts', () => {
+    const re = wildcardToRegExp('a.b+c');
+    expect(re.test('a.b+c')).toBe(true);
+    expect(re.test('axbxc')).toBe(false);
+  });
+});
+
+describe('matchTenantNames', () => {
+  const names = ['acme', 'acme-corp', 'globex', 'tenant-1', 'tenant-2', 'TENANT-3'];
+
+  it('returns [] for an empty pattern', () => {
+    expect(matchTenantNames(names, '', 'wildcard')).toEqual([]);
+    expect(matchTenantNames(names, '   ', 'regex')).toEqual([]);
+  });
+
+  it('matches by wildcard contains', () => {
+    expect(matchTenantNames(names, '*acme*', 'wildcard')).toEqual(['acme', 'acme-corp']);
+  });
+
+  it('matches by wildcard prefix', () => {
+    expect(matchTenantNames(names, 'tenant-*', 'wildcard')).toEqual(['tenant-1', 'tenant-2']);
+  });
+
+  it('wildcard is a full-name match, not substring by default', () => {
+    expect(matchTenantNames(names, 'acme', 'wildcard')).toEqual(['acme']);
+  });
+
+  it('matches by regex substring (unanchored)', () => {
+    expect(matchTenantNames(names, 'acme', 'regex')).toEqual(['acme', 'acme-corp']);
+  });
+
+  it('supports anchored regex', () => {
+    expect(matchTenantNames(names, '^tenant-\\d$', 'regex')).toEqual(['tenant-1', 'tenant-2']);
+  });
+
+  it('is case-sensitive by default', () => {
+    expect(matchTenantNames(names, 'tenant-3', 'regex')).toEqual([]);
+    expect(matchTenantNames(names, 'TENANT-3', 'regex')).toEqual(['TENANT-3']);
+  });
+
+  it('preserves input order', () => {
+    expect(matchTenantNames(names, '*', 'wildcard')).toEqual(names);
+  });
+
+  it('throws on invalid regex (caller surfaces the error)', () => {
+    expect(() => matchTenantNames(names, '(', 'regex')).toThrow();
+  });
+});
+
+describe('buildTenantMatcher', () => {
+  it('builds a wildcard matcher', () => {
+    expect(buildTenantMatcher('t*', 'wildcard').test('tenant')).toBe(true);
+  });
+  it('builds a regex matcher', () => {
+    expect(buildTenantMatcher('ten', 'regex').test('tenant')).toBe(true);
+  });
+});

--- a/src/utils/countFilter.ts
+++ b/src/utils/countFilter.ts
@@ -1,0 +1,92 @@
+/**
+ * Parser for the tenant object-count filter used in the Manage Tenants panel.
+ *
+ * Supported syntax (whitespace and case are ignored, `count` is the keyword):
+ *  - Comparison:      `count=0`, `count==0`, `count!=0`, `count>1`, `count>=10`,
+ *                     `count<50`, `count<=50`
+ *  - Reversed:        `0=count`, `5<count`, `50>=count` (number on the left)
+ *  - Range:           `10<count<50`, `10<=count<=50`, `50>count>10`
+ *
+ * Object count comes from node status and is only known for ACTIVE (loaded)
+ * tenants; tenants whose count is unknown (`null`) never match a non-empty
+ * filter.
+ */
+
+/** A predicate over a tenant's object count (`null` = unknown / not loaded). */
+export type CountPredicate = (count: number | null) => boolean;
+
+type Op = '=' | '==' | '!=' | '>' | '>=' | '<' | '<=';
+
+/** Evaluates `a <op> b`. */
+function compare(op: Op, a: number, b: number): boolean {
+  switch (op) {
+    case '=':
+    case '==':
+      return a === b;
+    case '!=':
+      return a !== b;
+    case '>':
+      return a > b;
+    case '>=':
+      return a >= b;
+    case '<':
+      return a < b;
+    case '<=':
+      return a <= b;
+    default:
+      return false;
+  }
+}
+
+const NUM = '(-?\\d+(?:\\.\\d+)?)';
+// Multi-char operators must precede single-char ones in the alternation.
+const OP = '(==|!=|>=|<=|=|>|<)';
+const RANGE_OP = '(<=|>=|<|>)';
+
+const RE_COUNT_LEFT = new RegExp(`^count${OP}${NUM}$`);
+const RE_NUM_LEFT = new RegExp(`^${NUM}${OP}count$`);
+const RE_RANGE = new RegExp(`^${NUM}${RANGE_OP}count${RANGE_OP}${NUM}$`);
+
+/**
+ * Parses a count-filter expression into a predicate.
+ *
+ * An empty/blank expression returns a predicate that matches everything
+ * (including unknown counts). Any non-empty expression only matches tenants
+ * with a known numeric count.
+ *
+ * @throws Error with a friendly message when the expression is not valid.
+ */
+export function parseCountFilter(expr: string): CountPredicate {
+  const raw = (expr ?? '').trim();
+  if (raw === '') {
+    return () => true;
+  }
+
+  // Normalize: drop all whitespace, lowercase the `count` keyword.
+  const t = raw.replace(/\s+/g, '').toLowerCase();
+
+  const range = t.match(RE_RANGE);
+  if (range) {
+    const lo = parseFloat(range[1]);
+    const loOp = range[2] as Op;
+    const hiOp = range[3] as Op;
+    const hi = parseFloat(range[4]);
+    return (c) => c !== null && compare(loOp, lo, c) && compare(hiOp, c, hi);
+  }
+
+  const countLeft = t.match(RE_COUNT_LEFT);
+  if (countLeft) {
+    const op = countLeft[1] as Op;
+    const n = parseFloat(countLeft[2]);
+    return (c) => c !== null && compare(op, c, n);
+  }
+
+  const numLeft = t.match(RE_NUM_LEFT);
+  if (numLeft) {
+    const n = parseFloat(numLeft[1]);
+    const op = numLeft[2] as Op;
+    return (c) => c !== null && compare(op, n, c);
+  }
+
+  throw new Error(`Invalid count filter: "${raw}"`);
+}

--- a/src/utils/multiTenancyCheck.ts
+++ b/src/utils/multiTenancyCheck.ts
@@ -100,6 +100,41 @@ export interface EmptyShardRatioEntry {
   severity: EmptyShardRatioSeverity;
 }
 
+// ─── Auto-tenant config check ─────────────────────────────────────────────────
+
+/**
+ * A multi-tenant collection whose auto-tenant flags are not both enabled.
+ *
+ * `autoTenantCreation` lets a collection create a tenant on first write, and
+ * `autoTenantActivation` loads a tenant into memory on access. When either is
+ * off, clients must manage tenant lifecycle manually, which is a common source
+ * of "tenant not found" / "tenant is inactive" errors.
+ */
+export interface AutoTenantConfigIssue {
+  collectionName: string;
+  /** Current value of the collection's `autoTenantCreation` flag. */
+  autoTenantCreation: boolean;
+  /** Current value of the collection's `autoTenantActivation` flag. */
+  autoTenantActivation: boolean;
+}
+
+// ─── Empty tenants check ──────────────────────────────────────────────────────
+
+/**
+ * A multi-tenant collection that has one or more empty ACTIVE tenants.
+ *
+ * Only ACTIVE (loaded-into-memory) tenants are considered, because those are the
+ * ones consuming RAM. INACTIVE/OFFLOADED tenants live on disk/cloud and do not
+ * appear as loaded shards in node status, so they are never flagged here —
+ * deleting them would free no memory. This makes the check a safe, targeted
+ * "reclaim memory from empty loaded tenants" signal.
+ */
+export interface EmptyTenantCollection {
+  collectionName: string;
+  /** Names of ACTIVE tenants holding zero objects, sorted for stable output. */
+  tenants: string[];
+}
+
 // ─── Replication imbalance check ─────────────────────────────────────────────
 
 /** Object-count breakdown for one replica of a shard. */
@@ -184,6 +219,14 @@ export interface ChecksResult {
   hasIssues: boolean;
   multiTenancy: {
     groups: MtCandidateGroup[];
+    hasIssues: boolean;
+  };
+  autoTenantConfig: {
+    issues: AutoTenantConfigIssue[];
+    hasIssues: boolean;
+  };
+  emptyTenants: {
+    collections: EmptyTenantCollection[];
     hasIssues: boolean;
   };
   emptyShards: {
@@ -337,6 +380,91 @@ export function findMultiTenantCandidates(
   groups.sort((a, b) => b.totalObjects - a.totalObjects);
 
   return groups;
+}
+
+/**
+ * Finds multi-tenant collections whose auto-tenant flags are not both enabled.
+ *
+ * A collection is flagged when `autoTenantCreation` OR `autoTenantActivation` is
+ * false. Non-multi-tenant collections are ignored — the flags are meaningless
+ * there. A missing flag is treated as `false` (the safe assumption: if the
+ * schema doesn't report it as enabled, surface it so the user can confirm).
+ *
+ * @param collections All collections for a connection, with their schema.
+ */
+export function findAutoTenantConfigIssues(
+  collections: CollectionWithSchema[]
+): AutoTenantConfigIssue[] {
+  const issues: AutoTenantConfigIssue[] = [];
+  for (const col of collections) {
+    const mt = col.schema?.multiTenancy;
+    if (!mt?.enabled) {
+      continue;
+    }
+    const autoTenantCreation = mt.autoTenantCreation === true;
+    const autoTenantActivation = mt.autoTenantActivation === true;
+    if (!autoTenantCreation || !autoTenantActivation) {
+      issues.push({ collectionName: col.label, autoTenantCreation, autoTenantActivation });
+    }
+  }
+  return issues;
+}
+
+/**
+ * Finds empty ACTIVE tenants in multi-tenant collections.
+ *
+ * A tenant is ACTIVE precisely when it is loaded into memory, which is exactly
+ * when it appears as a shard in verbose node status. An ACTIVE tenant that holds
+ * zero objects is wasting memory and is a safe deletion candidate. INACTIVE and
+ * OFFLOADED tenants never appear here, so they are correctly never flagged.
+ *
+ * Replicas are collapsed by tenant (shard) name: a tenant counts as empty only
+ * when every replica reports zero objects (max object count across replicas
+ * === 0). This avoids mistaking a lagging replica for an empty tenant — that
+ * case is handled by {@link findReplicationImbalances}.
+ *
+ * @param nodes         Verbose cluster node data.
+ * @param mtCollections Names of multi-tenant collections; only these are scanned
+ *                      so that regular single-tenant shards are never reported.
+ * @returns Flagged collections, sorted by empty-tenant count descending.
+ */
+export function findEmptyTenants(
+  nodes: NodeLike[],
+  mtCollections: Set<string>
+): EmptyTenantCollection[] {
+  // collectionName → tenant(shard)Name → max objectCount seen across replicas
+  const byCollection = new Map<string, Map<string, number>>();
+
+  for (const node of nodes) {
+    for (const shard of node.shards ?? []) {
+      if (!mtCollections.has(shard.class)) {
+        continue;
+      }
+      let byTenant = byCollection.get(shard.class);
+      if (!byTenant) {
+        byTenant = new Map();
+        byCollection.set(shard.class, byTenant);
+      }
+      const prev = byTenant.get(shard.name) ?? 0;
+      byTenant.set(shard.name, Math.max(prev, shard.objectCount ?? 0));
+    }
+  }
+
+  const result: EmptyTenantCollection[] = [];
+  for (const [collectionName, byTenant] of byCollection) {
+    const empties = [...byTenant.entries()]
+      .filter(([, maxObjects]) => maxObjects === 0)
+      .map(([name]) => name)
+      .sort();
+    if (empties.length > 0) {
+      result.push({ collectionName, tenants: empties });
+    }
+  }
+
+  // Highest-impact first: collections with the most empty tenants lead.
+  result.sort((a, b) => b.tenants.length - a.tenants.length);
+
+  return result;
 }
 
 /**

--- a/src/utils/tenantMatch.ts
+++ b/src/utils/tenantMatch.ts
@@ -1,0 +1,57 @@
+/**
+ * Tenant-name matching for bulk tenant operations.
+ *
+ * Users can target tenants either by explicit selection or by a pattern:
+ *  - `wildcard` — glob-style, where `*` matches any run of characters and `?`
+ *    matches a single character. The pattern is anchored (full-name match), so
+ *    `*_2024` matches names ending in `_2024` and `*acme*` matches names that
+ *    contain `acme`.
+ *  - `regex` — a JavaScript regular expression, tested unanchored so a bare
+ *    `acme` matches any name containing it. Use `^`/`$` for exact matches.
+ */
+
+export type TenantMatchMode = 'wildcard' | 'regex';
+
+/**
+ * Converts a glob-style wildcard pattern into an anchored RegExp.
+ *
+ * All regex metacharacters are escaped except `*` and `?`, which are translated
+ * to `.*` and `.` respectively. The result is anchored with `^…$` so the whole
+ * tenant name must match.
+ */
+export function wildcardToRegExp(pattern: string): RegExp {
+  // Escape every regex special char except * and ? (handled below).
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  const converted = escaped.replace(/\*/g, '.*').replace(/\?/g, '.');
+  return new RegExp(`^${converted}$`);
+}
+
+/**
+ * Builds the matcher RegExp for a pattern + mode.
+ *
+ * @throws SyntaxError if `mode` is `regex` and the pattern is not a valid regex.
+ */
+export function buildTenantMatcher(pattern: string, mode: TenantMatchMode): RegExp {
+  return mode === 'wildcard' ? wildcardToRegExp(pattern) : new RegExp(pattern);
+}
+
+/**
+ * Returns the subset of `names` that match `pattern` under the given `mode`.
+ *
+ * An empty/blank pattern matches nothing (returns `[]`) so an empty input never
+ * accidentally selects every tenant. Order of the input is preserved.
+ *
+ * @throws SyntaxError if `mode` is `regex` and the pattern is invalid — callers
+ *         should catch this to surface a friendly "invalid pattern" message.
+ */
+export function matchTenantNames(
+  names: string[],
+  pattern: string,
+  mode: TenantMatchMode
+): string[] {
+  if (!pattern || pattern.trim() === '') {
+    return [];
+  }
+  const matcher = buildTenantMatcher(pattern, mode);
+  return names.filter((name) => matcher.test(name));
+}

--- a/src/views/EditMultiTenancyPanel.ts
+++ b/src/views/EditMultiTenancyPanel.ts
@@ -1,0 +1,218 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+
+/** Data the webview form sends back on save. */
+export interface MultiTenancyUpdateData {
+  autoTenantCreation: boolean;
+  autoTenantActivation: boolean;
+}
+
+/** Current multi-tenancy config passed to the form on open. */
+export interface MultiTenancyInitData {
+  enabled: boolean;
+  autoTenantCreation: boolean;
+  autoTenantActivation: boolean;
+  readOnly: boolean;
+}
+
+/**
+ * Manages the "Edit Multi-Tenancy" webview panel — a small form to toggle
+ * autoTenantCreation / autoTenantActivation on a single collection.
+ *
+ * One panel per (connection, collection); re-opening reveals the existing one.
+ */
+export class EditMultiTenancyPanel {
+  private static readonly panels = new Map<string, EditMultiTenancyPanel>();
+  private readonly _panel: vscode.WebviewPanel;
+  private readonly _extensionUri: vscode.Uri;
+  private _disposables: vscode.Disposable[] = [];
+  private readonly _connectionId: string;
+  private readonly _collectionName: string;
+  private _init: MultiTenancyInitData;
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    extensionUri: vscode.Uri,
+    connectionId: string,
+    collectionName: string,
+    init: MultiTenancyInitData,
+    private readonly onSaveCallback: (data: MultiTenancyUpdateData) => Promise<void>
+  ) {
+    this._panel = panel;
+    this._extensionUri = extensionUri;
+    this._connectionId = connectionId;
+    this._collectionName = collectionName;
+    this._init = init;
+
+    this._update();
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+    this._panel.webview.onDidReceiveMessage(
+      async (message) => this._handleMessage(message),
+      null,
+      this._disposables
+    );
+  }
+
+  private static _key(connectionId: string, collectionName: string): string {
+    return `${connectionId}:${collectionName}`;
+  }
+
+  public static createOrShow(
+    extensionUri: vscode.Uri,
+    connectionId: string,
+    collectionName: string,
+    init: MultiTenancyInitData,
+    onSaveCallback: (data: MultiTenancyUpdateData) => Promise<void>
+  ): EditMultiTenancyPanel {
+    const column = vscode.window.activeTextEditor
+      ? vscode.window.activeTextEditor.viewColumn
+      : undefined;
+
+    const key = EditMultiTenancyPanel._key(connectionId, collectionName);
+    const existing = EditMultiTenancyPanel.panels.get(key);
+    if (existing) {
+      existing._init = init;
+      existing._panel.reveal(column);
+      existing.postMessage({ command: 'initData', ...existing._payload() });
+      return existing;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      'weaviateEditMultiTenancy',
+      `Multi-Tenancy: ${collectionName}`,
+      column || vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [
+          vscode.Uri.joinPath(extensionUri, 'dist', 'webview'),
+          vscode.Uri.joinPath(extensionUri, 'node_modules', '@vscode/codicons', 'dist'),
+        ],
+      }
+    );
+
+    const instance = new EditMultiTenancyPanel(
+      panel,
+      extensionUri,
+      connectionId,
+      collectionName,
+      init,
+      onSaveCallback
+    );
+    EditMultiTenancyPanel.panels.set(key, instance);
+    return instance;
+  }
+
+  public static closeFor(connectionId: string, collectionName: string): void {
+    EditMultiTenancyPanel.panels
+      .get(EditMultiTenancyPanel._key(connectionId, collectionName))
+      ?.dispose();
+  }
+
+  public postMessage(message: any): void {
+    this._panel.webview.postMessage(message);
+  }
+
+  private _payload() {
+    return {
+      connectionId: this._connectionId,
+      collectionName: this._collectionName,
+      enabled: this._init.enabled,
+      autoTenantCreation: this._init.autoTenantCreation,
+      autoTenantActivation: this._init.autoTenantActivation,
+      readOnly: this._init.readOnly,
+    };
+  }
+
+  private async _handleMessage(message: any): Promise<void> {
+    switch (message?.command) {
+      case 'ready':
+        this.postMessage({ command: 'initData', ...this._payload() });
+        break;
+      case 'save':
+        try {
+          await this.onSaveCallback({
+            autoTenantCreation: !!message.autoTenantCreation,
+            autoTenantActivation: !!message.autoTenantActivation,
+          });
+          this._init = {
+            ...this._init,
+            autoTenantCreation: !!message.autoTenantCreation,
+            autoTenantActivation: !!message.autoTenantActivation,
+          };
+          this.postMessage({ command: 'saved' });
+          this.dispose();
+        } catch (error) {
+          this.postMessage({
+            command: 'error',
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+        break;
+      case 'cancel':
+        this.dispose();
+        break;
+      default:
+        break;
+    }
+  }
+
+  public dispose(): void {
+    EditMultiTenancyPanel.panels.delete(
+      EditMultiTenancyPanel._key(this._connectionId, this._collectionName)
+    );
+    this._panel.dispose();
+    while (this._disposables.length) {
+      this._disposables.pop()?.dispose();
+    }
+  }
+
+  private _update(): void {
+    this._panel.webview.html = this._getHtmlForWebview(this._panel.webview);
+  }
+
+  private _getHtmlForWebview(webview: vscode.Webview): string {
+    const distPath = vscode.Uri.joinPath(this._extensionUri, 'dist', 'webview');
+    const htmlPath = vscode.Uri.joinPath(distPath, 'editMultiTenancy.html');
+
+    let html = '';
+    try {
+      html = fs.readFileSync(htmlPath.fsPath, 'utf8');
+    } catch (error) {
+      console.error('Failed to read HTML file:', error);
+      return `<!DOCTYPE html><html><body>
+        <h1>Error loading Edit Multi-Tenancy panel</h1>
+        <p>The webview bundle has not been built. Please run: npm run build:webview</p>
+        </body></html>`;
+    }
+
+    html = html.replace(/(src|href)="([^"]+)"/g, (match, attr, assetPath) => {
+      if (assetPath.startsWith('http') || assetPath.startsWith('//')) {
+        return match;
+      }
+      const assetUri = webview.asWebviewUri(vscode.Uri.joinPath(distPath, assetPath));
+      return `${attr}="${assetUri}"`;
+    });
+
+    const cspSource = webview.cspSource;
+    html = html.replace(
+      '<head>',
+      `<head>
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-{{nonce}}' ${cspSource}; script-src 'nonce-{{nonce}}' ${cspSource}; img-src ${cspSource} https: data:; font-src ${cspSource}; connect-src ${cspSource};">`
+    );
+
+    const nonce = this._getNonce();
+    html = html.replace(/{{nonce}}/g, nonce);
+
+    return html;
+  }
+
+  private _getNonce(): string {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+      text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+  }
+}

--- a/src/views/ManageTenantsPanel.ts
+++ b/src/views/ManageTenantsPanel.ts
@@ -1,0 +1,250 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+
+/** A tenant entry shown in the panel. */
+export interface TenantEntry {
+  name: string;
+  activityStatus: string;
+  /** Object count from node status; `null` when unknown (tenant not loaded). */
+  objectCount: number | null;
+}
+
+/** Init payload passed to the Manage Tenants webview. */
+export interface ManageTenantsInitData {
+  readOnly: boolean;
+  serverVersion: string;
+  offloadModuleAvailable: boolean;
+  offloadSupported: boolean;
+  offloadMinVersion: string;
+  tenants: TenantEntry[];
+}
+
+/** Payload sent from the webview when applying a status change. */
+export interface ApplyTenantStatusData {
+  status: 'ACTIVE' | 'INACTIVE' | 'OFFLOADED';
+  names: string[];
+}
+
+/**
+ * Manages the "Manage Tenants" webview panel — bulk activation / deactivation /
+ * offloading of tenants, selected either explicitly or by wildcard/regex pattern.
+ *
+ * One panel per (connection, collection); re-opening reveals the existing one.
+ */
+export class ManageTenantsPanel {
+  private static readonly panels = new Map<string, ManageTenantsPanel>();
+  private readonly _panel: vscode.WebviewPanel;
+  private readonly _extensionUri: vscode.Uri;
+  private _disposables: vscode.Disposable[] = [];
+  private readonly _connectionId: string;
+  private readonly _collectionName: string;
+  private _init: ManageTenantsInitData;
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    extensionUri: vscode.Uri,
+    connectionId: string,
+    collectionName: string,
+    init: ManageTenantsInitData,
+    private readonly onApplyCallback: (data: ApplyTenantStatusData) => Promise<TenantEntry[]>,
+    private readonly onDeleteCallback: (names: string[]) => Promise<TenantEntry[]>
+  ) {
+    this._panel = panel;
+    this._extensionUri = extensionUri;
+    this._connectionId = connectionId;
+    this._collectionName = collectionName;
+    this._init = init;
+
+    this._update();
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+    this._panel.webview.onDidReceiveMessage(
+      async (message) => this._handleMessage(message),
+      null,
+      this._disposables
+    );
+  }
+
+  private static _key(connectionId: string, collectionName: string): string {
+    return `${connectionId}:${collectionName}`;
+  }
+
+  public static createOrShow(
+    extensionUri: vscode.Uri,
+    connectionId: string,
+    collectionName: string,
+    init: ManageTenantsInitData,
+    onApplyCallback: (data: ApplyTenantStatusData) => Promise<TenantEntry[]>,
+    onDeleteCallback: (names: string[]) => Promise<TenantEntry[]>
+  ): ManageTenantsPanel {
+    const column = vscode.window.activeTextEditor
+      ? vscode.window.activeTextEditor.viewColumn
+      : undefined;
+
+    const key = ManageTenantsPanel._key(connectionId, collectionName);
+    const existing = ManageTenantsPanel.panels.get(key);
+    if (existing) {
+      existing._init = init;
+      existing._panel.reveal(column);
+      existing.postMessage({ command: 'initData', ...existing._payload() });
+      return existing;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      'weaviateManageTenants',
+      `Tenants: ${collectionName}`,
+      column || vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [
+          vscode.Uri.joinPath(extensionUri, 'dist', 'webview'),
+          vscode.Uri.joinPath(extensionUri, 'node_modules', '@vscode/codicons', 'dist'),
+        ],
+      }
+    );
+
+    const instance = new ManageTenantsPanel(
+      panel,
+      extensionUri,
+      connectionId,
+      collectionName,
+      init,
+      onApplyCallback,
+      onDeleteCallback
+    );
+    ManageTenantsPanel.panels.set(key, instance);
+    return instance;
+  }
+
+  public static closeFor(connectionId: string, collectionName: string): void {
+    ManageTenantsPanel.panels.get(ManageTenantsPanel._key(connectionId, collectionName))?.dispose();
+  }
+
+  public postMessage(message: any): void {
+    this._panel.webview.postMessage(message);
+  }
+
+  private _payload() {
+    return {
+      connectionId: this._connectionId,
+      collectionName: this._collectionName,
+      readOnly: this._init.readOnly,
+      serverVersion: this._init.serverVersion,
+      offloadModuleAvailable: this._init.offloadModuleAvailable,
+      offloadSupported: this._init.offloadSupported,
+      offloadMinVersion: this._init.offloadMinVersion,
+      tenants: this._init.tenants,
+    };
+  }
+
+  private async _handleMessage(message: any): Promise<void> {
+    switch (message?.command) {
+      case 'ready':
+        this.postMessage({ command: 'initData', ...this._payload() });
+        break;
+      case 'apply':
+        try {
+          const names: string[] = Array.isArray(message.names) ? message.names : [];
+          const status = message.status;
+          if (status !== 'ACTIVE' && status !== 'INACTIVE' && status !== 'OFFLOADED') {
+            throw new Error(`Unknown target status: ${status}`);
+          }
+          const tenants = await this.onApplyCallback({ status, names });
+          // A null/undefined result means the operation was cancelled — keep state.
+          if (tenants) {
+            this._init = { ...this._init, tenants };
+            this.postMessage({ command: 'tenantsUpdated', tenants });
+          } else {
+            this.postMessage({ command: 'tenantsUpdated', tenants: this._init.tenants });
+          }
+        } catch (error) {
+          this.postMessage({
+            command: 'error',
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+        break;
+      case 'delete':
+        try {
+          const names: string[] = Array.isArray(message.names) ? message.names : [];
+          const tenants = await this.onDeleteCallback(names);
+          if (tenants) {
+            this._init = { ...this._init, tenants };
+            this.postMessage({ command: 'tenantsUpdated', tenants });
+          } else {
+            this.postMessage({ command: 'tenantsUpdated', tenants: this._init.tenants });
+          }
+        } catch (error) {
+          this.postMessage({
+            command: 'error',
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+        break;
+      case 'cancel':
+        this.dispose();
+        break;
+      default:
+        break;
+    }
+  }
+
+  public dispose(): void {
+    ManageTenantsPanel.panels.delete(
+      ManageTenantsPanel._key(this._connectionId, this._collectionName)
+    );
+    this._panel.dispose();
+    while (this._disposables.length) {
+      this._disposables.pop()?.dispose();
+    }
+  }
+
+  private _update(): void {
+    this._panel.webview.html = this._getHtmlForWebview(this._panel.webview);
+  }
+
+  private _getHtmlForWebview(webview: vscode.Webview): string {
+    const distPath = vscode.Uri.joinPath(this._extensionUri, 'dist', 'webview');
+    const htmlPath = vscode.Uri.joinPath(distPath, 'manageTenants.html');
+
+    let html = '';
+    try {
+      html = fs.readFileSync(htmlPath.fsPath, 'utf8');
+    } catch (error) {
+      console.error('Failed to read HTML file:', error);
+      return `<!DOCTYPE html><html><body>
+        <h1>Error loading Manage Tenants panel</h1>
+        <p>The webview bundle has not been built. Please run: npm run build:webview</p>
+        </body></html>`;
+    }
+
+    html = html.replace(/(src|href)="([^"]+)"/g, (match, attr, assetPath) => {
+      if (assetPath.startsWith('http') || assetPath.startsWith('//')) {
+        return match;
+      }
+      const assetUri = webview.asWebviewUri(vscode.Uri.joinPath(distPath, assetPath));
+      return `${attr}="${assetUri}"`;
+    });
+
+    const cspSource = webview.cspSource;
+    html = html.replace(
+      '<head>',
+      `<head>
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-{{nonce}}' ${cspSource}; script-src 'nonce-{{nonce}}' ${cspSource}; img-src ${cspSource} https: data:; font-src ${cspSource}; connect-src ${cspSource};">`
+    );
+
+    const nonce = this._getNonce();
+    html = html.replace(/{{nonce}}/g, nonce);
+
+    return html;
+  }
+
+  private _getNonce(): string {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+      text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+  }
+}

--- a/src/webview/Cluster.css
+++ b/src/webview/Cluster.css
@@ -1258,8 +1258,13 @@
   cursor: default;
 }
 
-.checks-action-button--danger {
+.checks-group-actions {
   margin-left: auto;
+  display: flex;
+  gap: 8px;
+}
+
+.checks-action-button--danger {
   background-color: var(--vscode-button-secondaryBackground, transparent);
   color: var(--vscode-errorForeground);
   border: 1px solid var(--vscode-errorForeground);

--- a/src/webview/Cluster.css
+++ b/src/webview/Cluster.css
@@ -1230,3 +1230,75 @@
   color: var(--vscode-descriptionForeground);
   font-size: 11px;
 }
+
+/* ── Check action buttons (Enable on all, Delete empty tenants) ────────────── */
+.checks-section-actions {
+  display: flex;
+  gap: 8px;
+  margin: 8px 0 12px;
+}
+
+.checks-action-button {
+  padding: 5px 12px;
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  border: none;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+  font-family: var(--vscode-font-family);
+}
+
+.checks-action-button:hover:not(:disabled) {
+  background-color: var(--vscode-button-hoverBackground);
+}
+
+.checks-action-button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.checks-action-button--danger {
+  margin-left: auto;
+  background-color: var(--vscode-button-secondaryBackground, transparent);
+  color: var(--vscode-errorForeground);
+  border: 1px solid var(--vscode-errorForeground);
+}
+
+.checks-action-button--danger:hover:not(:disabled) {
+  background-color: var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1));
+}
+
+/* ── Auto-tenant flag cells ────────────────────────────────────────────────── */
+.checks-flag-on {
+  color: var(--vscode-testing-iconPassed, var(--vscode-charts-green, #3fb950));
+  font-weight: 600;
+}
+
+.checks-flag-off {
+  color: var(--vscode-errorForeground);
+  font-weight: 600;
+}
+
+/* ── Empty-tenant chips ────────────────────────────────────────────────────── */
+.checks-tenant-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 10px 12px;
+}
+
+.checks-tenant-chip {
+  font-size: 11px;
+  font-family: var(--vscode-editor-font-family, monospace);
+  color: var(--vscode-badge-foreground);
+  background-color: var(--vscode-badge-background);
+  padding: 1px 7px;
+  border-radius: 10px;
+}
+
+.checks-tenant-chip--more {
+  background-color: transparent;
+  color: var(--vscode-descriptionForeground);
+  font-style: italic;
+}

--- a/src/webview/ClusterPanel.tsx
+++ b/src/webview/ClusterPanel.tsx
@@ -125,12 +125,31 @@ interface AsyncReplicationDisabledEntry {
   replicationFactor: number;
 }
 
+interface AutoTenantConfigIssue {
+  collectionName: string;
+  autoTenantCreation: boolean;
+  autoTenantActivation: boolean;
+}
+
+interface EmptyTenantCollection {
+  collectionName: string;
+  tenants: string[];
+}
+
 interface ChecksResult {
   timestamp: string;
   /** True when any individual check has issues. Present in newer results. */
   hasIssues?: boolean;
   multiTenancy: {
     groups: MtCandidateGroup[];
+    hasIssues: boolean;
+  };
+  autoTenantConfig?: {
+    issues: AutoTenantConfigIssue[];
+    hasIssues: boolean;
+  };
+  emptyTenants?: {
+    collections: EmptyTenantCollection[];
     hasIssues: boolean;
   };
   emptyShards?: {
@@ -178,6 +197,16 @@ function openExternalLink(url: string) {
   vscode.postMessage({ command: 'openExternal', url });
 }
 
+/** Asks the extension to enable auto-tenant creation + activation on all flagged collections. */
+function enableAutoTenantAll() {
+  vscode.postMessage({ command: 'enableAutoTenantAll' });
+}
+
+/** Asks the extension to delete the empty ACTIVE tenants of a collection. */
+function deleteEmptyTenants(collectionName: string) {
+  vscode.postMessage({ command: 'deleteEmptyTenants', collectionName });
+}
+
 /**
  * Formats a replication ratio (0–1) as a percentage string.
  *
@@ -200,6 +229,8 @@ function formatReplicationPct(ratio: number): string {
 
 function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
   const groups = checksResult?.multiTenancy.groups ?? [];
+  const autoTenantIssues = checksResult?.autoTenantConfig?.issues ?? [];
+  const emptyTenantCollections = checksResult?.emptyTenants?.collections ?? [];
   const emptyShardEntries = checksResult?.emptyShards?.entries ?? [];
   const emptyShardRatioEntries = checksResult?.emptyShardRatio?.entries ?? [];
   const replicationCollections = checksResult?.replicationImbalance?.collections ?? [];
@@ -292,6 +323,161 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
                         </li>
                       ))}
                     </ul>
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+
+          {/* ── Auto-Tenant Configuration ─────────────────────────────── */}
+          <div
+            className={`checks-section${autoTenantIssues.length > 0 ? ' checks-section--warning' : ''}`}
+          >
+            <h3 className="checks-section-title">
+              {autoTenantIssues.length > 0 && (
+                <span className="checks-section-warning-icon">⚠</span>
+              )}
+              Auto-Tenant Configuration
+            </h3>
+            {autoTenantIssues.length === 0 ? (
+              <div className="checks-ok">
+                <span className="checks-ok-icon">✓</span>
+                All multi-tenant collections have auto-tenant creation and activation enabled.
+              </div>
+            ) : (
+              <>
+                <p className="checks-section-desc">
+                  The following multi-tenant collections have <code>autoTenantCreation</code> and/or{' '}
+                  <code>autoTenantActivation</code> disabled. When <code>autoTenantCreation</code>{' '}
+                  is off, clients must create tenants manually before writing (a common source of
+                  "tenant not found" errors); when <code>autoTenantActivation</code> is off,
+                  inactive tenants must be reactivated manually before use (a common source of
+                  "tenant is inactive" errors).{' '}
+                  <a
+                    href="https://docs.weaviate.io/weaviate/manage-collections/multi-tenancy#automatically-add-new-tenants"
+                    className="checks-link"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      openExternalLink(
+                        'https://docs.weaviate.io/weaviate/manage-collections/multi-tenancy#automatically-add-new-tenants'
+                      );
+                    }}
+                  >
+                    Learn more ↗
+                  </a>
+                </p>
+                <div className="checks-section-actions">
+                  <button
+                    className="checks-action-button"
+                    onClick={enableAutoTenantAll}
+                    title="Enable autoTenantCreation and autoTenantActivation on all listed collections"
+                  >
+                    Enable on all ({autoTenantIssues.length})
+                  </button>
+                </div>
+                <table className="checks-table">
+                  <thead>
+                    <tr>
+                      <th>Collection</th>
+                      <th>autoTenantCreation</th>
+                      <th>autoTenantActivation</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {autoTenantIssues.map((issue) => (
+                      <tr key={issue.collectionName}>
+                        <td>
+                          <span className="checks-col-name">{issue.collectionName}</span>
+                        </td>
+                        <td
+                          className={
+                            issue.autoTenantCreation ? 'checks-flag-on' : 'checks-flag-off'
+                          }
+                        >
+                          {issue.autoTenantCreation ? 'on' : 'off'}
+                        </td>
+                        <td
+                          className={
+                            issue.autoTenantActivation ? 'checks-flag-on' : 'checks-flag-off'
+                          }
+                        >
+                          {issue.autoTenantActivation ? 'on' : 'off'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </>
+            )}
+          </div>
+
+          {/* ── Empty Tenants (Active) ────────────────────────────────── */}
+          <div
+            className={`checks-section${emptyTenantCollections.length > 0 ? ' checks-section--warning' : ''}`}
+          >
+            <h3 className="checks-section-title">
+              {emptyTenantCollections.length > 0 && (
+                <span className="checks-section-warning-icon">⚠</span>
+              )}
+              Empty Tenants (Active)
+            </h3>
+            {emptyTenantCollections.length === 0 ? (
+              <div className="checks-ok">
+                <span className="checks-ok-icon">✓</span>
+                No empty active tenants detected.
+              </div>
+            ) : (
+              <>
+                <p className="checks-section-desc">
+                  The following multi-tenant collections have <strong>ACTIVE</strong> tenants that
+                  are loaded into memory but hold zero objects. These waste RAM. Consider deleting
+                  them, or deactivating them to offload to disk.{' '}
+                  <a
+                    href="https://docs.weaviate.io/weaviate/manage-collections/tenant-states"
+                    className="checks-link"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      openExternalLink(
+                        'https://docs.weaviate.io/weaviate/manage-collections/tenant-states'
+                      );
+                    }}
+                  >
+                    Learn more ↗
+                  </a>
+                </p>
+                <div className="checks-info-callout">
+                  <span className="checks-info-callout-icon">ℹ️</span>
+                  Only ACTIVE (in-memory) tenants are shown — INACTIVE/OFFLOADED tenants live on
+                  disk/cloud and are not counted here. Object counts from node status may lag
+                  slightly, so only delete tenants that consistently show zero objects.
+                </div>
+                {emptyTenantCollections.map((col) => (
+                  <div key={col.collectionName} className="checks-group">
+                    <div className="checks-group-header">
+                      <span className="checks-group-label">{col.collectionName}</span>
+                      <span className="checks-group-count">
+                        {col.tenants.length} empty tenant{col.tenants.length !== 1 ? 's' : ''}
+                      </span>
+                      <button
+                        className="checks-action-button checks-action-button--danger"
+                        onClick={() => deleteEmptyTenants(col.collectionName)}
+                        title={`Delete the ${col.tenants.length} empty tenants of ${col.collectionName}`}
+                      >
+                        Delete empty tenants
+                      </button>
+                    </div>
+                    <div className="checks-tenant-chips">
+                      {col.tenants.slice(0, 50).map((name) => (
+                        <span key={name} className="checks-tenant-chip">
+                          {name}
+                        </span>
+                      ))}
+                      {col.tenants.length > 50 && (
+                        <span className="checks-tenant-chip checks-tenant-chip--more">
+                          +{col.tenants.length - 50} more
+                        </span>
+                      )}
+                    </div>
                   </div>
                 ))}
               </>
@@ -1635,8 +1821,12 @@ function ClusterPanelWebview() {
                 if (!checksResult) return '';
                 const issueCount = [
                   checksResult.multiTenancy?.hasIssues,
+                  checksResult.autoTenantConfig?.hasIssues,
+                  checksResult.emptyTenants?.hasIssues,
                   checksResult.emptyShards?.hasIssues,
+                  checksResult.emptyShardRatio?.hasIssues,
                   checksResult.replicationImbalance?.hasIssues,
+                  checksResult.asyncReplicationDisabled?.hasIssues,
                 ].filter(Boolean).length;
                 return issueCount > 0 ? ` (${issueCount})` : '';
               })()}

--- a/src/webview/ClusterPanel.tsx
+++ b/src/webview/ClusterPanel.tsx
@@ -207,6 +207,11 @@ function deleteEmptyTenants(collectionName: string) {
   vscode.postMessage({ command: 'deleteEmptyTenants', collectionName });
 }
 
+/** Asks the extension to set the empty ACTIVE tenants of a collection to INACTIVE. */
+function deactivateEmptyTenants(collectionName: string) {
+  vscode.postMessage({ command: 'deactivateEmptyTenants', collectionName });
+}
+
 /**
  * Formats a replication ratio (0–1) as a percentage string.
  *
@@ -458,13 +463,22 @@ function ChecksView({ checksResult, isRunning, onRunChecks }: ChecksViewProps) {
                       <span className="checks-group-count">
                         {col.tenants.length} empty tenant{col.tenants.length !== 1 ? 's' : ''}
                       </span>
-                      <button
-                        className="checks-action-button checks-action-button--danger"
-                        onClick={() => deleteEmptyTenants(col.collectionName)}
-                        title={`Delete the ${col.tenants.length} empty tenants of ${col.collectionName}`}
-                      >
-                        Delete empty tenants
-                      </button>
+                      <div className="checks-group-actions">
+                        <button
+                          className="checks-action-button"
+                          onClick={() => deactivateEmptyTenants(col.collectionName)}
+                          title={`Set the ${col.tenants.length} empty tenants of ${col.collectionName} to INACTIVE (offload to disk, keeps the tenant)`}
+                        >
+                          Inactivate empty tenants
+                        </button>
+                        <button
+                          className="checks-action-button checks-action-button--danger"
+                          onClick={() => deleteEmptyTenants(col.collectionName)}
+                          title={`Delete the ${col.tenants.length} empty tenants of ${col.collectionName}`}
+                        >
+                          Delete empty tenants
+                        </button>
+                      </div>
                     </div>
                     <div className="checks-tenant-chips">
                       {col.tenants.slice(0, 50).map((name) => (

--- a/src/webview/EditMultiTenancy.css
+++ b/src/webview/EditMultiTenancy.css
@@ -1,0 +1,115 @@
+body {
+  color: var(--vscode-foreground);
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  padding: 0;
+  margin: 0;
+}
+
+.mt-form {
+  max-width: 640px;
+  padding: 20px 24px;
+}
+
+.mt-form h1 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+
+.mt-collection-name {
+  color: var(--vscode-descriptionForeground);
+  font-size: 13px;
+  margin: 0 0 20px;
+}
+
+.mt-collection-name code {
+  font-family: var(--vscode-editor-font-family, monospace);
+  color: var(--vscode-foreground);
+}
+
+.mt-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 6px;
+  margin-bottom: 12px;
+  background-color: var(--vscode-editor-background);
+}
+
+.mt-option input[type='checkbox'] {
+  margin-top: 2px;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: var(--vscode-checkbox-selectBackground, var(--vscode-button-background));
+}
+
+.mt-option-text {
+  flex: 1;
+}
+
+.mt-option-label {
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.mt-option-desc {
+  color: var(--vscode-descriptionForeground);
+  font-size: 12px;
+  margin-top: 4px;
+  line-height: 1.4;
+}
+
+.mt-disabled-note {
+  padding: 14px;
+  border: 1px solid var(--vscode-inputValidation-warningBorder, var(--vscode-panel-border));
+  background-color: var(--vscode-inputValidation-warningBackground, transparent);
+  border-radius: 6px;
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+
+.mt-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.mt-button {
+  padding: 7px 16px;
+  border: none;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  font-family: var(--vscode-font-family);
+}
+
+.mt-button--primary {
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+.mt-button--primary:hover:not(:disabled) {
+  background-color: var(--vscode-button-hoverBackground);
+}
+
+.mt-button--secondary {
+  background-color: var(--vscode-button-secondaryBackground, transparent);
+  color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+  border: 1px solid var(--vscode-panel-border);
+}
+
+.mt-button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.mt-error {
+  color: var(--vscode-errorForeground);
+  font-size: 13px;
+  margin-top: 12px;
+}

--- a/src/webview/EditMultiTenancy.tsx
+++ b/src/webview/EditMultiTenancy.tsx
@@ -1,0 +1,159 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { createRoot } from 'react-dom/client';
+import './EditMultiTenancy.css';
+
+let vscode: any;
+try {
+  vscode = window.acquireVsCodeApi();
+} catch (error) {
+  console.error('Failed to acquire VS Code API', error);
+}
+
+interface InitData {
+  connectionId: string;
+  collectionName: string;
+  enabled: boolean;
+  autoTenantCreation: boolean;
+  autoTenantActivation: boolean;
+  readOnly: boolean;
+}
+
+function EditMultiTenancyWebview() {
+  const [collectionName, setCollectionName] = useState('');
+  const [enabled, setEnabled] = useState(true);
+  const [readOnly, setReadOnly] = useState(false);
+  const [autoTenantCreation, setAutoTenantCreation] = useState(false);
+  const [autoTenantActivation, setAutoTenantActivation] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const applyInit = useCallback((data: InitData) => {
+    setCollectionName(data.collectionName);
+    setEnabled(data.enabled);
+    setReadOnly(data.readOnly);
+    setAutoTenantCreation(data.autoTenantCreation);
+    setAutoTenantActivation(data.autoTenantActivation);
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const message = event.data;
+      switch (message?.command) {
+        case 'initData':
+          applyInit(message as InitData);
+          break;
+        case 'saved':
+          setIsSaving(false);
+          break;
+        case 'error':
+          setIsSaving(false);
+          setError(message.message ?? 'Unknown error');
+          break;
+        default:
+          break;
+      }
+    };
+    window.addEventListener('message', handler);
+    vscode?.postMessage({ command: 'ready' });
+    return () => window.removeEventListener('message', handler);
+  }, [applyInit]);
+
+  const handleSave = () => {
+    setError(null);
+    setIsSaving(true);
+    vscode?.postMessage({
+      command: 'save',
+      autoTenantCreation,
+      autoTenantActivation,
+    });
+  };
+
+  const handleCancel = () => {
+    vscode?.postMessage({ command: 'cancel' });
+  };
+
+  return (
+    <div className="mt-form">
+      <h1>Edit Multi-Tenancy</h1>
+      <p className="mt-collection-name">
+        Collection <code>{collectionName || '…'}</code>
+      </p>
+
+      {!enabled && (
+        <div className="mt-disabled-note">
+          Multi-tenancy is <strong>disabled</strong> on this collection. Auto-tenant options only
+          take effect for multi-tenant collections and cannot be enabled after creation.
+        </div>
+      )}
+
+      <div className="mt-option">
+        <input
+          id="autoTenantCreation"
+          type="checkbox"
+          checked={autoTenantCreation}
+          disabled={!enabled || readOnly}
+          onChange={(e) => setAutoTenantCreation(e.target.checked)}
+        />
+        <div className="mt-option-text">
+          <label className="mt-option-label" htmlFor="autoTenantCreation">
+            Auto Tenant Creation
+          </label>
+          <div className="mt-option-desc">
+            Automatically create a tenant the first time data is written to it, so clients don't
+            have to create tenants explicitly before inserting.
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-option">
+        <input
+          id="autoTenantActivation"
+          type="checkbox"
+          checked={autoTenantActivation}
+          disabled={!enabled || readOnly}
+          onChange={(e) => setAutoTenantActivation(e.target.checked)}
+        />
+        <div className="mt-option-text">
+          <label className="mt-option-label" htmlFor="autoTenantActivation">
+            Auto Tenant Activation
+          </label>
+          <div className="mt-option-desc">
+            Automatically load an INACTIVE tenant back into memory when it is accessed, instead of
+            returning a "tenant is inactive" error.
+          </div>
+        </div>
+      </div>
+
+      {readOnly && (
+        <div className="mt-disabled-note">
+          This connection is <strong>read-only</strong>. Enable write access to change these
+          settings.
+        </div>
+      )}
+
+      {error && <div className="mt-error">{error}</div>}
+
+      <div className="mt-actions">
+        <button
+          className="mt-button mt-button--primary"
+          onClick={handleSave}
+          disabled={!enabled || readOnly || isSaving}
+        >
+          {isSaving ? 'Saving…' : 'Save'}
+        </button>
+        <button
+          className="mt-button mt-button--secondary"
+          onClick={handleCancel}
+          disabled={isSaving}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const container = document.getElementById('root');
+if (container) {
+  createRoot(container).render(<EditMultiTenancyWebview />);
+}

--- a/src/webview/ManageTenants.css
+++ b/src/webview/ManageTenants.css
@@ -1,0 +1,297 @@
+body {
+  color: var(--vscode-foreground);
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  padding: 0;
+  margin: 0;
+}
+
+.mtnt {
+  max-width: 820px;
+  padding: 20px 24px;
+}
+
+.mtnt h1 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+
+.mtnt-sub {
+  color: var(--vscode-descriptionForeground);
+  font-size: 13px;
+  margin: 0 0 16px;
+}
+
+.mtnt-sub code {
+  font-family: var(--vscode-editor-font-family, monospace);
+  color: var(--vscode-foreground);
+}
+
+/* ── Notes ─────────────────────────────────────────────────────────────────── */
+.mtnt-note {
+  padding: 12px 14px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  margin-bottom: 12px;
+  border: 1px solid var(--vscode-panel-border);
+}
+
+.mtnt-note--warning {
+  border-color: var(--vscode-inputValidation-warningBorder, var(--vscode-panel-border));
+  background-color: var(--vscode-inputValidation-warningBackground, transparent);
+}
+
+.mtnt-note code {
+  font-family: var(--vscode-editor-font-family, monospace);
+}
+
+/* ── Segments / radios ─────────────────────────────────────────────────────── */
+.mtnt-section {
+  margin-bottom: 18px;
+}
+
+.mtnt-section-title {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--vscode-descriptionForeground);
+  margin: 0 0 8px;
+}
+
+.mtnt-radio-row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.mtnt-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.mtnt-radio input {
+  cursor: pointer;
+}
+
+.mtnt-radio input:disabled + span {
+  opacity: 0.5;
+}
+
+/* ── Inputs ────────────────────────────────────────────────────────────────── */
+.mtnt-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  background-color: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+  border-radius: 4px;
+  font-family: var(--vscode-font-family);
+  font-size: 13px;
+}
+
+.mtnt-input:focus {
+  outline: none;
+  border-color: var(--vscode-focusBorder);
+}
+
+.mtnt-input--mono {
+  font-family: var(--vscode-editor-font-family, monospace);
+}
+
+/* ── Tenant list ───────────────────────────────────────────────────────────── */
+.mtnt-list-toolbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin: 8px 0;
+}
+
+.mtnt-list-toolbar .mtnt-input {
+  flex: 1;
+}
+
+.mtnt-link-button {
+  background: none;
+  border: none;
+  color: var(--vscode-textLink-foreground);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 4px;
+}
+
+.mtnt-list-summary {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  margin: 6px 2px;
+}
+
+.mtnt-list {
+  overflow-y: auto;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 6px;
+}
+
+.mtnt-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px;
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  font-size: 13px;
+}
+
+.mtnt-row:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.mtnt-row input {
+  cursor: pointer;
+}
+
+.mtnt-row-name {
+  flex: 1;
+  font-family: var(--vscode-editor-font-family, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mtnt-row-count {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  min-width: 52px;
+  text-align: right;
+}
+
+.mtnt-hint {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  line-height: 1.5;
+  margin: 2px 2px 8px;
+}
+
+.mtnt-hint code {
+  font-family: var(--vscode-editor-font-family, monospace);
+  background-color: var(--vscode-textCodeBlock-background, var(--vscode-badge-background));
+  padding: 0 4px;
+  border-radius: 3px;
+}
+
+.mtnt-empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--vscode-descriptionForeground);
+  font-size: 13px;
+}
+
+/* ── Status badges ─────────────────────────────────────────────────────────── */
+.mtnt-badge {
+  font-size: 11px;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.mtnt-badge--active {
+  background-color: var(--vscode-testing-iconPassed, #3fb950);
+  color: var(--vscode-editor-background);
+}
+
+.mtnt-badge--inactive {
+  background-color: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}
+
+.mtnt-badge--offloaded {
+  background-color: var(--vscode-charts-blue, #3794ff);
+  color: var(--vscode-editor-background);
+}
+
+.mtnt-badge--transition {
+  background-color: var(--vscode-charts-yellow, #d7ba7d);
+  color: var(--vscode-editor-background);
+}
+
+/* ── Pattern preview ───────────────────────────────────────────────────────── */
+.mtnt-preview {
+  margin-top: 8px;
+  font-size: 12.5px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.mtnt-preview-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.mtnt-chip {
+  font-size: 11px;
+  font-family: var(--vscode-editor-font-family, monospace);
+  color: var(--vscode-badge-foreground);
+  background-color: var(--vscode-badge-background);
+  padding: 1px 7px;
+  border-radius: 10px;
+}
+
+.mtnt-error {
+  color: var(--vscode-errorForeground);
+  font-size: 12.5px;
+  margin-top: 6px;
+}
+
+/* ── Apply bar ─────────────────────────────────────────────────────────────── */
+.mtnt-apply-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--vscode-panel-border);
+}
+
+.mtnt-button {
+  padding: 7px 16px;
+  border: none;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  font-family: var(--vscode-font-family);
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+.mtnt-button:hover:not(:disabled) {
+  background-color: var(--vscode-button-hoverBackground);
+}
+
+.mtnt-button--danger {
+  background-color: var(--vscode-button-secondaryBackground, transparent);
+  color: var(--vscode-errorForeground);
+  border: 1px solid var(--vscode-errorForeground);
+}
+
+.mtnt-button--danger:hover:not(:disabled) {
+  background-color: var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1));
+}
+
+.mtnt-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.mtnt-selection-count {
+  font-size: 13px;
+  color: var(--vscode-descriptionForeground);
+}

--- a/src/webview/ManageTenants.tsx
+++ b/src/webview/ManageTenants.tsx
@@ -1,0 +1,506 @@
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import './ManageTenants.css';
+import { matchTenantNames, TenantMatchMode } from '../utils/tenantMatch';
+import { parseCountFilter } from '../utils/countFilter';
+
+let vscode: any;
+try {
+  vscode = window.acquireVsCodeApi();
+} catch (error) {
+  console.error('Failed to acquire VS Code API', error);
+}
+
+type ActivityStatus = 'ACTIVE' | 'INACTIVE' | 'OFFLOADED' | 'OFFLOADING' | 'ONLOADING' | string;
+type TargetStatus = 'ACTIVE' | 'INACTIVE' | 'OFFLOADED';
+
+interface TenantEntry {
+  name: string;
+  activityStatus: ActivityStatus;
+  objectCount: number | null;
+}
+
+interface InitData {
+  connectionId: string;
+  collectionName: string;
+  readOnly: boolean;
+  serverVersion: string;
+  offloadModuleAvailable: boolean;
+  offloadSupported: boolean;
+  offloadMinVersion: string;
+  tenants: TenantEntry[];
+}
+
+const PREVIEW_LIMIT = 30;
+
+// Virtualized list geometry — only the rows in view are rendered, so the list
+// stays smooth with tens of thousands of tenants.
+const ROW_HEIGHT = 28;
+const LIST_HEIGHT = 340;
+const OVERSCAN = 8;
+
+function StatusBadge({ status }: { status: ActivityStatus }) {
+  const cls =
+    status === 'ACTIVE'
+      ? 'mtnt-badge--active'
+      : status === 'INACTIVE'
+        ? 'mtnt-badge--inactive'
+        : status === 'OFFLOADED'
+          ? 'mtnt-badge--offloaded'
+          : 'mtnt-badge--transition';
+  return <span className={`mtnt-badge ${cls}`}>{status}</span>;
+}
+
+function ManageTenantsWebview() {
+  const [collectionName, setCollectionName] = useState('');
+  const [readOnly, setReadOnly] = useState(false);
+  const [serverVersion, setServerVersion] = useState('');
+  const [offloadSupported, setOffloadSupported] = useState(false);
+  const [offloadModuleAvailable, setOffloadModuleAvailable] = useState(false);
+  const [offloadMinVersion, setOffloadMinVersion] = useState('1.26.0');
+  const [tenants, setTenants] = useState<TenantEntry[]>([]);
+
+  const [selectionMode, setSelectionMode] = useState<'list' | 'pattern'>('list');
+  const [filter, setFilter] = useState('');
+  const [countFilter, setCountFilter] = useState('');
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [pattern, setPattern] = useState('');
+  const [patternMode, setPatternMode] = useState<TenantMatchMode>('wildcard');
+  const [targetStatus, setTargetStatus] = useState<TargetStatus>('INACTIVE');
+  const [isApplying, setIsApplying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const applyInit = useCallback((data: InitData) => {
+    setCollectionName(data.collectionName);
+    setReadOnly(data.readOnly);
+    setServerVersion(data.serverVersion);
+    setOffloadSupported(data.offloadSupported);
+    setOffloadModuleAvailable(data.offloadModuleAvailable);
+    setOffloadMinVersion(data.offloadMinVersion);
+    setTenants(data.tenants ?? []);
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const message = event.data;
+      switch (message?.command) {
+        case 'initData':
+          applyInit(message as InitData);
+          break;
+        case 'tenantsUpdated':
+          setTenants(message.tenants ?? []);
+          setSelected(new Set());
+          setIsApplying(false);
+          setError(null);
+          break;
+        case 'error':
+          setIsApplying(false);
+          setError(message.message ?? 'Unknown error');
+          break;
+        default:
+          break;
+      }
+    };
+    window.addEventListener('message', handler);
+    vscode?.postMessage({ command: 'ready' });
+    return () => window.removeEventListener('message', handler);
+  }, [applyInit]);
+
+  // If offload becomes unsupported but was selected, fall back to a safe status.
+  useEffect(() => {
+    if (targetStatus === 'OFFLOADED' && !offloadSupported) {
+      setTargetStatus('INACTIVE');
+    }
+  }, [offloadSupported, targetStatus]);
+
+  const tenantNames = useMemo(() => tenants.map((t) => t.name), [tenants]);
+
+  // Compile the count-filter expression once; surface a friendly error on bad input.
+  const { countPredicate, countFilterError } = useMemo(() => {
+    try {
+      return {
+        countPredicate: parseCountFilter(countFilter),
+        countFilterError: null as string | null,
+      };
+    } catch (e) {
+      return {
+        countPredicate: () => true,
+        countFilterError: e instanceof Error ? e.message : 'Invalid count filter',
+      };
+    }
+  }, [countFilter]);
+
+  const filteredTenants = useMemo(() => {
+    const f = filter.trim().toLowerCase();
+    return tenants.filter((t) => {
+      // Name matches as a substring; status matches as a prefix so "active" does
+      // not also match "INACTIVE" (which contains the substring "active").
+      const textMatch =
+        !f || t.name.toLowerCase().includes(f) || t.activityStatus.toLowerCase().startsWith(f);
+      return textMatch && countPredicate(t.objectCount);
+    });
+  }, [tenants, filter, countPredicate]);
+
+  // ── Virtualized list windowing ─────────────────────────────────────────────
+  const listRef = useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+
+  // Reset the scroll position whenever the filtered set changes so we never
+  // stay scrolled past the end of a now-shorter list.
+  useEffect(() => {
+    setScrollTop(0);
+    if (listRef.current) {
+      listRef.current.scrollTop = 0;
+    }
+  }, [filter, countFilter, tenants]);
+
+  const totalRows = filteredTenants.length;
+  const startIndex = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN);
+  const visibleRowCount = Math.ceil(LIST_HEIGHT / ROW_HEIGHT) + OVERSCAN * 2;
+  const endIndex = Math.min(totalRows, startIndex + visibleRowCount);
+  const visibleTenants = filteredTenants.slice(startIndex, endIndex);
+  const topSpacer = startIndex * ROW_HEIGHT;
+  const bottomSpacer = Math.max(0, (totalRows - endIndex) * ROW_HEIGHT);
+
+  const selectedFilteredCount = useMemo(
+    () => filteredTenants.reduce((n, t) => (selected.has(t.name) ? n + 1 : n), 0),
+    [filteredTenants, selected]
+  );
+
+  // Pattern-mode matches + validation.
+  const { matchedNames, patternError } = useMemo(() => {
+    if (selectionMode !== 'pattern' || pattern.trim() === '') {
+      return { matchedNames: [] as string[], patternError: null as string | null };
+    }
+    try {
+      return {
+        matchedNames: matchTenantNames(tenantNames, pattern, patternMode),
+        patternError: null,
+      };
+    } catch (e) {
+      return {
+        matchedNames: [] as string[],
+        patternError: e instanceof Error ? e.message : 'Invalid pattern',
+      };
+    }
+  }, [selectionMode, pattern, patternMode, tenantNames]);
+
+  const selectedNames = selectionMode === 'list' ? Array.from(selected) : matchedNames;
+  const count = selectedNames.length;
+
+  const toggleOne = (name: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  };
+
+  const selectAllFiltered = () => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      filteredTenants.forEach((t) => next.add(t.name));
+      return next;
+    });
+  };
+
+  const deselectAllFiltered = () => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      filteredTenants.forEach((t) => next.delete(t.name));
+      return next;
+    });
+  };
+
+  const clearSelection = () => setSelected(new Set());
+
+  const offloadDisabled = !offloadSupported;
+  const applyDisabled =
+    readOnly || isApplying || count === 0 || (targetStatus === 'OFFLOADED' && offloadDisabled);
+
+  const handleApply = () => {
+    if (readOnly) {
+      return;
+    }
+    setError(null);
+    setIsApplying(true);
+    vscode?.postMessage({
+      command: 'apply',
+      status: targetStatus,
+      names: selectedNames,
+    });
+  };
+
+  const handleDelete = () => {
+    if (readOnly) {
+      return;
+    }
+    setError(null);
+    setIsApplying(true);
+    vscode?.postMessage({
+      command: 'delete',
+      names: selectedNames,
+    });
+  };
+
+  const deleteDisabled = readOnly || isApplying || count === 0;
+
+  return (
+    <div className="mtnt">
+      <h1>Manage Tenants</h1>
+      <p className="mtnt-sub">
+        Collection <code>{collectionName || '…'}</code> · {tenants.length} tenant
+        {tenants.length !== 1 ? 's' : ''}
+      </p>
+
+      {readOnly && (
+        <div className="mtnt-note mtnt-note--warning">
+          This connection is <strong>read-only</strong>. Enable write access to change tenant
+          states.
+        </div>
+      )}
+
+      {!offloadSupported && (
+        <div className="mtnt-note mtnt-note--warning">
+          <strong>Offloading is unavailable.</strong> Setting a tenant to <code>OFFLOADED</code>{' '}
+          requires Weaviate <code>&ge; {offloadMinVersion}</code> and the <code>offload-s3</code>{' '}
+          module to be enabled and configured on the server.
+          <br />
+          Detected server version: <code>{serverVersion || 'unknown'}</code>;{' '}
+          <code>offload-s3</code> module:{' '}
+          <code>{offloadModuleAvailable ? 'available' : 'not available'}</code>.
+        </div>
+      )}
+
+      {/* ── Selection ─────────────────────────────────────────────── */}
+      <div className="mtnt-section">
+        <p className="mtnt-section-title">Select tenants</p>
+        <div className="mtnt-radio-row">
+          <label className="mtnt-radio">
+            <input
+              type="radio"
+              name="selMode"
+              checked={selectionMode === 'list'}
+              onChange={() => setSelectionMode('list')}
+            />
+            <span>From list</span>
+          </label>
+          <label className="mtnt-radio">
+            <input
+              type="radio"
+              name="selMode"
+              checked={selectionMode === 'pattern'}
+              onChange={() => setSelectionMode('pattern')}
+            />
+            <span>By pattern</span>
+          </label>
+        </div>
+
+        {selectionMode === 'list' ? (
+          <>
+            <div className="mtnt-list-toolbar">
+              <input
+                className="mtnt-input"
+                placeholder="Filter by tenant name or status…"
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+              />
+              <button
+                className="mtnt-link-button"
+                onClick={selectAllFiltered}
+                title={`Select the ${totalRows} tenant(s) currently shown`}
+              >
+                Select all{filter ? ' shown' : ''}
+              </button>
+              {filter && selectedFilteredCount > 0 && (
+                <button className="mtnt-link-button" onClick={deselectAllFiltered}>
+                  Deselect shown
+                </button>
+              )}
+              <button className="mtnt-link-button" onClick={clearSelection}>
+                Clear
+              </button>
+            </div>
+            <div className="mtnt-list-toolbar">
+              <input
+                className="mtnt-input mtnt-input--mono"
+                placeholder="Count filter — e.g. count=0, count>1, 10<count<50"
+                value={countFilter}
+                onChange={(e) => setCountFilter(e.target.value)}
+              />
+            </div>
+            <div className="mtnt-hint">
+              Filter by object count (from node status). Examples: <code>count=0</code>,{' '}
+              <code>count&gt;1</code>, <code>count&gt;=10</code>, <code>count&lt;50</code>,{' '}
+              <code>10&lt;count&lt;50</code>. Count is only known for <strong>ACTIVE</strong>{' '}
+              tenants — others show <code>—</code> and are excluded while a count filter is active.
+            </div>
+            {countFilterError && <div className="mtnt-error">{countFilterError}</div>}
+            <div className="mtnt-list-summary">
+              {filter
+                ? `${totalRows.toLocaleString()} of ${tenants.length.toLocaleString()} shown`
+                : `${tenants.length.toLocaleString()} tenants`}
+              {' · '}
+              {selected.size.toLocaleString()} selected
+            </div>
+            <div
+              className="mtnt-list"
+              ref={listRef}
+              style={{ height: LIST_HEIGHT }}
+              onScroll={(e) => setScrollTop(e.currentTarget.scrollTop)}
+            >
+              {totalRows === 0 ? (
+                <div className="mtnt-empty">No tenants match the filter.</div>
+              ) : (
+                <>
+                  <div style={{ height: topSpacer }} />
+                  {visibleTenants.map((t) => (
+                    <label key={t.name} className="mtnt-row" style={{ height: ROW_HEIGHT }}>
+                      <input
+                        type="checkbox"
+                        checked={selected.has(t.name)}
+                        onChange={() => toggleOne(t.name)}
+                      />
+                      <span className="mtnt-row-name">{t.name}</span>
+                      <span
+                        className="mtnt-row-count"
+                        title={
+                          t.objectCount === null
+                            ? 'Object count unknown (tenant not loaded)'
+                            : `${t.objectCount} objects`
+                        }
+                      >
+                        {t.objectCount === null ? '—' : t.objectCount.toLocaleString()}
+                      </span>
+                      <StatusBadge status={t.activityStatus} />
+                    </label>
+                  ))}
+                  <div style={{ height: bottomSpacer }} />
+                </>
+              )}
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="mtnt-list-toolbar">
+              <input
+                className="mtnt-input mtnt-input--mono"
+                placeholder={
+                  patternMode === 'wildcard' ? 'e.g. *acme* or tenant-*' : 'e.g. ^tenant-\\d+$'
+                }
+                value={pattern}
+                onChange={(e) => setPattern(e.target.value)}
+              />
+            </div>
+            <div className="mtnt-radio-row">
+              <label className="mtnt-radio">
+                <input
+                  type="radio"
+                  name="patMode"
+                  checked={patternMode === 'wildcard'}
+                  onChange={() => setPatternMode('wildcard')}
+                />
+                <span>Wildcard (* ?)</span>
+              </label>
+              <label className="mtnt-radio">
+                <input
+                  type="radio"
+                  name="patMode"
+                  checked={patternMode === 'regex'}
+                  onChange={() => setPatternMode('regex')}
+                />
+                <span>Regex</span>
+              </label>
+            </div>
+            {patternError ? (
+              <div className="mtnt-error">Invalid pattern: {patternError}</div>
+            ) : (
+              pattern.trim() !== '' && (
+                <div className="mtnt-preview">
+                  {matchedNames.length} tenant{matchedNames.length !== 1 ? 's' : ''} match
+                  {matchedNames.length > 0 && (
+                    <div className="mtnt-preview-chips">
+                      {matchedNames.slice(0, PREVIEW_LIMIT).map((n) => (
+                        <span key={n} className="mtnt-chip">
+                          {n}
+                        </span>
+                      ))}
+                      {matchedNames.length > PREVIEW_LIMIT && (
+                        <span className="mtnt-chip">
+                          +{matchedNames.length - PREVIEW_LIMIT} more
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )
+            )}
+          </>
+        )}
+      </div>
+
+      {/* ── Target status ─────────────────────────────────────────── */}
+      <div className="mtnt-section">
+        <p className="mtnt-section-title">Set status to</p>
+        <div className="mtnt-radio-row">
+          <label className="mtnt-radio">
+            <input
+              type="radio"
+              name="target"
+              checked={targetStatus === 'ACTIVE'}
+              onChange={() => setTargetStatus('ACTIVE')}
+            />
+            <span>Active (load into memory)</span>
+          </label>
+          <label className="mtnt-radio">
+            <input
+              type="radio"
+              name="target"
+              checked={targetStatus === 'INACTIVE'}
+              onChange={() => setTargetStatus('INACTIVE')}
+            />
+            <span>Inactive (offload to disk)</span>
+          </label>
+          <label className="mtnt-radio" title={offloadDisabled ? 'Offloading is unavailable' : ''}>
+            <input
+              type="radio"
+              name="target"
+              disabled={offloadDisabled}
+              checked={targetStatus === 'OFFLOADED'}
+              onChange={() => setTargetStatus('OFFLOADED')}
+            />
+            <span>Offloaded (offload-s3)</span>
+          </label>
+        </div>
+      </div>
+
+      {error && <div className="mtnt-error">{error}</div>}
+
+      <div className="mtnt-apply-bar">
+        <button className="mtnt-button" onClick={handleApply} disabled={applyDisabled}>
+          {isApplying
+            ? 'Applying…'
+            : `Set ${count} tenant${count !== 1 ? 's' : ''} to ${targetStatus}`}
+        </button>
+        <button
+          className="mtnt-button mtnt-button--danger"
+          onClick={handleDelete}
+          disabled={deleteDisabled}
+          title={readOnly ? 'Read-only connection' : 'Permanently delete the selected tenants'}
+        >
+          {`Delete ${count} tenant${count !== 1 ? 's' : ''}`}
+        </button>
+        <span className="mtnt-selection-count">{count} selected</span>
+      </div>
+    </div>
+  );
+}
+
+const container = document.getElementById('root');
+if (container) {
+  createRoot(container).render(<ManageTenantsWebview />);
+}

--- a/src/webview/editMultiTenancy.html
+++ b/src/webview/editMultiTenancy.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit Multi-Tenancy</title>
+</head>
+<body>
+    <div id="root"></div>
+</body>
+</html>

--- a/src/webview/manageTenants.html
+++ b/src/webview/manageTenants.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Manage Tenants</title>
+</head>
+<body>
+    <div id="root"></div>
+</body>
+</html>

--- a/webpack.webview.config.js
+++ b/webpack.webview.config.js
@@ -48,6 +48,7 @@ module.exports = {
     'rbac-user': './src/webview/RbacUser.tsx',
     'rbac-group': './src/webview/RbacGroup.tsx',
     connection: './src/webview/ConnectionForm.tsx',
+    'edit-multi-tenancy': './src/webview/EditMultiTenancy.tsx',
   },
   output: {
     path: path.resolve(__dirname, 'dist', 'webview'),
@@ -193,6 +194,14 @@ module.exports = {
       template: './src/webview/connection.html',
       filename: 'connection.html',
       chunks: ['connection'],
+      inject: 'body',
+      scriptLoading: 'defer',
+      minify: isProduction,
+    }),
+    new HtmlWebpackPlugin({
+      template: './src/webview/editMultiTenancy.html',
+      filename: 'editMultiTenancy.html',
+      chunks: ['edit-multi-tenancy'],
       inject: 'body',
       scriptLoading: 'defer',
       minify: isProduction,

--- a/webpack.webview.config.js
+++ b/webpack.webview.config.js
@@ -49,6 +49,7 @@ module.exports = {
     'rbac-group': './src/webview/RbacGroup.tsx',
     connection: './src/webview/ConnectionForm.tsx',
     'edit-multi-tenancy': './src/webview/EditMultiTenancy.tsx',
+    'manage-tenants': './src/webview/ManageTenants.tsx',
   },
   output: {
     path: path.resolve(__dirname, 'dist', 'webview'),
@@ -202,6 +203,14 @@ module.exports = {
       template: './src/webview/editMultiTenancy.html',
       filename: 'editMultiTenancy.html',
       chunks: ['edit-multi-tenancy'],
+      inject: 'body',
+      scriptLoading: 'defer',
+      minify: isProduction,
+    }),
+    new HtmlWebpackPlugin({
+      template: './src/webview/manageTenants.html',
+      filename: 'manageTenants.html',
+      chunks: ['manage-tenants'],
       inject: 'body',
       scriptLoading: 'defer',
       minify: isProduction,


### PR DESCRIPTION
New cluster checks (extends the v1.8.0 checks framework)

- Auto-Tenant Configuration — flags MT collections where autoTenantCreation and/or autoTenantActivation is off. One-click Enable on all. Copy explains each flag's failure mode separately.
- Empty Tenants (Active) — finds ACTIVE (in-memory) tenants holding 0 objects (the ones wasting RAM; INACTIVE/OFFLOADED are correctly excluded). Per-collection actions: Inactivate empty tenants (offload to disk, keep the tenant) and Delete empty tenants.
- Both wired into the two runChecks sites, the Checks-tab badge count, and the warning banner.

Edit multi-tenancy from the tree

- Edit Multi-Tenancy webview form (EditMultiTenancyPanel) to toggle the two auto-tenant flags, opened from the Multi Tenancy tree node.
- Tree warning badge (icon + "auto-tenant off" label) when flags are off, plus a right-click Toggle on the individual flag rows.

Tenant management (ManageTenantsPanel)

- Set tenants ACTIVE / INACTIVE / OFFLOADED, or Delete them.
- Selection by list (checkboxes) or by wildcard/regex pattern (*acme*, ^tenant-\d+$) with a live match preview.
- Virtualized list — only visible rows render, so it stays smooth with thousands of tenants.
- Filters: by name/status (status matched as a prefix), and a separate object-count filter (count=0, count>1, 10<count<50, …) with the syntax documented inline. Counts come from node status; unknown counts show —.
- Tenant list is sorted naturally by name (deterministic; tenant-2 before tenant-10).
- Offload gate: the OFFLOADED option is disabled — with a UI note — unless the server is ≥ 1.26.0 and the offload-s3 module is present; the backend re-checks so it can't be bypassed.

Cross-cutting

- Run Checks tree action next to Refresh Connection Info on active connections.
- Read-only gating on every mutating action (control disabled + backend guard that throws).
- Seed script sandbox/populate_mt_empty_tenants.py — creates a MT collection with N tenants (default 1000; 20% filled, 80% empty ACTIVE, flags off) for exercising all of the above.

<img width="1204" height="982" alt="image" src="https://github.com/user-attachments/assets/a8c18617-5395-468a-9969-a2a3e67561be" />

<img width="847" height="835" alt="image" src="https://github.com/user-attachments/assets/c59c66bd-02d2-42d1-9b1a-93bc942e58d9" />

<img width="404" height="100" alt="image" src="https://github.com/user-attachments/assets/465829ef-b1ff-49e8-bd2d-6dc819403ac8" />

<img width="674" height="332" alt="image" src="https://github.com/user-attachments/assets/67fcfc5d-3a61-4e78-bb53-873e15a4611c" />
