### PR TITLE
feat: harden schema-aware GraphQL query generation

### DIFF
--- a/docs/GRAPHQL_TEMPLATES.md
+++ b/docs/GRAPHQL_TEMPLATES.md
@@ -342,12 +342,55 @@ The selector surfaces non-mutating templates that are stable across Weaviate ver
 
 ## Dynamic generation and schema awareness
 
-When schema is provided, dynamic templates:
+When schema is provided, sample queries and dynamic templates share the same property classification and selection helpers.
 
-- Prefer primitive properties (text/string/int/number/boolean/date).
-- Include geocoordinates with latitude/longitude sub-selection.
-- Keep cross-reference selections minimal (inline fragment with \_additional.id) to avoid overwhelming results.
-- Tailor generative prompts to an available text property if generativePrompt isn’t provided.
+### Property classification
+
+| Kind                     | Weaviate `dataType` examples                | GraphQL selection                                                  |
+| ------------------------ | ------------------------------------------- | ------------------------------------------------------------------ |
+| Primitive (incl. arrays) | `text`, `text[]`, `int[]`, `uuid`           | bare field                                                         |
+| Geo                      | `geoCoordinates`                            | `latitude` / `longitude`                                           |
+| Phone                    | `phoneNumber`                               | nested phone fields (`input`, `internationalFormatted`, …)         |
+| Blob                     | `blob`                                      | **excluded by default** (large base64); opt-in via `includeBlobs`  |
+| Nested object            | `object`, `object[]`                        | `... on Collection_prop_object { … }` when nested fields are known |
+| Cross-reference          | `Person`, multi-target `Author`+`Publisher` | `... on Class { … }` (capped by default)                           |
+
+**Important:** Array scalars such as `text[]` are **not** cross-references. Emitting `... on text[]` is invalid GraphQL and is rejected by validation.
+
+### Safe sample defaults
+
+Schema-based samples (Query Editor → Templates → Schema-based Sample):
+
+- Cap properties (~12) instead of dumping every field
+- Exclude `blob` fields (comment lists what was omitted)
+- At most one cross-reference by default
+- Header `#` comments explain multi-tenancy, named vectors, and exclusions
+- `includeAllProperties: true` expands to the full non-blob set when needed
+
+### Multi-tenancy
+
+If the collection has `multiTenancy.enabled`, generated Get/Aggregate queries include:
+
+```
+tenant: "YOUR_TENANT_ID"
+```
+
+Replace the placeholder before running. Validation reports this as a **warning** (not a hard error) so samples still load.
+
+### Named / multi-vector collections
+
+When the schema exposes multiple named vectors (or a non-`default` vector name), nearVector / nearText / hybrid templates may include:
+
+```
+targetVectors: ["title", "content"]
+```
+
+### Other schema-aware behavior
+
+- Prefer primitive properties, then phone/geo, nested objects, then minimal references
+- BM25 / hybrid default `properties` from text fields (including `text[]`)
+- Generative prompts use available text properties when `generativePrompt` is omitted
+- Empty nested objects without `nestedProperties` become comments (no invalid `__typename` selection)
 
 ## Configuration (QueryConfig)
 
@@ -375,6 +418,11 @@ You can customize dynamic generation via QueryConfig. Notable fields:
 - vector: number[] — explicit query vector for nearVector/hybrid.
 - sortBy: { path: string; order?: 'asc' | 'desc' } — sort clause.
 - returnProperties: string[] — explicit GraphQL selection fields.
+- includeBlobs: boolean — include blob fields in selections (default false).
+- includeAllProperties: boolean — select all non-blob fields in sample generation.
+- includeHeaderComments: boolean — schema-aware `#` comments at the top of generated queries.
+- targetVector / targetVectors: named vector targeting for multi-vector collections.
+- fullSchema: full `{ classes }` map so cross-references can expand target class fields.
 
 ## Template placeholders and processing
 

--- a/src/query-editor/extension/QueryEditorPanel.ts
+++ b/src/query-editor/extension/QueryEditorPanel.ts
@@ -193,6 +193,15 @@ export class QueryEditorPanel {
         description?: string;
         nestedProperties?: any[];
       }>;
+      vectorizer?: string;
+      vectorizers?: Record<string, any>;
+      vectorNames?: string[];
+      multiTenancy?: {
+        enabled?: boolean;
+        autoTenantCreation?: boolean;
+        autoTenantActivation?: boolean;
+      };
+      moduleConfig?: Record<string, any>;
     }>;
   }> {
     // Check if connection is still active (state is maintained by the listener)
@@ -208,13 +217,49 @@ export class QueryEditorPanel {
     // Use Weaviate v3 collections API and adapt to legacy schema shape expected by webview
     const collections: CollectionConfig[] = await this._weaviateClient.collections.listAll();
     return {
-      classes: (collections || []).map((collection: CollectionConfig) => ({
-        class: collection.name || '',
-        description: (collection as any).description,
-        properties: (collection.properties || []).map((prop: PropertyConfig) =>
-          this._mapPropertySchema(prop)
-        ),
-      })),
+      classes: await Promise.all(
+        (collections || []).map(async (collection: CollectionConfig) => {
+          const base: any = collection as any;
+          let vectorizers = base.vectorizers ?? base.vectorizerConfig;
+          let multiTenancy = base.multiTenancy;
+          let moduleConfig = base.moduleConfig;
+          let vectorizer = base.vectorizer;
+
+          // Enrich from full config when listAll() omits MT / named-vector details
+          try {
+            const name = collection.name || base.class;
+            if (name && this._weaviateClient?.collections?.get) {
+              const coll = this._weaviateClient.collections.get(name);
+              if (coll?.config?.get) {
+                const cfg = await coll.config.get();
+                vectorizers =
+                  (cfg as any).vectorizers ?? (cfg as any).vectorizerConfig ?? vectorizers;
+                multiTenancy = (cfg as any).multiTenancy ?? multiTenancy;
+                moduleConfig = (cfg as any).moduleConfig ?? moduleConfig;
+                vectorizer = (cfg as any).vectorizer ?? vectorizer;
+              }
+            }
+          } catch {
+            // Proceed with listAll() data
+          }
+
+          const vectorNames =
+            vectorizers && typeof vectorizers === 'object' ? Object.keys(vectorizers) : undefined;
+
+          return {
+            class: collection.name || '',
+            description: base.description,
+            properties: (collection.properties || []).map((prop: PropertyConfig) =>
+              this._mapPropertySchema(prop)
+            ),
+            vectorizer,
+            vectorizers,
+            vectorNames,
+            multiTenancy,
+            moduleConfig,
+          };
+        })
+      ),
     };
   }
 

--- a/src/query-editor/extension/QueryEditorPanel.ts
+++ b/src/query-editor/extension/QueryEditorPanel.ts
@@ -329,9 +329,33 @@ export class QueryEditorPanel {
     }
 
     const protocol = conn.httpSecure ? 'https' : 'http';
-    const host = conn.httpHost || 'localhost';
-    const port = conn.httpPort || (conn.httpSecure ? 443 : 8080);
-    return `${protocol}://${host}:${port}/v1/graphql`;
+    let host = conn.httpHost || 'localhost';
+    let port = conn.httpPort;
+
+    // Strip leading protocol if user accidentally included it in host field
+    if (/^https?:\/\//i.test(host)) {
+      try {
+        const parsed = new URL(host);
+        host = parsed.hostname;
+        if (parsed.port) {
+          port = parseInt(parsed.port, 10);
+        }
+      } catch {
+        host = host.replace(/^https?:\/\//i, '');
+      }
+    }
+
+    // Handle port suffix in hostname (e.g. "localhost:8080")
+    if (host.includes(':')) {
+      const parts = host.split(':');
+      host = parts[0];
+      if (parts[1] && !port) {
+        port = parseInt(parts[1], 10);
+      }
+    }
+
+    const finalPort = port || (conn.httpSecure ? 443 : 8080);
+    return `${protocol}://${host}:${finalPort}/v1/graphql`;
   }
 
   private async _performGraphQLHttp(query: string, signal?: AbortSignal): Promise<any> {

--- a/src/query-editor/extension/QueryEditorPanel.ts
+++ b/src/query-editor/extension/QueryEditorPanel.ts
@@ -328,7 +328,8 @@ export class QueryEditorPanel {
       return `${base}/v1/graphql`;
     }
 
-    const protocol = conn.httpSecure ? 'https' : 'http';
+    // Start from connection flags; a fully-qualified URL in httpHost may override scheme.
+    let secure = Boolean(conn.httpSecure);
     let host = conn.httpHost || 'localhost';
     let port = conn.httpPort;
 
@@ -336,26 +337,51 @@ export class QueryEditorPanel {
     if (/^https?:\/\//i.test(host)) {
       try {
         const parsed = new URL(host);
+        // URL.hostname is unbracketed for IPv6 (e.g. "::1")
         host = parsed.hostname;
         if (parsed.port) {
           port = parseInt(parsed.port, 10);
+        }
+        // Prefer scheme from the pasted URL when present
+        if (parsed.protocol === 'https:') {
+          secure = true;
+        } else if (parsed.protocol === 'http:') {
+          secure = false;
         }
       } catch {
         host = host.replace(/^https?:\/\//i, '');
       }
     }
 
-    // Handle port suffix in hostname (e.g. "localhost:8080")
-    if (host.includes(':')) {
-      const parts = host.split(':');
-      host = parts[0];
-      if (parts[1] && !port) {
-        port = parseInt(parts[1], 10);
+    // Port suffix handling:
+    // - "localhost:8080" / "127.0.0.1:8080" → extract port
+    // - "[2001:db8::1]:8080" → extract IPv6 + port
+    // - bare IPv6 ("2001:db8::1") → leave host alone (do not split on ':')
+    if (host.startsWith('[')) {
+      const m = host.match(/^\[([^\]]+)\](?::(\d+))?$/);
+      if (m) {
+        host = m[1];
+        if (m[2] && (port === undefined || port === null)) {
+          port = parseInt(m[2], 10);
+        }
+      }
+    } else if (!host.includes('::') && (host.match(/:/g) || []).length === 1) {
+      // Exactly one colon → hostname/IPv4 with optional port (not multi-colon IPv6)
+      const lastColon = host.lastIndexOf(':');
+      const maybePort = host.slice(lastColon + 1);
+      if (/^\d+$/.test(maybePort)) {
+        if (port === undefined || port === null) {
+          port = parseInt(maybePort, 10);
+        }
+        host = host.slice(0, lastColon);
       }
     }
 
-    const finalPort = port || (conn.httpSecure ? 443 : 8080);
-    return `${protocol}://${host}:${finalPort}/v1/graphql`;
+    const finalPort = port || (secure ? 443 : 8080);
+    const protocol = secure ? 'https' : 'http';
+    // Bracket IPv6 hostnames for a valid URL
+    const hostForUrl = host.includes(':') ? `[${host}]` : host;
+    return `${protocol}://${hostForUrl}:${finalPort}/v1/graphql`;
   }
 
   private async _performGraphQLHttp(query: string, signal?: AbortSignal): Promise<any> {

--- a/src/query-editor/extension/QueryEditorPanel.ts
+++ b/src/query-editor/extension/QueryEditorPanel.ts
@@ -225,22 +225,26 @@ export class QueryEditorPanel {
           let moduleConfig = base.moduleConfig;
           let vectorizer = base.vectorizer;
 
-          // Enrich from full config when listAll() omits MT / named-vector details
-          try {
-            const name = collection.name || base.class;
-            if (name && this._weaviateClient?.collections?.get) {
-              const coll = this._weaviateClient.collections.get(name);
-              if (coll?.config?.get) {
-                const cfg = await coll.config.get();
-                vectorizers =
-                  (cfg as any).vectorizers ?? (cfg as any).vectorizerConfig ?? vectorizers;
-                multiTenancy = (cfg as any).multiTenancy ?? multiTenancy;
-                moduleConfig = (cfg as any).moduleConfig ?? moduleConfig;
-                vectorizer = (cfg as any).vectorizer ?? vectorizer;
+          // Lazy-fetch full config only when listAll() omitted MT / named-vector details
+          // (avoids N+1 config.get() round-trips on large clusters).
+          const needsEnrichment = vectorizers === undefined || multiTenancy === undefined;
+          if (needsEnrichment) {
+            try {
+              const name = collection.name || base.class;
+              if (name && this._weaviateClient?.collections?.get) {
+                const coll = this._weaviateClient.collections.get(name);
+                if (coll?.config?.get) {
+                  const cfg = await coll.config.get();
+                  vectorizers =
+                    (cfg as any).vectorizers ?? (cfg as any).vectorizerConfig ?? vectorizers;
+                  multiTenancy = (cfg as any).multiTenancy ?? multiTenancy;
+                  moduleConfig = (cfg as any).moduleConfig ?? moduleConfig;
+                  vectorizer = (cfg as any).vectorizer ?? vectorizer;
+                }
               }
+            } catch {
+              // Proceed with listAll() data
             }
-          } catch {
-            // Proceed with listAll() data
           }
 
           const vectorNames =

--- a/src/query-editor/extension/__tests__/QueryEditorPanel.test.ts
+++ b/src/query-editor/extension/__tests__/QueryEditorPanel.test.ts
@@ -117,4 +117,74 @@ describe('QueryEditorPanel.createOrShow unique key behaviour', () => {
     });
     expect((QueryEditorPanel as any).panels.size).toBe(1);
   });
+
+  describe('_buildGraphQLEndpoint endpoint builder sanitization', () => {
+    let panelInstance: any;
+
+    beforeEach(() => {
+      QueryEditorPanel.createOrShow(dummyContext, {
+        connectionId: 'c1',
+        collectionName: 'ColA',
+        tabId: 'test-endpoint',
+      });
+      panelInstance = Array.from((QueryEditorPanel as any).panels.values())[0];
+    });
+
+    it('returns custom endpoint correctly when host has no protocol/port', () => {
+      panelInstance._getActiveConnection = jest.fn().mockReturnValue({
+        type: 'custom',
+        httpHost: 'localhost',
+        httpPort: 8080,
+        httpSecure: false,
+      });
+      expect(panelInstance._buildGraphQLEndpoint()).toBe('http://localhost:8080/v1/graphql');
+    });
+
+    it('strips leading http:// protocol from httpHost', () => {
+      panelInstance._getActiveConnection = jest.fn().mockReturnValue({
+        type: 'custom',
+        httpHost: 'http://localhost',
+        httpPort: 8080,
+        httpSecure: false,
+      });
+      expect(panelInstance._buildGraphQLEndpoint()).toBe('http://localhost:8080/v1/graphql');
+    });
+
+    it('strips leading https:// protocol and detects secure port from it', () => {
+      panelInstance._getActiveConnection = jest.fn().mockReturnValue({
+        type: 'custom',
+        httpHost: 'https://my-weaviate.com',
+        httpSecure: true,
+      });
+      expect(panelInstance._buildGraphQLEndpoint()).toBe('https://my-weaviate.com:443/v1/graphql');
+    });
+
+    it('extracts port suffix from httpHost if httpPort is missing', () => {
+      panelInstance._getActiveConnection = jest.fn().mockReturnValue({
+        type: 'custom',
+        httpHost: 'localhost:9000',
+        httpSecure: false,
+      });
+      expect(panelInstance._buildGraphQLEndpoint()).toBe('http://localhost:9000/v1/graphql');
+    });
+
+    it('prefers explicit httpPort over suffix in httpHost', () => {
+      panelInstance._getActiveConnection = jest.fn().mockReturnValue({
+        type: 'custom',
+        httpHost: 'localhost:9000',
+        httpPort: 1234,
+        httpSecure: false,
+      });
+      expect(panelInstance._buildGraphQLEndpoint()).toBe('http://localhost:1234/v1/graphql');
+    });
+
+    it('correctly handles full pasted URL into httpHost', () => {
+      panelInstance._getActiveConnection = jest.fn().mockReturnValue({
+        type: 'custom',
+        httpHost: 'http://127.0.0.1:8080',
+        httpSecure: false,
+      });
+      expect(panelInstance._buildGraphQLEndpoint()).toBe('http://127.0.0.1:8080/v1/graphql');
+    });
+  });
 });

--- a/src/query-editor/extension/__tests__/QueryEditorPanel.test.ts
+++ b/src/query-editor/extension/__tests__/QueryEditorPanel.test.ts
@@ -159,6 +159,24 @@ describe('QueryEditorPanel.createOrShow unique key behaviour', () => {
       expect(panelInstance._buildGraphQLEndpoint()).toBe('https://my-weaviate.com:443/v1/graphql');
     });
 
+    it('prefers https scheme from pasted URL even when httpSecure is false', () => {
+      panelInstance._getActiveConnection = jest.fn().mockReturnValue({
+        type: 'custom',
+        httpHost: 'https://my-weaviate.com',
+        httpSecure: false,
+      });
+      expect(panelInstance._buildGraphQLEndpoint()).toBe('https://my-weaviate.com:443/v1/graphql');
+    });
+
+    it('prefers http scheme from pasted URL even when httpSecure is true', () => {
+      panelInstance._getActiveConnection = jest.fn().mockReturnValue({
+        type: 'custom',
+        httpHost: 'http://localhost:8080',
+        httpSecure: true,
+      });
+      expect(panelInstance._buildGraphQLEndpoint()).toBe('http://localhost:8080/v1/graphql');
+    });
+
     it('extracts port suffix from httpHost if httpPort is missing', () => {
       panelInstance._getActiveConnection = jest.fn().mockReturnValue({
         type: 'custom',
@@ -185,6 +203,34 @@ describe('QueryEditorPanel.createOrShow unique key behaviour', () => {
         httpSecure: false,
       });
       expect(panelInstance._buildGraphQLEndpoint()).toBe('http://127.0.0.1:8080/v1/graphql');
+    });
+
+    it('brackets bare IPv6 hosts and does not split on colons', () => {
+      panelInstance._getActiveConnection = jest.fn().mockReturnValue({
+        type: 'custom',
+        httpHost: '2001:db8::1',
+        httpPort: 8080,
+        httpSecure: false,
+      });
+      expect(panelInstance._buildGraphQLEndpoint()).toBe('http://[2001:db8::1]:8080/v1/graphql');
+    });
+
+    it('parses bracketed IPv6 with port suffix', () => {
+      panelInstance._getActiveConnection = jest.fn().mockReturnValue({
+        type: 'custom',
+        httpHost: '[2001:db8::1]:9000',
+        httpSecure: false,
+      });
+      expect(panelInstance._buildGraphQLEndpoint()).toBe('http://[2001:db8::1]:9000/v1/graphql');
+    });
+
+    it('parses full IPv6 URL pasted into httpHost', () => {
+      panelInstance._getActiveConnection = jest.fn().mockReturnValue({
+        type: 'custom',
+        httpHost: 'http://[::1]:8080',
+        httpSecure: false,
+      });
+      expect(panelInstance._buildGraphQLEndpoint()).toBe('http://[::1]:8080/v1/graphql');
     });
   });
 });

--- a/src/query-editor/extension/__tests__/SampleQueryFlow.test.ts
+++ b/src/query-editor/extension/__tests__/SampleQueryFlow.test.ts
@@ -32,7 +32,7 @@ describe('Sample query flow', () => {
     jest.clearAllMocks();
   });
 
-  it('posts sampleQuery message to webview', async () => {
+  function createPanelWithClient(client: any) {
     const vscode = require('vscode');
     const webviewPost = jest.fn();
     vscode.window.createWebviewPanel.mockImplementation(() => ({
@@ -47,52 +47,101 @@ describe('Sample query flow', () => {
     QueryEditorPanel.createOrShow(dummyContext, { connectionId: 'c1', collectionName: 'ColA' });
     const panelInstance: any = Array.from((QueryEditorPanel as any).panels.values())[0];
 
-    // Mock the ConnectionManager to return a connected status
     panelInstance._connectionManager = {
       getConnections: jest.fn().mockReturnValue([{ id: 'c1', status: 'connected', name: 'test' }]),
+      getConnection: jest.fn().mockReturnValue({ id: 'c1', status: 'connected', name: 'test' }),
       onConnectionsChanged: {
         subscribe: jest.fn().mockReturnValue({ dispose: jest.fn() }),
       },
     };
-
-    // Stub weaviate client with minimal schema getter
-    panelInstance._weaviateClient = {
-      schema: {
-        // @ts-ignore
-        getter: (): any => ({
-          // @ts-expect-error - Jest mock type incompatibility
-          do: jest.fn().mockResolvedValue({
-            classes: [
-              {
-                class: 'ColA',
-                properties: [{ name: 'name', dataType: ['string'] }],
-              },
-            ],
-          }),
-        }),
-      },
-    } as any;
-
-    // Mark connection as active since _sendSampleQuery now checks connection state
+    panelInstance._weaviateClient = client;
     panelInstance._isConnectionActive = true;
+
+    return { panelInstance, webviewPost };
+  }
+
+  it('posts a schema-aware sampleQuery using collections.listAll()', async () => {
+    const listAll = jest.fn().mockResolvedValue([
+      {
+        name: 'ColA',
+        properties: [
+          { name: 'name', dataType: ['text'] },
+          { name: 'aliases', dataType: ['text[]'] },
+          { name: 'image', dataType: ['blob'] },
+        ],
+        multiTenancy: { enabled: false },
+      },
+    ]);
+
+    const { panelInstance, webviewPost } = createPanelWithClient({
+      collections: { listAll },
+    });
 
     await panelInstance._sendSampleQuery('ColA');
 
-    expect(webviewPost).toHaveBeenCalled();
-    // _updateConnectionState() sends connectionStatusChanged first, then sampleQuery
-    const calls = webviewPost.mock.calls;
-    const sampleQueryMsg = calls.find((call: any[]) => call[0].type === 'sampleQuery');
+    expect(listAll).toHaveBeenCalled();
+    const sampleQueryMsg = webviewPost.mock.calls.find(
+      (call: any[]) => call[0].type === 'sampleQuery'
+    );
+    expect(sampleQueryMsg).toBeDefined();
+    const q: string = sampleQueryMsg![0].data.sampleQuery;
+    expect(q).toContain('ColA');
+    expect(q).toContain('name');
+    expect(q).toContain('aliases');
+    expect(q).not.toMatch(/\.\.\.\s*on\s+text\[\]/);
+    // blobs excluded by default
+    expect(q).not.toMatch(/^\s*image\s*$/m);
+  });
 
-    // If sampleQuery not found, the first message should be it or one of the early ones
-    if (sampleQueryMsg) {
-      const msg: any = sampleQueryMsg[0];
-      expect(msg.type).toBe('sampleQuery');
-      expect(msg.data.sampleQuery).toContain('ColA');
-    } else {
-      // Check if _sendSampleQuery sent anything at all
-      expect(calls.length).toBeGreaterThan(0);
-      // For now, just verify it was called
-      expect(webviewPost).toHaveBeenCalled();
-    }
+  it('includes tenant placeholder when multi-tenancy is enabled', async () => {
+    const listAll = jest.fn().mockResolvedValue([
+      {
+        name: 'TenantCol',
+        properties: [{ name: 'title', dataType: ['text'] }],
+        multiTenancy: { enabled: true },
+      },
+    ]);
+
+    const { panelInstance, webviewPost } = createPanelWithClient({
+      collections: {
+        listAll,
+        get: jest.fn().mockReturnValue({
+          config: {
+            get: jest.fn().mockResolvedValue({
+              multiTenancy: { enabled: true },
+              properties: [{ name: 'title', dataType: ['text'] }],
+            }),
+          },
+        }),
+      },
+    });
+
+    await panelInstance._sendSampleQuery('TenantCol');
+
+    const sampleQueryMsg = webviewPost.mock.calls.find(
+      (call: any[]) => call[0].type === 'sampleQuery'
+    );
+    expect(sampleQueryMsg).toBeDefined();
+    const q: string = sampleQueryMsg![0].data.sampleQuery;
+    expect(q).toContain('tenant:');
+    expect(q).toContain('YOUR_TENANT_ID');
+  });
+
+  it('falls back to a minimal query when schema fetch fails', async () => {
+    const listAll = jest.fn().mockRejectedValue(new Error('network down'));
+
+    const { panelInstance, webviewPost } = createPanelWithClient({
+      collections: { listAll },
+    });
+
+    await panelInstance._sendSampleQuery('ColA');
+
+    const sampleQueryMsg = webviewPost.mock.calls.find(
+      (call: any[]) => call[0].type === 'sampleQuery'
+    );
+    expect(sampleQueryMsg).toBeDefined();
+    const q: string = sampleQueryMsg![0].data.sampleQuery;
+    expect(q).toContain('ColA');
+    expect(q).toContain('_additional');
   });
 });

--- a/src/query-editor/extension/__tests__/SampleQueryFlow.test.ts
+++ b/src/query-editor/extension/__tests__/SampleQueryFlow.test.ts
@@ -61,7 +61,7 @@ describe('Sample query flow', () => {
   }
 
   it('posts a schema-aware sampleQuery using collections.listAll()', async () => {
-    const listAll = jest.fn().mockResolvedValue([
+    const listAll = (jest.fn() as any).mockResolvedValue([
       {
         name: 'ColA',
         properties: [
@@ -84,7 +84,7 @@ describe('Sample query flow', () => {
       (call: any[]) => call[0].type === 'sampleQuery'
     );
     expect(sampleQueryMsg).toBeDefined();
-    const q: string = sampleQueryMsg![0].data.sampleQuery;
+    const q: string = (sampleQueryMsg![0] as any).data.sampleQuery;
     expect(q).toContain('ColA');
     expect(q).toContain('name');
     expect(q).toContain('aliases');
@@ -94,7 +94,7 @@ describe('Sample query flow', () => {
   });
 
   it('includes tenant placeholder when multi-tenancy is enabled', async () => {
-    const listAll = jest.fn().mockResolvedValue([
+    const listAll = (jest.fn() as any).mockResolvedValue([
       {
         name: 'TenantCol',
         properties: [{ name: 'title', dataType: ['text'] }],
@@ -107,7 +107,7 @@ describe('Sample query flow', () => {
         listAll,
         get: jest.fn().mockReturnValue({
           config: {
-            get: jest.fn().mockResolvedValue({
+            get: (jest.fn() as any).mockResolvedValue({
               multiTenancy: { enabled: true },
               properties: [{ name: 'title', dataType: ['text'] }],
             }),
@@ -122,13 +122,13 @@ describe('Sample query flow', () => {
       (call: any[]) => call[0].type === 'sampleQuery'
     );
     expect(sampleQueryMsg).toBeDefined();
-    const q: string = sampleQueryMsg![0].data.sampleQuery;
+    const q: string = (sampleQueryMsg![0] as any).data.sampleQuery;
     expect(q).toContain('tenant:');
     expect(q).toContain('YOUR_TENANT_ID');
   });
 
   it('falls back to a minimal query when schema fetch fails', async () => {
-    const listAll = jest.fn().mockRejectedValue(new Error('network down'));
+    const listAll = (jest.fn() as any).mockRejectedValue(new Error('network down'));
 
     const { panelInstance, webviewPost } = createPanelWithClient({
       collections: { listAll },
@@ -140,7 +140,7 @@ describe('Sample query flow', () => {
       (call: any[]) => call[0].type === 'sampleQuery'
     );
     expect(sampleQueryMsg).toBeDefined();
-    const q: string = sampleQueryMsg![0].data.sampleQuery;
+    const q: string = (sampleQueryMsg![0] as any).data.sampleQuery;
     expect(q).toContain('ColA');
     expect(q).toContain('_additional');
   });

--- a/src/query-editor/webview/GraphQLSchemaProvider.ts
+++ b/src/query-editor/webview/GraphQLSchemaProvider.ts
@@ -141,35 +141,39 @@ export class SchemaProvider {
           let vectorizers = (collection as any).vectorizers ?? (collection as any).vectorizerConfig;
           let multiTenancy = (collection as any).multiTenancy;
 
-          // If vectorizer details are missing, attempt to fetch full config for this collection
-          try {
-            const collHandle: any = (weaviateClient as any)?.collections?.get?.(
-              (collection as any).name || (collection as any).class
-            );
+          // Lazy-fetch full config only when listAll() omitted key fields (avoids N+1 round-trips)
+          const needsEnrichment =
+            vectorizers === undefined || multiTenancy === undefined || !rawProps?.length;
+          if (needsEnrichment) {
+            try {
+              const collHandle: any = (weaviateClient as any)?.collections?.get?.(
+                (collection as any).name || (collection as any).class
+              );
 
-            const cfg =
-              collHandle && typeof collHandle.config === 'function'
-                ? await collHandle.config()
-                : collHandle && typeof collHandle.getConfig === 'function'
-                  ? await collHandle.getConfig()
-                  : collHandle?.config && typeof collHandle.config.get === 'function'
-                    ? await collHandle.config.get()
-                    : undefined;
+              const cfg =
+                collHandle && typeof collHandle.config === 'function'
+                  ? await collHandle.config()
+                  : collHandle && typeof collHandle.getConfig === 'function'
+                    ? await collHandle.getConfig()
+                    : collHandle?.config && typeof collHandle.config.get === 'function'
+                      ? await collHandle.config.get()
+                      : undefined;
 
-            if (cfg && typeof cfg === 'object') {
-              // Prefer values from cfg when available
-              description = cfg.description ?? description;
-              rawProps = Array.isArray(cfg.properties) ? cfg.properties : rawProps;
-              vectorizer = cfg.vectorizer ?? vectorizer;
-              moduleConfig = cfg.moduleConfig ?? moduleConfig;
-              vectorizers = cfg.vectorizers ?? cfg.vectorizerConfig ?? vectorizers;
-              multiTenancy = cfg.multiTenancy ?? multiTenancy;
+              if (cfg && typeof cfg === 'object') {
+                // Prefer values from cfg when available
+                description = cfg.description ?? description;
+                rawProps = Array.isArray(cfg.properties) ? cfg.properties : rawProps;
+                vectorizer = cfg.vectorizer ?? vectorizer;
+                moduleConfig = cfg.moduleConfig ?? moduleConfig;
+                vectorizers = cfg.vectorizers ?? cfg.vectorizerConfig ?? vectorizers;
+                multiTenancy = cfg.multiTenancy ?? multiTenancy;
+              }
+            } catch (e) {
+              console.warn(
+                'Could not fetch full collection config; proceeding with listAll() data',
+                e
+              );
             }
-          } catch (e) {
-            console.warn(
-              'Could not fetch full collection config; proceeding with listAll() data',
-              e
-            );
           }
 
           const mapProperty = (prop: any): any => {

--- a/src/query-editor/webview/GraphQLSchemaProvider.ts
+++ b/src/query-editor/webview/GraphQLSchemaProvider.ts
@@ -11,6 +11,7 @@ export interface WeaviateSchemaProperty {
   indexFilterable?: boolean;
   moduleConfig?: Record<string, any>;
   vectorizerConfig?: Record<string, any>;
+  nestedProperties?: WeaviateSchemaProperty[];
 }
 
 export interface WeaviateSchemaClass {
@@ -20,6 +21,12 @@ export interface WeaviateSchemaClass {
   vectorizer?: string;
   moduleConfig?: Record<string, any>;
   vectorizers?: Record<string, any>;
+  vectorNames?: string[];
+  multiTenancy?: {
+    enabled?: boolean;
+    autoTenantCreation?: boolean;
+    autoTenantActivation?: boolean;
+  };
 }
 
 export interface WeaviateSchema {
@@ -131,7 +138,8 @@ export class SchemaProvider {
           let rawProps: any[] = ((collection as any).properties || []) as any[];
           let vectorizer = (collection as any).vectorizer as any;
           let moduleConfig = (collection as any).moduleConfig as any;
-          let vectorizers = (collection as any).vectorizers as any;
+          let vectorizers = (collection as any).vectorizers ?? (collection as any).vectorizerConfig;
+          let multiTenancy = (collection as any).multiTenancy;
 
           // If vectorizer details are missing, attempt to fetch full config for this collection
           try {
@@ -144,7 +152,9 @@ export class SchemaProvider {
                 ? await collHandle.config()
                 : collHandle && typeof collHandle.getConfig === 'function'
                   ? await collHandle.getConfig()
-                  : undefined;
+                  : collHandle?.config && typeof collHandle.config.get === 'function'
+                    ? await collHandle.config.get()
+                    : undefined;
 
             if (cfg && typeof cfg === 'object') {
               // Prefer values from cfg when available
@@ -152,7 +162,8 @@ export class SchemaProvider {
               rawProps = Array.isArray(cfg.properties) ? cfg.properties : rawProps;
               vectorizer = cfg.vectorizer ?? vectorizer;
               moduleConfig = cfg.moduleConfig ?? moduleConfig;
-              vectorizers = cfg.vectorizers ?? vectorizers;
+              vectorizers = cfg.vectorizers ?? cfg.vectorizerConfig ?? vectorizers;
+              multiTenancy = cfg.multiTenancy ?? multiTenancy;
             }
           } catch (e) {
             console.warn(
@@ -183,6 +194,8 @@ export class SchemaProvider {
           };
 
           const properties = (rawProps || []).map(mapProperty);
+          const vectorNames =
+            vectorizers && typeof vectorizers === 'object' ? Object.keys(vectorizers) : undefined;
 
           return {
             class: (collection as any).name || (collection as any).class || '',
@@ -192,6 +205,8 @@ export class SchemaProvider {
             vectorizer,
             moduleConfig,
             vectorizers,
+            vectorNames,
+            multiTenancy,
           } as WeaviateSchemaClass;
         })
       );

--- a/src/query-editor/webview/__tests__/graphqlTemplates.test.ts
+++ b/src/query-editor/webview/__tests__/graphqlTemplates.test.ts
@@ -332,6 +332,172 @@ describe('graphqlTemplates helpers', () => {
       expect(result.valid).toBe(false);
       expect(result.errors.some((e: string) => e.includes('text[]'))).toBe(true);
     });
+
+    it('classifies phoneNumber and blob specially', () => {
+      const {
+        isPhoneNumberDataType,
+        isBlobDataType,
+        classifyProperty,
+      } = require('../graphqlTemplates');
+      expect(isPhoneNumberDataType(['phoneNumber'])).toBe(true);
+      expect(isBlobDataType(['blob'])).toBe(true);
+      expect(classifyProperty({ name: 'phone', dataType: ['phoneNumber'] })).toBe('phone');
+      expect(classifyProperty({ name: 'image', dataType: ['blob'] })).toBe('blob');
+      expect(isReferenceDataType(['phoneNumber'])).toBe(false);
+      expect(isReferenceDataType(['blob'])).toBe(false);
+    });
+
+    it('warns on placeholder tenant without invalidating the query', () => {
+      const q = `{ Get { X (tenant: "YOUR_TENANT_ID" limit: 1) { title } } }`;
+      const result = validateAndSanitizeQuery(q);
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some((w: string) => w.includes('YOUR_TENANT_ID'))).toBe(true);
+    });
+  });
+
+  describe('safe sample defaults and special types', () => {
+    it('expands phoneNumber with nested fields', () => {
+      const { generateSampleQuery } = require('../graphqlTemplates');
+      const schema = {
+        classes: [
+          {
+            class: 'Contact',
+            properties: [
+              { name: 'name', dataType: ['text'] },
+              { name: 'phone', dataType: ['phoneNumber'] },
+            ],
+          },
+        ],
+      };
+      const q = generateSampleQuery('Contact', [], 10, schema, { includeHeaderComments: false });
+      expect(q).toContain('phone');
+      expect(q).toContain('internationalFormatted');
+      expect(q).toContain('input');
+    });
+
+    it('excludes blob fields by default and documents them in comments', () => {
+      const { generateSampleQuery } = require('../graphqlTemplates');
+      const schema = {
+        classes: [
+          {
+            class: 'Doc',
+            properties: [
+              { name: 'title', dataType: ['text'] },
+              { name: 'image', dataType: ['blob'] },
+            ],
+          },
+        ],
+      };
+      const q = generateSampleQuery('Doc', [], 10, schema);
+      expect(q).toContain('title');
+      expect(q).toMatch(/Excluded blob fields[\s\S]*image/);
+      // bare field selection for image should not appear as a property line
+      expect(q).not.toMatch(/^\s*image\s*$/m);
+    });
+
+    it('includes blobs when includeBlobs is true', () => {
+      const { generateSampleQuery } = require('../graphqlTemplates');
+      const schema = {
+        classes: [
+          {
+            class: 'Doc',
+            properties: [
+              { name: 'title', dataType: ['text'] },
+              { name: 'image', dataType: ['blob'] },
+            ],
+          },
+        ],
+      };
+      const q = generateSampleQuery('Doc', [], 10, schema, {
+        includeBlobs: true,
+        includeHeaderComments: false,
+      });
+      expect(q).toMatch(/image/);
+    });
+
+    it('does not emit __typename for empty nested objects', () => {
+      const { generateSampleQuery } = require('../graphqlTemplates');
+      const schema = {
+        classes: [
+          {
+            class: 'Item',
+            properties: [
+              { name: 'title', dataType: ['text'] },
+              { name: 'meta', dataType: ['object'] },
+            ],
+          },
+        ],
+      };
+      const q = generateSampleQuery('Item', [], 10, schema, { includeHeaderComments: false });
+      expect(q).not.toContain('__typename');
+      expect(q).toMatch(/meta: nested fields unavailable/);
+    });
+
+    it('injects tenant when multi-tenancy is enabled', () => {
+      const { generateSampleQuery } = require('../graphqlTemplates');
+      const schema = {
+        classes: [
+          {
+            class: 'Tenanted',
+            multiTenancy: { enabled: true },
+            properties: [{ name: 'title', dataType: ['text'] }],
+          },
+        ],
+      };
+      const q = generateSampleQuery('Tenanted', [], 10, schema);
+      expect(q).toContain('tenant:');
+      expect(q).toContain('YOUR_TENANT_ID');
+      expect(q).toMatch(/Multi-tenancy is enabled/);
+    });
+
+    it('emits targetVectors for named multi-vector collections', () => {
+      const { processTemplate } = require('../graphqlTemplates');
+      const schema = {
+        classes: [
+          {
+            class: 'MultiVec',
+            vectorizers: {
+              title: { vectorizer: { name: 'text2vec-openai' } },
+              content: { vectorizer: { name: 'text2vec-openai' } },
+            },
+            properties: [{ name: 'title', dataType: ['text'] }],
+          },
+        ],
+      };
+      const q = processTemplate('Vector Search (nearVector)', 'MultiVec', 5, schema);
+      expect(q).toContain('targetVectors');
+      expect(q).toContain('title');
+      expect(q).toContain('content');
+    });
+
+    it('caps default sample properties instead of dumping the full schema', () => {
+      const { generateSampleQuery } = require('../graphqlTemplates');
+      const props = Array.from({ length: 30 }, (_, i) => ({
+        name: `field_${i}`,
+        dataType: ['text'] as string[],
+      }));
+      const schema = { classes: [{ class: 'Wide', properties: props }] };
+      const q = generateSampleQuery('Wide', [], 10, schema, { includeHeaderComments: false });
+      const fieldCount = (q.match(/field_\d+/g) || []).length;
+      expect(fieldCount).toBeLessThanOrEqual(12);
+      expect(fieldCount).toBeGreaterThan(0);
+    });
+
+    it('includeAllProperties selects the full non-blob set', () => {
+      const { generateSampleQuery } = require('../graphqlTemplates');
+      const props = Array.from({ length: 15 }, (_, i) => ({
+        name: `field_${i}`,
+        dataType: ['text'] as string[],
+      }));
+      const schema = { classes: [{ class: 'Wide', properties: props }] };
+      const q = generateSampleQuery('Wide', [], 10, schema, {
+        includeAllProperties: true,
+        includeHeaderComments: false,
+      });
+      for (let i = 0; i < 15; i++) {
+        expect(q).toContain(`field_${i}`);
+      }
+    });
   });
 
   describe('generateDynamicSampleQuery with array types', () => {

--- a/src/query-editor/webview/__tests__/graphqlTemplates.test.ts
+++ b/src/query-editor/webview/__tests__/graphqlTemplates.test.ts
@@ -470,6 +470,64 @@ describe('graphqlTemplates helpers', () => {
       expect(q).toContain('content');
     });
 
+    it('honours singular config.targetVector', () => {
+      const { formatTargetVectorsArg } = require('../graphqlTemplates');
+      const line = formatTargetVectorsArg(
+        { class: 'X', properties: [], vectorNames: ['default'] },
+        { targetVector: 'content_vec' }
+      );
+      expect(line).toBe('targetVectors: ["content_vec"]');
+    });
+
+    it('does not mutate config.fullSchema in generateDynamicSampleQuery', () => {
+      const { generateDynamicSampleQuery } = require('../graphqlTemplates');
+      const otherClass = {
+        class: 'Other',
+        properties: [{ name: 'a', dataType: ['text'] }],
+      };
+      const fullSchema = { classes: [otherClass] };
+      const originalClassesRef = fullSchema.classes;
+      const classSchema = {
+        class: 'Primary',
+        properties: [{ name: 'title', dataType: ['text'] }],
+      };
+
+      generateDynamicSampleQuery('Primary', classSchema, 5, { fullSchema });
+
+      // Same array reference — not replaced/mutated
+      expect(fullSchema.classes).toBe(originalClassesRef);
+      expect(fullSchema.classes).toHaveLength(1);
+      expect(fullSchema.classes[0].class).toBe('Other');
+    });
+
+    it('puts tenant before groupBy/limit in Aggregate groupBy queries', () => {
+      const { generateDynamicGroupByQuery } = require('../graphqlTemplates');
+      const classSchema = {
+        class: 'Tenanted',
+        multiTenancy: { enabled: true },
+        properties: [{ name: 'category', dataType: ['text'] }],
+      };
+      const q = generateDynamicGroupByQuery('Tenanted', classSchema, {
+        tenantName: 'acme',
+      });
+      const tenantIdx = q.indexOf('tenant:');
+      const groupByIdx = q.indexOf('groupBy:');
+      const limitIdx = q.indexOf('limit:');
+      expect(tenantIdx).toBeGreaterThan(-1);
+      expect(tenantIdx).toBeLessThan(groupByIdx);
+      expect(groupByIdx).toBeLessThan(limitIdx);
+    });
+
+    it('buildQueryHeaderComments respects custom indent', () => {
+      const { buildQueryHeaderComments } = require('../graphqlTemplates');
+      const header = buildQueryHeaderComments(
+        'Article',
+        { class: 'Article', properties: [] },
+        { kind: 'sample Get', indent: '    ' }
+      );
+      expect(header).toMatch(/^    # Schema-aware sample Get for Article/m);
+    });
+
     it('caps default sample properties instead of dumping the full schema', () => {
       const { generateSampleQuery } = require('../graphqlTemplates');
       const props = Array.from({ length: 30 }, (_, i) => ({

--- a/src/query-editor/webview/graphqlTemplates.ts
+++ b/src/query-editor/webview/graphqlTemplates.ts
@@ -957,19 +957,19 @@ export function buildQueryHeaderComments(
   const lines: string[] = [];
   lines.push(`# Schema-aware ${options?.kind || 'query'} for ${collectionName}`);
   if (isMultiTenantCollection(classSchema)) {
-    lines.push('# Multi-tenancy is enabled — set tenant to a real tenant name before running');
+    lines.push('# Multi-tenancy is enabled - set tenant to a real tenant name before running');
   }
   const vectors = getNamedVectorNames(classSchema);
   if (vectors.length > 1 || (vectors.length === 1 && vectors[0] !== 'default')) {
-    lines.push(`# Named vectors: ${vectors.join(', ')} — templates may set targetVectors`);
+    lines.push(`# Named vectors: ${vectors.join(', ')} - templates may set targetVectors`);
   }
   if (options?.excludedBlobs?.length) {
     lines.push(
-      `# Excluded blob fields (large payloads): ${options.excludedBlobs.join(', ')} — add manually if needed`
+      `# Excluded blob fields (large payloads): ${options.excludedBlobs.join(', ')} - add manually if needed`
     );
   }
   if (!hasTextVectorizerModule(classSchema) && options?.kind === 'nearText') {
-    lines.push('# No text vectorizer detected — nearText may fail; prefer nearVector if so');
+    lines.push('# No text vectorizer detected - nearText may fail; prefer nearVector if so');
   }
   return lines.map((l) => `${indent}${l}`).join('\n') + '\n';
 }
@@ -1101,7 +1101,7 @@ ${indent}}`;
     const nested = (prop.nestedProperties || []).slice(0, maxNestedProps);
     if (nested.length === 0) {
       // Do not emit bare object or __typename — Weaviate nested types need real fields.
-      return `${indent}# ${prop.name}: nested fields unavailable in schema — add a sub-selection manually`;
+      return `${indent}# ${prop.name}: nested fields unavailable in schema - add a sub-selection manually`;
     }
     const nestedPropsStr = nested
       .map((np) => {

--- a/src/query-editor/webview/graphqlTemplates.ts
+++ b/src/query-editor/webview/graphqlTemplates.ts
@@ -930,8 +930,8 @@ export function buildCollectionArgs(
 /** Optional targetVectors line for nearVector / nearText / hybrid when named vectors exist. */
 export function formatTargetVectorsArg(classSchema?: ClassSchema, config?: QueryConfig): string {
   let names: string[] = [];
-  if (Array.isArray(config?.targetVectors) && config!.targetVectors!.length > 0) {
-    names = config!.targetVectors!;
+  if (Array.isArray(config?.targetVectors) && config.targetVectors.length > 0) {
+    names = config.targetVectors;
   } else if (config?.targetVector) {
     names = [config.targetVector];
   } else {
@@ -951,8 +951,9 @@ export function formatTargetVectorsArg(classSchema?: ClassSchema, config?: Query
 export function buildQueryHeaderComments(
   collectionName: string,
   classSchema?: ClassSchema,
-  options?: { kind?: string; excludedBlobs?: string[] }
+  options?: { kind?: string; excludedBlobs?: string[]; indent?: string }
 ): string {
+  const indent = options?.indent ?? '  ';
   const lines: string[] = [];
   lines.push(`# Schema-aware ${options?.kind || 'query'} for ${collectionName}`);
   if (isMultiTenantCollection(classSchema)) {
@@ -970,7 +971,7 @@ export function buildQueryHeaderComments(
   if (!hasTextVectorizerModule(classSchema) && options?.kind === 'nearText') {
     lines.push('# No text vectorizer detected — nearText may fail; prefer nearVector if so');
   }
-  return lines.map((l) => `  ${l}`).join('\n') + '\n';
+  return lines.map((l) => `${indent}${l}`).join('\n') + '\n';
 }
 
 /**
@@ -1780,11 +1781,22 @@ export function generateDynamicSampleQuery(
   limit: number = 10,
   config?: QueryConfig
 ): string {
-  // Delegate to the shared sample generator for consistent safe defaults
-  const schema = config?.fullSchema || (classSchema ? { classes: [classSchema] } : undefined);
-  if (classSchema && schema && !schema.classes?.some((c) => c.class === classSchema.class)) {
-    schema.classes = [...(schema.classes || []), classSchema];
-  }
+  // Delegate to the shared sample generator for consistent safe defaults.
+  // Always build a new schema object — never mutate config.fullSchema.
+  const existingClasses = config?.fullSchema?.classes ?? [];
+  const hasClass =
+    !!classSchema &&
+    existingClasses.some(
+      (c) =>
+        c.class === classSchema.class || c.class?.toLowerCase() === classSchema.class?.toLowerCase()
+    );
+  const schema =
+    classSchema || existingClasses.length
+      ? {
+          classes: [...existingClasses, ...(classSchema && !hasClass ? [classSchema] : [])],
+        }
+      : undefined;
+
   return generateSampleQuery(collectionName, [], limit, schema, {
     ...config,
     maxProperties: config?.maxProperties ?? 8,
@@ -2219,16 +2231,19 @@ export function generateDynamicGroupByQuery(
     config?.groupByPath ||
     classSchema?.properties?.find((p) => isTextDataType(p.dataType))?.name ||
     'category';
+  // tenant → groupBy → limit (readable order; GraphQL arg order is not semantic)
   const tenantRequired = isMultiTenantCollection(classSchema) || Boolean(config?.tenantName);
-  const tenantLine = tenantRequired
-    ? `\n      tenant: "${config?.tenantName?.trim() || 'YOUR_TENANT_ID'}"`
-    : '';
+  const argLines: string[] = [];
+  if (tenantRequired) {
+    argLines.push(`tenant: "${config?.tenantName?.trim() || 'YOUR_TENANT_ID'}"`);
+  }
+  argLines.push(`groupBy: ["${groupByPath}"]`);
+  argLines.push('limit: 10');
 
   return `{
   Aggregate {
     ${collectionName} (
-      groupBy: ["${groupByPath}"]
-      limit: 10${tenantLine}
+      ${argLines.join('\n      ')}
     ) {
       groupedBy {
         value

--- a/src/query-editor/webview/graphqlTemplates.ts
+++ b/src/query-editor/webview/graphqlTemplates.ts
@@ -612,8 +612,10 @@ export function validateAndSanitizeQuery(query: string): {
   valid: boolean;
   sanitizedQuery: string;
   errors: string[];
+  warnings: string[];
 } {
   const errors: string[] = [];
+  const warnings: string[] = [];
 
   // Basic validation - check for balanced braces
   const openBraces = (query.match(/{/g) || []).length;
@@ -639,12 +641,29 @@ export function validateAndSanitizeQuery(query: string): {
       );
     } else if (
       PRIMITIVE_BASE_TYPES.has(typeName.toLowerCase()) ||
-      typeName.toLowerCase() === 'geocoordinates'
+      typeName.toLowerCase() === 'geocoordinates' ||
+      typeName.toLowerCase() === 'phonenumber' ||
+      typeName.toLowerCase() === 'blob'
     ) {
       errors.push(
         `Invalid inline fragment type "${typeName}" — scalar Weaviate types are selected as plain fields, not fragments`
       );
     }
+  }
+
+  // Empty selection sets (e.g. `prop { }`) are invalid GraphQL
+  if (/\{\s*\}/.test(query.replace(/#[^\n]*/g, ''))) {
+    errors.push('Empty selection set `{ }` found — nested fields require at least one selection');
+  }
+
+  // Soft guidance — do not block the editor from loading the sample
+  if (/tenant:\s*"YOUR_TENANT_ID"/.test(query)) {
+    warnings.push(
+      'Placeholder tenant "YOUR_TENANT_ID" present — replace with a real tenant name before running'
+    );
+  }
+  if (/vector:\s*\[0\.1,\s*0\.2,\s*0\.3\]/.test(query)) {
+    warnings.push('Placeholder vector [0.1, 0.2, 0.3] present — replace with a real embedding');
   }
 
   // Sanitize by removing potential harmful content (basic implementation)
@@ -656,6 +675,7 @@ export function validateAndSanitizeQuery(query: string): {
     valid: errors.length === 0,
     sanitizedQuery,
     errors,
+    warnings,
   };
 }
 
@@ -669,9 +689,11 @@ export function getRecommendedConfig(classSchema?: ClassSchema): Partial<QueryCo
     return {};
   }
 
-  const hasVector = classSchema.vectorizer !== undefined;
+  const hasVector =
+    classSchema.vectorizer !== undefined || getNamedVectorNames(classSchema).length > 0;
   const hasTextProperties = classSchema.properties.some((p) => isTextDataType(p.dataType));
   const hasGeoProperties = classSchema.properties.some((p) => isGeoDataType(p.dataType));
+  const namedVectors = getNamedVectorNames(classSchema);
 
   return {
     includeVectors: hasVector,
@@ -681,6 +703,8 @@ export function getRecommendedConfig(classSchema?: ClassSchema): Partial<QueryCo
     certainty: 0.7,
     distance: 0.6,
     limit: 10,
+    includeBlobs: false,
+    includeHeaderComments: true,
     // Prefer text fields (including text[]) for BM25 / hybrid when available
     searchProperties: hasTextProperties
       ? classSchema.properties
@@ -688,6 +712,11 @@ export function getRecommendedConfig(classSchema?: ClassSchema): Partial<QueryCo
           .map((p) => p.name)
           .slice(0, 5)
       : undefined,
+    targetVectors:
+      namedVectors.length > 1 || (namedVectors.length === 1 && namedVectors[0] !== 'default')
+        ? namedVectors
+        : undefined,
+    tenantName: isMultiTenantCollection(classSchema) ? 'YOUR_TENANT_ID' : undefined,
   };
 }
 
@@ -766,12 +795,21 @@ export interface ClassSchema {
   properties: PropertySchema[];
   vectorizer?: string;
   moduleConfig?: Record<string, any>;
+  /** Named-vector map (v3/v4 client shape), e.g. { title: {...}, content: {...} } */
   vectorizers?: Record<string, any>;
+  /** Explicit list of named vector keys when known */
+  vectorNames?: string[];
+  multiTenancy?: {
+    enabled?: boolean;
+    autoTenantCreation?: boolean;
+    autoTenantActivation?: boolean;
+  };
 }
 
 /**
  * Scalar Weaviate property types (array forms like text[] share the same base).
  * Cross-references use collection/class names and are NOT listed here.
+ * phoneNumber and blob are compound/special and classified separately.
  */
 export const PRIMITIVE_BASE_TYPES = new Set([
   'text',
@@ -780,12 +818,17 @@ export const PRIMITIVE_BASE_TYPES = new Set([
   'number',
   'boolean',
   'date',
-  'phonenumber',
   'uuid',
-  'blob',
 ]);
 
-export type PropertyKind = 'primitive' | 'geo' | 'object' | 'reference' | 'unknown';
+export type PropertyKind =
+  | 'primitive'
+  | 'geo'
+  | 'phone'
+  | 'blob'
+  | 'object'
+  | 'reference'
+  | 'unknown';
 
 /** Coerce Weaviate dataType (string | string[]) to a non-empty string array. */
 export function coerceDataType(dataType: string | string[] | undefined | null): string[] {
@@ -827,6 +870,14 @@ export function isGeoDataType(dataType: string | string[] | undefined | null): b
   return getBaseDataType(dataType) === 'geocoordinates';
 }
 
+export function isPhoneNumberDataType(dataType: string | string[] | undefined | null): boolean {
+  return getBaseDataType(dataType) === 'phonenumber';
+}
+
+export function isBlobDataType(dataType: string | string[] | undefined | null): boolean {
+  return getBaseDataType(dataType) === 'blob';
+}
+
 export function isObjectDataType(dataType: string | string[] | undefined | null): boolean {
   return getBaseDataType(dataType) === 'object';
 }
@@ -834,6 +885,92 @@ export function isObjectDataType(dataType: string | string[] | undefined | null)
 export function isTextDataType(dataType: string | string[] | undefined | null): boolean {
   const base = getBaseDataType(dataType);
   return base === 'text' || base === 'string';
+}
+
+/** Named vector names from class schema (vectorNames, vectorizers keys). */
+export function getNamedVectorNames(classSchema?: ClassSchema): string[] {
+  if (!classSchema) {
+    return [];
+  }
+  if (Array.isArray(classSchema.vectorNames) && classSchema.vectorNames.length > 0) {
+    return classSchema.vectorNames.filter((n) => typeof n === 'string' && n.length > 0);
+  }
+  if (classSchema.vectorizers && typeof classSchema.vectorizers === 'object') {
+    return Object.keys(classSchema.vectorizers);
+  }
+  return [];
+}
+
+export function isMultiTenantCollection(classSchema?: ClassSchema): boolean {
+  return Boolean(classSchema?.multiTenancy?.enabled);
+}
+
+/**
+ * Build GraphQL argument lines for Get { Collection(…) }.
+ * Includes tenant when multi-tenancy is enabled or a tenant is configured.
+ */
+export function buildCollectionArgs(
+  classSchema: ClassSchema | undefined,
+  limit: number,
+  config?: QueryConfig
+): string {
+  const lines: string[] = [];
+  const tenantRequired = isMultiTenantCollection(classSchema) || Boolean(config?.tenantName);
+  if (tenantRequired) {
+    const tenant = config?.tenantName?.trim() || 'YOUR_TENANT_ID';
+    lines.push(`tenant: "${tenant}"`);
+  }
+  if (typeof config?.offset === 'number' && config.offset > 0) {
+    lines.push(`offset: ${config.offset}`);
+  }
+  lines.push(`limit: ${limit}`);
+  return lines.join('\n      ');
+}
+
+/** Optional targetVectors line for nearVector / nearText / hybrid when named vectors exist. */
+export function formatTargetVectorsArg(classSchema?: ClassSchema, config?: QueryConfig): string {
+  let names: string[] = [];
+  if (Array.isArray(config?.targetVectors) && config!.targetVectors!.length > 0) {
+    names = config!.targetVectors!;
+  } else if (config?.targetVector) {
+    names = [config.targetVector];
+  } else {
+    names = getNamedVectorNames(classSchema);
+  }
+  if (names.length === 0) {
+    return '';
+  }
+  // Single anonymous/default vector — omit targetVectors to stay compatible
+  if (names.length === 1 && (names[0] === 'default' || names[0] === 'Default')) {
+    return '';
+  }
+  return `targetVectors: [${names.map((n) => `"${n}"`).join(', ')}]`;
+}
+
+/** Header comments describing schema-aware choices. */
+export function buildQueryHeaderComments(
+  collectionName: string,
+  classSchema?: ClassSchema,
+  options?: { kind?: string; excludedBlobs?: string[] }
+): string {
+  const lines: string[] = [];
+  lines.push(`# Schema-aware ${options?.kind || 'query'} for ${collectionName}`);
+  if (isMultiTenantCollection(classSchema)) {
+    lines.push('# Multi-tenancy is enabled — set tenant to a real tenant name before running');
+  }
+  const vectors = getNamedVectorNames(classSchema);
+  if (vectors.length > 1 || (vectors.length === 1 && vectors[0] !== 'default')) {
+    lines.push(`# Named vectors: ${vectors.join(', ')} — templates may set targetVectors`);
+  }
+  if (options?.excludedBlobs?.length) {
+    lines.push(
+      `# Excluded blob fields (large payloads): ${options.excludedBlobs.join(', ')} — add manually if needed`
+    );
+  }
+  if (!hasTextVectorizerModule(classSchema) && options?.kind === 'nearText') {
+    lines.push('# No text vectorizer detected — nearText may fail; prefer nearVector if so');
+  }
+  return lines.map((l) => `  ${l}`).join('\n') + '\n';
 }
 
 /**
@@ -855,7 +992,12 @@ export function isReferenceDataType(dataType: string | string[] | undefined | nu
     if (PRIMITIVE_BASE_TYPES.has(lower)) {
       return false;
     }
-    if (lower === 'object' || lower === 'geocoordinates') {
+    if (
+      lower === 'object' ||
+      lower === 'geocoordinates' ||
+      lower === 'phonenumber' ||
+      lower === 'blob'
+    ) {
       return false;
     }
     return true;
@@ -874,6 +1016,12 @@ export function classifyProperty(prop: PropertySchema): PropertyKind {
   if (isGeoDataType(dataType)) {
     return 'geo';
   }
+  if (isPhoneNumberDataType(dataType)) {
+    return 'phone';
+  }
+  if (isBlobDataType(dataType)) {
+    return 'blob';
+  }
   if (isPrimitiveDataType(dataType)) {
     return 'primitive';
   }
@@ -890,8 +1038,10 @@ export function classifyProperty(prop: PropertySchema): PropertyKind {
 
 /**
  * Format a property for a GraphQL selection set.
- * - primitives / unknown: bare field name (works for text, text[], int[], …)
+ * - primitives / unknown: bare field name (works for text, text[], int[], uuid, …)
  * - geo: latitude/longitude subselection
+ * - phoneNumber: nested phone fields
+ * - blob: plain field with optional size warning
  * - nested object/object[]: `... on Collection_prop_object { nested fields }`
  * - cross-references: `... on TargetClass { … }` (multi-target: one fragment each)
  */
@@ -923,29 +1073,46 @@ ${indent}  longitude
 ${indent}}`;
   }
 
+  if (kind === 'phone') {
+    return `${indent}${prop.name} {
+${indent}  input
+${indent}  internationalFormatted
+${indent}  nationalFormatted
+${indent}  national
+${indent}  countryCode
+${indent}  defaultCountry
+${indent}  valid
+${indent}}`;
+  }
+
+  if (kind === 'blob') {
+    const warn = includeWarning
+      ? `${indent}# WARNING: ${prop.name} is a blob and may return large base64 data\n`
+      : '';
+    return `${warn}${indent}${prop.name}`;
+  }
+
   if (kind === 'object') {
     const nestedTypeName = `${collectionName}_${prop.name}_object`;
     if (!isValidGraphQLTypeName(nestedTypeName)) {
-      // The generated inline-fragment type name contains characters that are not allowed
-      // in GraphQL identifiers (e.g. hyphens in the collection or property name).  Fall
-      // back to a bare field selection so the query remains valid — the user can add a
-      // manual sub-selection if needed.
-      return `${indent}${prop.name}`;
+      return `${indent}# ${prop.name}: nested object type name is not GraphQL-safe; add a manual sub-selection`;
     }
     const nested = (prop.nestedProperties || []).slice(0, maxNestedProps);
     if (nested.length === 0) {
-      // Schema did not expose nested fields — still select the object safely.
-      return `${indent}${prop.name} {
-${indent}  # Nested fields unavailable in schema; add them manually if needed.
-${indent}  __typename
-${indent}}`;
+      // Do not emit bare object or __typename — Weaviate nested types need real fields.
+      return `${indent}# ${prop.name}: nested fields unavailable in schema — add a sub-selection manually`;
     }
     const nestedPropsStr = nested
       .map((np) => {
-        // Nested props may themselves be nested objects or geo; keep first level simple.
         const npKind = classifyProperty(np);
         if (npKind === 'geo') {
           return `${indent}  ${np.name} {\n${indent}    latitude\n${indent}    longitude\n${indent}  }`;
+        }
+        if (npKind === 'phone') {
+          return `${indent}  ${np.name} {\n${indent}    input\n${indent}    internationalFormatted\n${indent}  }`;
+        }
+        if (npKind === 'blob') {
+          return `${indent}  # skip nested blob ${np.name}`;
         }
         if (npKind === 'object' && np.nestedProperties?.length) {
           const deeper = np.nestedProperties
@@ -978,17 +1145,24 @@ ${indent}}`;
       : '';
     const fragments = classNames
       .map((className) => {
-        const referencedClass = schema?.classes?.find((c) => c.class === className);
+        const referencedClass = schema?.classes?.find(
+          (c) => c.class === className || c.class?.toLowerCase() === className.toLowerCase()
+        );
         let body: string;
         if (referencedClass?.properties?.length) {
           const refPrimitiveProps = referencedClass.properties
             .filter((p) => {
               const k = classifyProperty(p);
-              return k === 'primitive' || k === 'unknown';
+              return k === 'primitive' || k === 'unknown' || k === 'phone';
             })
             .slice(0, maxNestedProps);
           if (refPrimitiveProps.length > 0) {
-            const lines = refPrimitiveProps.map((p) => `${indent}    ${p.name}`);
+            const lines = refPrimitiveProps.map((p) => {
+              if (classifyProperty(p) === 'phone') {
+                return `${indent}    ${p.name} {\n${indent}      input\n${indent}      internationalFormatted\n${indent}    }`;
+              }
+              return `${indent}    ${p.name}`;
+            });
             if (includeRefAdditional) {
               lines.push(`${indent}    _additional {`, `${indent}      id`, `${indent}    }`);
             }
@@ -996,12 +1170,12 @@ ${indent}}`;
           } else if (includeRefAdditional) {
             body = `${indent}    _additional {\n${indent}      id\n${indent}    }`;
           } else {
-            body = `${indent}    __typename`;
+            body = `${indent}    # no scalar fields available on ${className}`;
           }
         } else if (includeRefAdditional) {
           body = `${indent}    _additional {\n${indent}      id\n${indent}    }`;
         } else {
-          body = `${indent}    __typename`;
+          body = `${indent}    # referenced class ${className} not in schema`;
         }
         return `${indent}  ... on ${className} {\n${body}\n${indent}  }`;
       })
@@ -1015,19 +1189,28 @@ ${indent}}`;
   return `${indent}${prop.name}`;
 }
 
+export interface PropertySelectionOptions {
+  maxCount?: number;
+  schema?: { classes?: ClassSchema[] };
+  /** Include every non-blob property (sample "full" mode). Blobs still require includeBlobs. */
+  includeAll?: boolean;
+  maxNestedProps?: number;
+  includeWarning?: boolean;
+  indent?: string;
+  /** Default false — blobs can return huge base64 payloads. */
+  includeBlobs?: boolean;
+  maxReferences?: number;
+  maxObjects?: number;
+  maxGeo?: number;
+  maxPhones?: number;
+}
+
 /**
  * Build a selection list for display/query generators from a class schema.
  */
 export function buildPropertySelections(
   classSchema: ClassSchema | undefined,
-  options: {
-    maxCount?: number;
-    schema?: { classes?: ClassSchema[] };
-    includeAll?: boolean;
-    maxNestedProps?: number;
-    includeWarning?: boolean;
-    indent?: string;
-  } = {}
+  options: PropertySelectionOptions = {}
 ): string[] {
   if (!classSchema?.properties?.length) {
     return [];
@@ -1040,10 +1223,17 @@ export function buildPropertySelections(
     maxNestedProps = 5,
     includeWarning = true,
     indent = '      ',
+    includeBlobs = false,
+    maxReferences = 1,
+    maxObjects = 2,
+    maxGeo = 1,
+    maxPhones = 1,
   } = options;
 
   const primitives: PropertySchema[] = [];
   const geo: PropertySchema[] = [];
+  const phones: PropertySchema[] = [];
+  const blobs: PropertySchema[] = [];
   const objects: PropertySchema[] = [];
   const references: PropertySchema[] = [];
 
@@ -1051,6 +1241,12 @@ export function buildPropertySelections(
     switch (classifyProperty(prop)) {
       case 'geo':
         geo.push(prop);
+        break;
+      case 'phone':
+        phones.push(prop);
+        break;
+      case 'blob':
+        blobs.push(prop);
         break;
       case 'object':
         objects.push(prop);
@@ -1078,13 +1274,15 @@ export function buildPropertySelections(
   if (includeAll) {
     return [
       ...primitives.map(format),
+      ...phones.map(format),
       ...geo.map(format),
       ...objects.map(format),
       ...references.map(format),
+      ...(includeBlobs ? blobs.map(format) : []),
     ];
   }
 
-  // Prefer scalars, then geo, nested objects, then a small number of refs.
+  // Prefer scalars, then phones, geo, nested objects, then a small number of refs.
   const result: string[] = [];
   const take = (items: PropertySchema[], n: number) => {
     for (const prop of items) {
@@ -1099,11 +1297,23 @@ export function buildPropertySelections(
   };
 
   take(primitives, maxCount);
-  take(geo, Math.max(0, maxCount - result.length));
-  take(objects, Math.min(2, Math.max(0, maxCount - result.length)));
-  take(references, Math.min(2, Math.max(0, maxCount - result.length)));
+  take(phones, maxPhones);
+  take(geo, maxGeo);
+  take(objects, maxObjects);
+  take(references, maxReferences);
+  if (includeBlobs) {
+    take(blobs, 1);
+  }
 
   return result;
+}
+
+/** Blob property names excluded from a selection pass (for header comments). */
+export function getExcludedBlobNames(classSchema?: ClassSchema, includeBlobs?: boolean): string[] {
+  if (includeBlobs || !classSchema?.properties) {
+    return [];
+  }
+  return classSchema.properties.filter((p) => classifyProperty(p) === 'blob').map((p) => p.name);
 }
 
 /**
@@ -1134,44 +1344,66 @@ export interface QueryConfig {
   vector?: number[];
   sortBy?: { path: string; order?: 'asc' | 'desc' };
   returnProperties?: string[];
+  /** Include blob fields in generated selections (default false). */
+  includeBlobs?: boolean;
+  /** Include every non-blob property instead of the capped safe default. */
+  includeAllProperties?: boolean;
+  /** Prefixed # comments explaining schema-aware choices (default true for samples). */
+  includeHeaderComments?: boolean;
+  /** Single named vector target. */
+  targetVector?: string;
+  /** Multi-target named vectors. */
+  targetVectors?: string[];
+  /** Full schema for expanding cross-reference selections. */
+  fullSchema?: { classes?: ClassSchema[] };
 }
 
 /**
  * Generate a sample GraphQL Get query for a collection.
  *
- * @param collectionName - The Weaviate collection/class name.
- * @param properties     - Explicit list of property names to select. When empty, the full
- *                         schema is used (all properties are auto-classified and formatted).
- * @param limit          - Result limit (default 10).
- * @param schema         - Full schema used to resolve cross-reference targets and nested fields.
- * @returns A GraphQL query string ready to paste into the editor.
+ * Defaults favour safe, runnable queries:
+ * - capped property set (not every field)
+ * - blobs excluded
+ * - at most one cross-reference
+ * - tenant arg when multi-tenancy is enabled
  *
- * **Indentation contract**: each entry in `propertyStrings` is already indented by six
- * spaces (the depth of a property inside `Get { Collection { … } }`).  Callers that
- * post-process the returned string should account for this.
+ * Pass `config.includeAllProperties` to expand to all non-blob fields.
+ *
+ * **Indentation contract**: each property line is already indented by six spaces.
  */
-
 export function generateSampleQuery(
   collectionName: string,
   properties: string[] = [],
   limit: number = 10,
-  schema?: { classes?: ClassSchema[] }
+  schema?: { classes?: ClassSchema[] },
+  config?: QueryConfig
 ): string {
   // Find the class definition from schema if available (case-insensitive)
   const classSchema =
     schema?.classes?.find((c) => c.class === collectionName) ||
     schema?.classes?.find((c) => c.class?.toLowerCase() === collectionName.toLowerCase());
 
+  const fullSchema = config?.fullSchema || schema;
+  const includeBlobs = config?.includeBlobs === true;
+  const includeAll = config?.includeAllProperties === true;
+  const maxProps = config?.maxProperties ?? (includeAll ? 50 : 12);
+  const includeComments = config?.includeHeaderComments !== false;
+
   let propertyStrings: string[] = [];
 
   if (properties.length === 0 && classSchema?.properties?.length) {
-    // Include all schema properties, classified correctly (text[] is scalar, not a ref).
     propertyStrings = buildPropertySelections(classSchema, {
-      includeAll: true,
-      schema,
+      includeAll,
+      maxCount: maxProps,
+      schema: fullSchema,
       indent: '      ',
       maxNestedProps: 5,
       includeWarning: true,
+      includeBlobs,
+      maxReferences: includeAll ? 10 : 1,
+      maxObjects: includeAll ? 10 : 2,
+      maxGeo: includeAll ? 10 : 1,
+      maxPhones: includeAll ? 10 : 1,
     });
   } else if (properties.length > 0) {
     propertyStrings = properties.map((propName) => {
@@ -1179,28 +1411,37 @@ export function generateSampleQuery(
       if (propSchema && classSchema) {
         return formatPropertySelection(propSchema, {
           collectionName: classSchema.class,
-          schema,
+          schema: fullSchema,
           indent: '      ',
           maxNestedProps: 5,
           includeWarning: true,
         });
       }
-      // Unknown property name — emit as a plain field (never invent invalid fragments).
       return `      ${propName}`;
     });
   } else {
     propertyStrings = ['      # Add your properties here'];
   }
 
-  // Always include _additional.id for object identification
   if (!propertyStrings.some((p) => p.includes('_additional'))) {
     propertyStrings.unshift('      _additional {\n        id\n      }');
   }
 
-  // formatPropertySelection already indents; join without extra leading indent.
+  const args = buildCollectionArgs(classSchema, limit, config);
+  const excludedBlobs = getExcludedBlobNames(classSchema, includeBlobs);
+  const header =
+    includeComments && classSchema
+      ? buildQueryHeaderComments(collectionName, classSchema, {
+          kind: 'sample Get',
+          excludedBlobs,
+        })
+      : '';
+
   return `{
-  Get {
-    ${collectionName} (limit: ${limit}) {
+${header}  Get {
+    ${collectionName} (
+      ${args}
+    ) {
 ${propertyStrings.join('\n')}
     }
   }
@@ -1354,17 +1595,36 @@ export function processTemplate(
         : undefined,
     });
 
+    const extractVectorNames = (input: any): string[] | undefined => {
+      if (Array.isArray(input?.vectorNames)) {
+        return input.vectorNames;
+      }
+      const fromVectorizers =
+        input?.vectorizers && typeof input.vectorizers === 'object'
+          ? Object.keys(input.vectorizers)
+          : [];
+      const fromConfig =
+        input?.vectorizerConfig && typeof input.vectorizerConfig === 'object'
+          ? Object.keys(input.vectorizerConfig)
+          : [];
+      const names = fromVectorizers.length > 0 ? fromVectorizers : fromConfig;
+      return names.length > 0 ? names : undefined;
+    };
+
     const normalizeClassSchema = (input: any): ClassSchema | undefined => {
       if (!input) {
         return undefined;
       }
+      const vectorizers = input.vectorizers ?? input.vectorizerConfig;
       const normalized: ClassSchema = {
         class: input.class ?? input.name,
         description: input.description,
         properties: Array.isArray(input.properties) ? input.properties.map(normalizeProperty) : [],
         vectorizer: input.vectorizer,
         moduleConfig: input.moduleConfig,
-        vectorizers: input.vectorizers,
+        vectorizers,
+        vectorNames: extractVectorNames(input),
+        multiTenancy: input.multiTenancy,
       };
       return normalized;
     };
@@ -1373,7 +1633,11 @@ export function processTemplate(
     let classSchema: ClassSchema | undefined = undefined;
     const classesAny = (schema as any)?.classes || (schema as any)?.collections;
     const lc = (s: any) => (typeof s === 'string' ? s.toLowerCase() : '');
+    let allClasses: ClassSchema[] = [];
     if (Array.isArray(classesAny)) {
+      allClasses = classesAny
+        .map((c: any) => normalizeClassSchema(c))
+        .filter((c: ClassSchema | undefined): c is ClassSchema => Boolean(c));
       let raw = classesAny.find(
         (c: any) => lc(c.class) === lc(collectionName) || lc(c.name) === lc(collectionName)
       );
@@ -1386,6 +1650,9 @@ export function processTemplate(
       lc((schema as any)?.class) === lc(collectionName)
     ) {
       classSchema = normalizeClassSchema(schema);
+      if (classSchema) {
+        allClasses = [classSchema];
+      }
     }
 
     // Check if the template is a predefined template name (queries only)
@@ -1396,13 +1663,22 @@ export function processTemplate(
 
     // Determine effective limit (config overrides param)
     const effectiveLimit = config?.limit ?? limit;
+    const effectiveConfig: QueryConfig = {
+      ...config,
+      fullSchema: config?.fullSchema || (allClasses.length ? { classes: allClasses } : schema),
+    };
 
     // Replace placeholders with actual values using dynamic generation when possible
     let query = template
       .replace(
         '{nearVectorQuery}',
         classSchema
-          ? generateDynamicNearVectorQuery(collectionName, classSchema, effectiveLimit, config)
+          ? generateDynamicNearVectorQuery(
+              collectionName,
+              classSchema,
+              effectiveLimit,
+              effectiveConfig
+            )
           : generateNearVectorQuery(collectionName, effectiveLimit, config?.returnProperties)
       )
       .replace(
@@ -1412,19 +1688,24 @@ export function processTemplate(
       .replace(
         '{nearTextQuery}',
         classSchema
-          ? generateDynamicNearTextQuery(collectionName, classSchema, effectiveLimit, config)
+          ? generateDynamicNearTextQuery(
+              collectionName,
+              classSchema,
+              effectiveLimit,
+              effectiveConfig
+            )
           : generateNearTextQuery(collectionName, effectiveLimit, config?.returnProperties)
       )
       .replace(
         '{hybridQuery}',
         classSchema
-          ? generateDynamicHybridQuery(collectionName, classSchema, effectiveLimit, config)
+          ? generateDynamicHybridQuery(collectionName, classSchema, effectiveLimit, effectiveConfig)
           : generateHybridQuery(collectionName, effectiveLimit, config?.returnProperties)
       )
       .replace(
         '{bm25Query}',
         classSchema
-          ? generateDynamicBM25Query(collectionName, classSchema, effectiveLimit, config)
+          ? generateDynamicBM25Query(collectionName, classSchema, effectiveLimit, effectiveConfig)
           : generateBM25Query(collectionName, effectiveLimit, config?.returnProperties)
       )
       .replace(
@@ -1434,31 +1715,43 @@ export function processTemplate(
               collectionName,
               classSchema,
               effectiveLimit,
-              config
+              effectiveConfig
             )
           : generateGenerativeSearchQuery(collectionName, effectiveLimit, config?.returnProperties)
       )
       .replace(
         '{groupByQuery}',
         classSchema
-          ? generateDynamicGroupByQuery(collectionName, classSchema)
+          ? generateDynamicGroupByQuery(collectionName, classSchema, effectiveConfig)
           : generateGroupByQuery(collectionName)
       )
       .replace(
         '{filterQuery}',
         classSchema
-          ? generateDynamicFilterQuery(collectionName, classSchema, effectiveLimit, config)
+          ? generateDynamicFilterQuery(collectionName, classSchema, effectiveLimit, effectiveConfig)
           : generateFilterQuery(collectionName, effectiveLimit)
       )
       .replace(
         '{aggregationQuery}',
         classSchema
-          ? generateDynamicAggregationQuery(collectionName, classSchema)
+          ? generateDynamicAggregationQuery(collectionName, classSchema, effectiveConfig)
           : generateAggregationQuery(collectionName)
       )
       .replace(
         '{tenantQuery}',
-        generateTenantQuery(collectionName, config?.tenantName ?? 'tenant-name', effectiveLimit)
+        classSchema
+          ? generateDynamicTenantQuery(
+              collectionName,
+              classSchema,
+              effectiveConfig?.tenantName ?? 'YOUR_TENANT_ID',
+              effectiveLimit,
+              effectiveConfig
+            )
+          : generateTenantQuery(
+              collectionName,
+              config?.tenantName ?? 'YOUR_TENANT_ID',
+              effectiveLimit
+            )
       )
       .replace('{exploreQuery}', generateExploreQuery(collectionName, effectiveLimit));
 
@@ -1484,50 +1777,19 @@ export function processTemplate(
 export function generateDynamicSampleQuery(
   collectionName: string,
   classSchema?: ClassSchema,
-  limit: number = 10
+  limit: number = 10,
+  config?: QueryConfig
 ): string {
-  if (!classSchema || !classSchema.properties) {
-    return `{
-  Get {
-    ${collectionName} (limit: ${limit}) {
-      # Add your properties here - replace with actual properties from your schema
-      _additional {
-        id
-        creationTimeUnix
-        lastUpdateTimeUnix
-      }
-    }
+  // Delegate to the shared sample generator for consistent safe defaults
+  const schema = config?.fullSchema || (classSchema ? { classes: [classSchema] } : undefined);
+  if (classSchema && schema && !schema.classes?.some((c) => c.class === classSchema.class)) {
+    schema.classes = [...(schema.classes || []), classSchema];
   }
-}`;
-  }
-
-  // Ensure class name is set for nested type names
-  const schemaForBuild: ClassSchema = {
-    ...classSchema,
-    class: classSchema.class || collectionName,
-  };
-
-  const propertyLines = buildPropertySelections(schemaForBuild, {
-    maxCount: 8,
-    includeAll: false,
-    maxNestedProps: 3,
-    includeWarning: true,
-    indent: '      ',
+  return generateSampleQuery(collectionName, [], limit, schema, {
+    ...config,
+    maxProperties: config?.maxProperties ?? 8,
+    includeHeaderComments: config?.includeHeaderComments !== false,
   });
-
-  propertyLines.unshift(`      _additional {
-        id
-        creationTimeUnix
-        lastUpdateTimeUnix
-      }`);
-
-  return `{
-  Get {
-    ${collectionName}(limit: ${limit}) {
-${propertyLines.join('\n')}
-    }
-  }
-}`;
 }
 
 /**
@@ -1543,7 +1805,7 @@ export function generateDynamicNearVectorQuery(
   limit: number = 10,
   config?: QueryConfig
 ): string {
-  const properties = getTopPropertiesForDisplay(classSchema, 3);
+  const properties = getTopPropertiesForDisplay(classSchema, 3, config);
   const vec = Array.isArray(config?.vector) ? config!.vector : [0.1, 0.2, 0.3];
   const vectorStr = `[${vec.join(', ')}]`;
   const distanceVal = typeof config?.distance === 'number' ? config!.distance : undefined;
@@ -1563,14 +1825,22 @@ export function generateDynamicNearVectorQuery(
     ? `${dimsLabel} dimensions`
     : 'match your vectorizer dimensions';
 
+  const targetVectorsLine = formatTargetVectorsArg(classSchema, config);
+  const collectionArgs = buildCollectionArgs(classSchema, limit, config);
+  const header =
+    config?.includeHeaderComments === false
+      ? ''
+      : buildQueryHeaderComments(collectionName, classSchema, { kind: 'nearVector' });
+
   return `{
-  Get {
+${header}  Get {
     ${collectionName}(
       nearVector: {
         vector: ${vectorStr} # Replace with your actual vector (${dimsText})
         ${thresholdLine}
+${targetVectorsLine ? `        ${targetVectorsLine}` : ''}
       }
-      limit: ${limit}
+      ${collectionArgs}
     ) {
 ${properties.join('\n')}
       _additional {
@@ -1594,7 +1864,7 @@ export function generateDynamicNearTextQuery(
   limit: number = 10,
   config?: QueryConfig
 ): string {
-  const properties = getTopPropertiesForDisplay(classSchema, 3);
+  const properties = getTopPropertiesForDisplay(classSchema, 3, config);
 
   const conceptsArr =
     Array.isArray(config?.concepts) && config!.concepts.length > 0
@@ -1631,12 +1901,17 @@ export function generateDynamicNearTextQuery(
 
   const includeExplain = config?.includeExplainScore === false ? '' : '        explainScore';
   const hasTextVec = hasTextVectorizerModule(classSchema);
-  const headerComment = hasTextVec
-    ? ''
-    : `  # NOTE: nearText requires a text vectorizer module (text2vec-openai, text2vec-cohere, etc.)
-  # If you get an "Unknown argument nearText" error, use nearVector instead or configure a text vectorizer
-
-`;
+  const targetVectorsLine = formatTargetVectorsArg(classSchema, config);
+  const collectionArgs = buildCollectionArgs(classSchema, limit, config);
+  const headerComment =
+    config?.includeHeaderComments === false
+      ? hasTextVec
+        ? ''
+        : `  # NOTE: nearText requires a text vectorizer module\n`
+      : buildQueryHeaderComments(collectionName, classSchema, { kind: 'nearText' }) +
+        (hasTextVec
+          ? ''
+          : `  # NOTE: nearText requires a text vectorizer module (text2vec-openai, text2vec-cohere, etc.)\n  # If you get an "Unknown argument nearText" error, use nearVector instead\n`);
 
   return `{
 ${headerComment}  Get {
@@ -1646,8 +1921,9 @@ ${headerComment}  Get {
         ${thresholdLine}
 ${moveAwayBlock}
 ${moveToBlock}
+${targetVectorsLine ? `        ${targetVectorsLine}` : ''}
       }
-      limit: ${limit}
+      ${collectionArgs}
     ) {
 ${properties.join('\n')}
       _additional {
@@ -1674,9 +1950,10 @@ export function generateDynamicFilterQuery(
   limit: number = 10,
   config?: QueryConfig
 ): string {
-  const properties = getTopPropertiesForDisplay(classSchema, 3);
+  const properties = getTopPropertiesForDisplay(classSchema, 3, config);
   const filterExamples = generateFilterExamples(classSchema);
   const operator = config?.filterOperator ?? 'And';
+  const collectionArgs = buildCollectionArgs(classSchema, limit, config);
 
   return `{
   Get {
@@ -1687,7 +1964,7 @@ export function generateDynamicFilterQuery(
 ${filterExamples.join(',\n')}
         ]
       }
-      limit: ${limit}
+      ${collectionArgs}
     ) {
 ${properties.join('\n')}
       _additional {
@@ -1706,17 +1983,22 @@ ${properties.join('\n')}
  */
 export function generateDynamicAggregationQuery(
   collectionName: string,
-  classSchema?: ClassSchema
+  classSchema?: ClassSchema,
+  config?: QueryConfig
 ): string {
   if (!classSchema?.properties) {
     return generateAggregationQuery(collectionName);
   }
 
   const aggregationFields = generateAggregationFields(classSchema);
+  const tenantRequired = isMultiTenantCollection(classSchema) || Boolean(config?.tenantName);
+  const aggregateArgs = tenantRequired
+    ? `(\n      tenant: "${config?.tenantName?.trim() || 'YOUR_TENANT_ID'}"\n    )`
+    : '';
 
   return `{
   Aggregate {
-    ${collectionName} {
+    ${collectionName}${aggregateArgs} {
       meta {
         count
       }
@@ -1739,7 +2021,7 @@ export function generateDynamicHybridQuery(
   limit: number = 10,
   config?: QueryConfig
 ): string {
-  const properties = getTopPropertiesForDisplay(classSchema, 3);
+  const properties = getTopPropertiesForDisplay(classSchema, 3, config);
   const queryText =
     typeof config?.searchQuery === 'string' && config!.searchQuery.length > 0
       ? config!.searchQuery.replace(/"/g, '\\"')
@@ -1749,9 +2031,13 @@ export function generateDynamicHybridQuery(
   const propsOverride =
     Array.isArray(config?.propertiesOverride) && config!.propertiesOverride.length > 0
       ? config!.propertiesOverride
-      : getTextProperties(classSchema).slice(0, 3);
+      : Array.isArray(config?.searchProperties) && config!.searchProperties!.length > 0
+        ? config!.searchProperties!
+        : getTextProperties(classSchema).slice(0, 3);
 
   const vec = Array.isArray(config?.vector) ? `[${config!.vector.join(', ')}]` : `[0.1, 0.2, 0.3]`;
+  const targetVectorsLine = formatTargetVectorsArg(classSchema, config);
+  const collectionArgs = buildCollectionArgs(classSchema, limit, config);
 
   return `{
   Get {
@@ -1761,8 +2047,9 @@ export function generateDynamicHybridQuery(
         alpha: ${alphaVal} # Balance: 0=pure vector, 1=pure keyword search
         vector: ${vec} # Optional: provide custom vector (ensure its length matches your embedding model's dimension)
         properties: [${propsOverride.map((p) => `"${p}"`).join(', ')}] # Optional: limit search to specific properties
+${targetVectorsLine ? `        ${targetVectorsLine}` : ''}
       }
-      limit: ${limit}
+      ${collectionArgs}
     ) {
 ${properties.join('\n')}
       _additional {
@@ -1788,7 +2075,7 @@ export function generateDynamicBM25Query(
   limit: number = 10,
   config?: QueryConfig
 ): string {
-  const properties = getTopPropertiesForDisplay(classSchema, 3);
+  const properties = getTopPropertiesForDisplay(classSchema, 3, config);
   const defaultTextProps = getTextProperties(classSchema);
   const queryText =
     typeof config?.searchQuery === 'string' && config!.searchQuery.length > 0
@@ -1797,7 +2084,10 @@ export function generateDynamicBM25Query(
   const propsOverride =
     Array.isArray(config?.propertiesOverride) && config!.propertiesOverride.length > 0
       ? config!.propertiesOverride
-      : defaultTextProps.slice(0, 3);
+      : Array.isArray(config?.searchProperties) && config!.searchProperties!.length > 0
+        ? config!.searchProperties!
+        : defaultTextProps.slice(0, 3);
+  const collectionArgs = buildCollectionArgs(classSchema, limit, config);
 
   return `{
   Get {
@@ -1806,7 +2096,7 @@ export function generateDynamicBM25Query(
         query: "${queryText}"
         properties: [${propsOverride.map((p) => `"${p}"`).join(', ')}] # Optional: limit search to specific properties
       }
-      limit: ${limit}
+      ${collectionArgs}
     ) {
 ${properties.join('\n')}
       _additional {
@@ -1831,7 +2121,7 @@ export function generateDynamicGenerativeSearchQuery(
   limit: number = 5,
   config?: QueryConfig
 ): string {
-  const properties = getTopPropertiesForDisplay(classSchema, 3);
+  const properties = getTopPropertiesForDisplay(classSchema, 3, config);
   const conceptsArr =
     Array.isArray(config?.concepts) && config!.concepts.length > 0
       ? `[${config!.concepts.map((c) => `"${String(c).replace(/"/g, '\\"')}"`).join(', ')}]`
@@ -1850,6 +2140,8 @@ export function generateDynamicGenerativeSearchQuery(
     Array.isArray(config?.propertiesOverride) && config!.propertiesOverride.length > 0
       ? config!.propertiesOverride.slice(0, 2)
       : getTextProperties(classSchema).slice(0, 2);
+  const targetVectorsLine = formatTargetVectorsArg(classSchema, config);
+  const collectionArgs = buildCollectionArgs(classSchema, limit, config);
 
   return `{
   Get {
@@ -1857,8 +2149,9 @@ export function generateDynamicGenerativeSearchQuery(
       nearText: {
         concepts: ${conceptsArr}
         ${thresholdLine}
+${targetVectorsLine ? `        ${targetVectorsLine}` : ''}
       }
-      limit: ${limit}
+      ${collectionArgs}
     ) {
 ${properties.join('\n')}
       _additional {
@@ -1879,6 +2172,39 @@ ${properties.join('\n')}
 }
 
 /**
+ * Schema-aware multi-tenant Get query with property selection.
+ */
+export function generateDynamicTenantQuery(
+  collectionName: string,
+  classSchema?: ClassSchema,
+  tenantName: string = 'YOUR_TENANT_ID',
+  limit: number = 10,
+  config?: QueryConfig
+): string {
+  const cfg: QueryConfig = { ...config, tenantName };
+  const properties = getTopPropertiesForDisplay(classSchema, 5, cfg);
+  const collectionArgs = buildCollectionArgs(classSchema, limit, cfg);
+  const header =
+    config?.includeHeaderComments === false
+      ? ''
+      : buildQueryHeaderComments(collectionName, classSchema, { kind: 'tenant Get' });
+
+  return `{
+${header}  Get {
+    ${collectionName} (
+      ${collectionArgs}
+    ) {
+${properties.join('\n')}
+      _additional {
+        id
+        tenant
+      }
+    }
+  }
+}`;
+}
+
+/**
  * Generate a dynamic groupBy query based on schema
  * @param collectionName The name of the collection
  * @param classSchema The class schema definition
@@ -1886,16 +2212,23 @@ ${properties.join('\n')}
  */
 export function generateDynamicGroupByQuery(
   collectionName: string,
-  classSchema?: ClassSchema
+  classSchema?: ClassSchema,
+  config?: QueryConfig
 ): string {
   const groupByPath =
-    classSchema?.properties?.find((p) => isTextDataType(p.dataType))?.name || 'category';
+    config?.groupByPath ||
+    classSchema?.properties?.find((p) => isTextDataType(p.dataType))?.name ||
+    'category';
+  const tenantRequired = isMultiTenantCollection(classSchema) || Boolean(config?.tenantName);
+  const tenantLine = tenantRequired
+    ? `\n      tenant: "${config?.tenantName?.trim() || 'YOUR_TENANT_ID'}"`
+    : '';
 
   return `{
   Aggregate {
     ${collectionName} (
       groupBy: ["${groupByPath}"]
-      limit: 10
+      limit: 10${tenantLine}
     ) {
       groupedBy {
         value
@@ -1942,21 +2275,32 @@ export function generateDynamicGroupByQuery(
 /**
  * Helper function to get top properties for display
  */
-function getTopPropertiesForDisplay(classSchema?: ClassSchema, maxCount: number = 5): string[] {
+function getTopPropertiesForDisplay(
+  classSchema?: ClassSchema,
+  maxCount: number = 5,
+  config?: QueryConfig
+): string[] {
   if (!classSchema?.properties) {
     return ['      # Add your properties here'];
   }
 
   const result = buildPropertySelections(classSchema, {
     maxCount,
+    schema: config?.fullSchema,
     includeWarning: true,
     maxNestedProps: 3,
     indent: '      ',
+    includeBlobs: config?.includeBlobs === true,
+    maxReferences: 1,
+    maxObjects: 1,
   });
 
-  // Fallback: if classification produced nothing, include bare field names
+  // Fallback: if classification produced nothing, include bare field names (skip blobs)
   if (result.length === 0 && classSchema.properties.length > 0) {
-    return classSchema.properties.slice(0, maxCount).map((prop) => `      ${prop.name}`);
+    return classSchema.properties
+      .filter((p) => classifyProperty(p) !== 'blob')
+      .slice(0, maxCount)
+      .map((prop) => `      ${prop.name}`);
   }
 
   return result.length > 0 ? result : ['      # No properties found in schema'];

--- a/src/query-editor/webview/graphqlTemplates.ts
+++ b/src/query-editor/webview/graphqlTemplates.ts
@@ -646,24 +646,24 @@ export function validateAndSanitizeQuery(query: string): {
       typeName.toLowerCase() === 'blob'
     ) {
       errors.push(
-        `Invalid inline fragment type "${typeName}" — scalar Weaviate types are selected as plain fields, not fragments`
+        `Invalid inline fragment type "${typeName}" - scalar Weaviate types are selected as plain fields, not fragments`
       );
     }
   }
 
   // Empty selection sets (e.g. `prop { }`) are invalid GraphQL
   if (/\{\s*\}/.test(query.replace(/#[^\n]*/g, ''))) {
-    errors.push('Empty selection set `{ }` found — nested fields require at least one selection');
+    errors.push('Empty selection set `{ }` found - nested fields require at least one selection');
   }
 
-  // Soft guidance — do not block the editor from loading the sample
+  // Soft guidance - do not block the editor from loading the sample
   if (/tenant:\s*"YOUR_TENANT_ID"/.test(query)) {
     warnings.push(
-      'Placeholder tenant "YOUR_TENANT_ID" present — replace with a real tenant name before running'
+      'Placeholder tenant "YOUR_TENANT_ID" present - replace with a real tenant name before running'
     );
   }
   if (/vector:\s*\[0\.1,\s*0\.2,\s*0\.3\]/.test(query)) {
-    warnings.push('Placeholder vector [0.1, 0.2, 0.3] present — replace with a real embedding');
+    warnings.push('Placeholder vector [0.1, 0.2, 0.3] present - replace with a real embedding');
   }
 
   // Sanitize by removing potential harmful content (basic implementation)


### PR DESCRIPTION
## Summary
Completes the query-generation backlog after #84:

- **Safer samples**: capped property set, blobs excluded by default, limited cross-refs, header comments explaining exclusions
- **Special types**: `phoneNumber` nested selection; empty nested objects no longer emit invalid `__typename`
- **Multi-tenancy**: auto `tenant: "YOUR_TENANT_ID"` when MT is enabled (warning, not hard error)
- **Named vectors**: `targetVectors` on nearVector / nearText / hybrid when multiple vectors exist
- **Schema plumbing**: `_fetchSchema` / SchemaProvider pass through multiTenancy + named vector keys
- **Validation**: empty selection sets; soft warnings for placeholders
- **Tests & docs**: 72 query-editor tests; GRAPHQL_TEMPLATES.md updated

## Test plan
- [x] `npm test -- src/query-editor --no-coverage` (72 tests)
- [ ] Open Schema-based Sample on a collection with `text[]` + blob — confirm no `... on text[]`, blob excluded with comment
- [ ] Multi-tenant collection sample includes tenant placeholder
- [ ] Multi-vector collection nearVector template includes `targetVectors`
- [ ] Collection with `phoneNumber` expands nested phone fields