### PR TITLE
feat(data-explorer): add query profiling with per-shard timing visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Weaviate Studio extension will be documented in this 
 The format is based on [Keep a Changelog](https://keep.achangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2026-07-31
+
+### ✨ Added
+
+- **Query Profiling in Data Explorer** — Per-query timing breakdowns for vector, keyword, and hybrid searches, powered by Weaviate's query profiling API (server ≥ 1.36.9). Enable the "Profile query" toggle in the Vector Search panel to see per-shard waterfall visualizations: total time, vector search (HNSW layer traversal, rescoring), filter evaluation, object hydration, and BM25 scoring stages. Color-coded bars highlight bottlenecks. Multi-shard collections show per-shard tabs with node attribution. (PR #XX)
+
+### 🔧 Improved
+
+- **Upgraded weaviate-client** from v3.11.0 to v3.14.0 — adds query profiling support (`returnMetadata: ['all', 'queryProfile']`), boost parameter for queries, diversity selection for near-queries, and search cancellation.
+
 ## [1.9.1] - 2026-07-16
 
 ### 🐛 Fixed

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ interface. Supports self-hosted and cloud Weaviate instances.**
 
 - **Multiple Connections:** Manage several Weaviate instances at once
 - **Generative Search:** Ask natural-language questions across one or more collections—configure top-k results per collection, view source-attributed context objects, and get combined LLM answers
-- **Data Explorer:** Interactive visual browser with advanced filtering, 4 vector search modes (text, object, vector, hybrid), and JSON/CSV export
+- **Data Explorer:** Interactive visual browser with advanced filtering, 4 vector search modes (text, object, vector, hybrid), query profiling, and JSON/CSV export
 - **RBAC & Security:** Manage users, roles, and groups with native RBAC support and API key rotation
 - **Read-Only Mode:** Connection-level guards to prevent accidental modifications to production data
 - **Backup & Restore:** Create, monitor, and restore backups across multiple backends (filesystem, S3, GCS, Azure)
@@ -102,6 +102,7 @@ This spins up a fully-configured Weaviate instance with sample jeopardy question
 - Visual filter builder with 10+ operators and AND/OR logic
 - Four vector search modes: Text, Object, Vector, and Hybrid (BM25 + semantic)
 - Alpha slider for balancing keyword vs semantic search
+- **Query profiling** — per-shard timing breakdowns for search optimization (requires Weaviate ≥ 1.36.9)
 - Export to JSON/CSV with flexible scopes (current page, filtered results, or entire collection)
 - Keyboard shortcuts (Ctrl+F, Ctrl+K, Ctrl+E) for power users
 - User preferences persistence per collection

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-json-tree": "^0.20.0",
         "react-json-view-lite": "^2.4.1",
         "weaviate-add-collection": "github:weaviate/weaviate-add-collection",
-        "weaviate-client": "^3.11.0"
+        "weaviate-client": "^3.14.0"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -7487,14 +7487,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -9028,6 +9020,18 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+    },
+    "node_modules/graphql-request": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-7.4.0.tgz",
+      "integrity": "sha512-xfr+zFb/QYbs4l4ty0dltqiXIp07U6sl+tOKAb0t50/EnQek6CVVBLjETXi+FghElytvgaAWtIOt3EV7zLzIAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
+      }
     },
     "node_modules/graphql-ws": {
       "version": "5.12.1",
@@ -14318,15 +14322,16 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -14581,36 +14586,23 @@
       }
     },
     "node_modules/weaviate-client": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/weaviate-client/-/weaviate-client-3.11.0.tgz",
-      "integrity": "sha512-pEO+V8OZ84KUKz9ftQnSuooCT4Fdh3SjkDj6FPfxI3Iy6qc+PTTAMFFO0wL2prnf71DIs0tdNw/1RFX4kJkE/w==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/weaviate-client/-/weaviate-client-3.14.0.tgz",
+      "integrity": "sha512-A6oiawEPpmJBDIHXIr/bDMg7ss6zylwE7KEn5Vl4B52uhX+lU5ddiYSHDtDKXDIyjTR2sDLvZ3S1bOs2AFvVkw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@datastructures-js/deque": "^1.0.8",
         "abort-controller-x": "^0.5.0",
         "graphql": "^16.12.0",
-        "graphql-request": "^6.1.0",
+        "graphql-request": "^7.4.0",
         "long": "^5.3.2",
         "nice-grpc": "^2.1.14",
         "nice-grpc-client-middleware-retry": "^3.1.13",
         "nice-grpc-common": "^2.0.2",
-        "uuid": "^9.0.1"
+        "uuid": "^14.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/weaviate-client/node_modules/graphql-request": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
-      "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.2.0",
-        "cross-fetch": "^3.1.5"
-      },
-      "peerDependencies": {
-        "graphql": "14 - 16"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@types/node": "20.x",
         "@types/react": "^19.1.6",
         "@types/react-dom": "^19.1.6",
-        "@types/vscode": "^1.80.0",
+        "@types/vscode": "^1.101.0",
         "@typescript-eslint/eslint-plugin": "^8.31.1",
         "@typescript-eslint/parser": "^8.31.1",
         "@vscode/codicons": "^0.0.44",
@@ -64,7 +64,7 @@
         "webpack-cli": "^6.0.1"
       },
       "engines": {
-        "vscode": "^1.80.0"
+        "vscode": "^1.101.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -949,6 +949,6 @@
     "react-json-tree": "^0.20.0",
     "react-json-view-lite": "^2.4.1",
     "weaviate-add-collection": "github:weaviate/weaviate-add-collection",
-    "weaviate-client": "^3.11.0"
+    "weaviate-client": "^3.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "query-editor"
   ],
   "engines": {
-    "vscode": "^1.80.0"
+    "vscode": "^1.101.0"
   },
   "categories": [
     "Data Science",
@@ -907,7 +907,7 @@
     "@types/node": "20.x",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.6",
-    "@types/vscode": "^1.80.0",
+    "@types/vscode": "^1.101.0",
     "@typescript-eslint/eslint-plugin": "^8.31.1",
     "@typescript-eslint/parser": "^8.31.1",
     "@vscode/codicons": "^0.0.44",

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -7,6 +7,16 @@ description: Full version history and release notes for Weaviate Studio — new 
 
 All notable changes to the Weaviate Studio extension.
 
+## [1.10.0] - 2026-07-31
+
+### ✨ Added
+
+- **Query Profiling in Data Explorer** — Per-query timing breakdowns for vector, keyword, and hybrid searches, powered by Weaviate's query profiling API (server ≥ 1.36.9). Enable the "Profile query" toggle in the Vector Search panel to see per-shard waterfall visualizations: total time, vector search (HNSW layer traversal, rescoring), filter evaluation, object hydration, and BM25 scoring stages. Color-coded bars highlight bottlenecks. Multi-shard collections show per-shard tabs with node attribution.
+
+### 🔧 Improved
+
+- **Upgraded weaviate-client** from v3.11.0 to v3.14.0 — adds query profiling support, boost parameter, diversity selection, and search cancellation.
+
 ## [1.9.1] - 2026-07-16
 
 ### 🐛 Fixed

--- a/site/features/data-explorer.md
+++ b/site/features/data-explorer.md
@@ -1,6 +1,6 @@
 ---
 title: Data Explorer — Browse & Filter Weaviate Collections in VS Code
-description: Visually browse Weaviate collections, apply advanced filters, run vector and hybrid searches, and export results as JSON or CSV — all from the Weaviate Studio VS Code extension.
+description: Visually browse Weaviate collections, apply advanced filters, run vector and hybrid searches with query profiling, and export results as JSON or CSV — all from the Weaviate Studio VS Code extension.
 ---
 
 # Data Explorer
@@ -13,6 +13,7 @@ The Data Explorer is an interactive visual browser for your Weaviate collections
 - **Visual filter builder** with 10+ operators (Equal, Not Equal, Contains, Greater Than, Less Than, Like, ContainsAny, ContainsAll, IsNull, IsNotNull)
 - **AND/OR logic** for combining multiple filter conditions
 - **Four vector search modes**: Text (semantic), Object (similarity), Vector (raw embeddings), Hybrid (BM25 + vector)
+- **Query profiling** — per-shard timing breakdowns to diagnose slow searches
 - **Data export** to JSON or CSV (current page, filtered results, or entire collection)
 - **Virtual scrolling** for large datasets (1000+ objects)
 - **Filter presets** — save, load, and delete frequently used filter combinations
@@ -39,6 +40,65 @@ Combines BM25 keyword matching with vector semantic search. Features:
 - **Score breakdown** showing keyword, semantic, and combined scores
 - **Property selection** for targeted keyword search
 - **Preset buttons** (Keyword Only, Balanced, Semantic Only)
+
+## Query Profiling
+
+::: tip Requires Weaviate ≥ 1.36.9
+Query profiling uses the same instrumentation as Weaviate's slow query log. The toggle only appears when connected to a compatible server.
+:::
+
+Query profiling returns an inline timing breakdown for each search, showing exactly where time was spent across all shards and nodes. It's designed for debugging and optimization — not for always-on production use.
+
+### Enabling Profiling
+
+1. Open the **Vector Search** panel (`Ctrl+K`)
+2. In **Search Parameters**, check **Profile query**
+3. Run any search (text, object, vector, or hybrid)
+4. The **Query Profile** panel appears below the results
+
+### What You'll See
+
+The profile is organized by **shard**, with tabs for multi-shard collections. Each shard shows:
+
+- **Shard name** and **node** that executed the search
+- **Search type sections** (Vector Search, Keyword/BM25, Object) — only sections that ran are shown
+
+#### Vector Search Metrics
+
+| Metric                      | What it measures                                                |
+| --------------------------- | --------------------------------------------------------------- |
+| **Total**                   | Wall time for the entire shard search                           |
+| **Vector Search**           | Time in the vector index (HNSW graph traversal)                 |
+| **HNSW Layer N**            | Per-layer traversal time (Layer 0 usually dominates)            |
+| **Rescore (decompression)** | Time reading full-precision vectors when compression is enabled |
+| **Filter Allow List**       | Time resolving `where` filters via the inverted index           |
+| **Filter IDs Matched**      | Number of document IDs matched by filters                       |
+| **Object Hydration**        | Time loading final objects from disk                            |
+| **Flat Search**             | `true` when filters were selective enough for brute-force scan  |
+
+#### Keyword / BM25 Metrics
+
+| Metric        | What it measures                                        |
+| ------------- | ------------------------------------------------------- |
+| **Term Time** | Time reading per-term posting lists from inverted index |
+| **BMW Time**  | Time in BlockMax WAND traversal and scoring             |
+
+### Reading the Waterfall
+
+Each timing metric shows a **color-coded bar** proportional to its share of total time:
+
+- 🟢 **Green** — under 33% of total (healthy)
+- 🟡 **Yellow** — 33–66% (worth investigating)
+- 🔴 **Red** — over 66% (likely bottleneck)
+
+### Common Patterns
+
+| Pattern                     | Likely cause                              | Tuning lever                           |
+| --------------------------- | ----------------------------------------- | -------------------------------------- |
+| Object Hydration dominates  | Large objects or high `limit`             | Reduce limit, select fewer properties  |
+| Filter Allow List dominates | Broad filter matching many IDs            | Tighten filter selectivity             |
+| HNSW Layer 0 dominates      | Expensive graph traversal                 | Tune `ef`, check vector dimensionality |
+| Rescore dominates           | Compression enabled, disk-bound rescoring | Check disk I/O, consider RQ over PQ    |
 
 ## Exporting Data
 

--- a/src/data-explorer/README.md
+++ b/src/data-explorer/README.md
@@ -31,6 +31,18 @@ Four search modes to find similar objects:
    - Score breakdown showing keyword, semantic, and combined scores
    - Property selection for targeted search
 
+### Query Profiling
+
+Per-query timing breakdowns for diagnosing slow searches (requires Weaviate ≥ 1.36.9):
+
+- **Enable**: Check "Profile query" in Search Parameters before running a search
+- **Per-shard breakdown**: Each shard shows its node, search type sections, and timing waterfall
+- **Vector search metrics**: Total time, HNSW layer traversal, rescoring, filter evaluation, object hydration
+- **Keyword/BM25 metrics**: Term reading time, BlockMax WAND scoring time
+- **Color-coded bars**: Green (< 33%), yellow (33–66%), red (> 66%) highlight bottlenecks
+- **Multi-shard tabs**: Navigate between shards in multi-shard collections
+- **Non-timing metrics**: Filter match counts, flat-search (brute-force) indicators
+
 ### Export
 
 - **Multiple formats** - JSON or CSV
@@ -86,7 +98,8 @@ Four search modes to find similar objects:
    - **Object**: Click "Find Similar" from any object's action menu
    - **Vector**: Paste an embedding vector (advanced users)
 3. Adjust distance threshold and result limit as needed
-4. Click "Search" to view results with similarity scores
+4. Optionally enable **"Profile query"** to get a timing breakdown (Weaviate ≥ 1.36.9)
+5. Click "Search" to view results with similarity scores
 
 ### Export Data
 
@@ -171,8 +184,8 @@ Four search modes to find similar objects:
 
 ## Requirements
 
-- **Weaviate**: v1.23 or later
-- **Weaviate TypeScript Client**: v3.0 or later
+- **Weaviate**: v1.23 or later (v1.36.9+ for query profiling)
+- **Weaviate TypeScript Client**: v3.14 or later
 - **VS Code**: 1.80 or later
 
 ## Contributing

--- a/src/data-explorer/README.md
+++ b/src/data-explorer/README.md
@@ -186,7 +186,7 @@ Per-query timing breakdowns for diagnosing slow searches (requires Weaviate ≥ 
 
 - **Weaviate**: v1.23 or later (v1.36.9+ for query profiling)
 - **Weaviate TypeScript Client**: v3.14 or later
-- **VS Code**: 1.80 or later
+- **VS Code**: 1.101 or later
 
 ## Contributing
 

--- a/src/data-explorer/extension/DataExplorerAPI.ts
+++ b/src/data-explorer/extension/DataExplorerAPI.ts
@@ -49,6 +49,7 @@ import type {
   PropertyNumericStats,
   PropertyDateRange,
   PropertyBooleanCounts,
+  QueryProfile,
 } from '../types';
 import type {
   WeaviateFilter,
@@ -255,7 +256,12 @@ export class DataExplorerAPI {
       }
 
       // Execute appropriate query based on vector search type
-      const result = await this.executeQuery(collection, baseOptions, params.vectorSearch);
+      const result = await this.executeQuery(
+        collection,
+        baseOptions,
+        params.vectorSearch,
+        params.queryProfile
+      );
 
       // Transform result to our format
       const objects: WeaviateObject[] = result.objects.map(
@@ -359,7 +365,7 @@ export class DataExplorerAPI {
         }
       }
 
-      return { objects, total, unfilteredTotal };
+      return { objects, total, unfilteredTotal, queryProfile: result.queryProfile };
     } catch (error) {
       console.error('Error fetching objects from collection:', {
         collection: params.collectionName,
@@ -430,18 +436,27 @@ export class DataExplorerAPI {
   private async executeQuery(
     collection: Collection,
     options: WeaviateQueryOptions,
-    vectorSearch?: VectorSearchParams
+    vectorSearch?: VectorSearchParams,
+    queryProfile?: boolean
   ): Promise<WeaviateQueryResult> {
     // Determine query mode
     if (!vectorSearch || vectorSearch.type === 'none') {
       // Boolean-only query mode (default)
+      if (queryProfile) {
+        return collection.query.fetchObjects({
+          ...options,
+          returnMetadata: ['all', 'queryProfile'],
+        } as Record<string, unknown>) as unknown as WeaviateQueryResult;
+      }
       return collection.query.fetchObjects(options);
     }
 
     // Build vector search options using Weaviate vector query types
     const vectorOptions: WeaviateVectorQueryOptions = {
       limit: options.limit,
-      returnMetadata: options.returnMetadata,
+      returnMetadata: queryProfile
+        ? (['all', 'queryProfile'] as unknown as WeaviateQueryOptions['returnMetadata'])
+        : options.returnMetadata,
     };
 
     if (options.returnProperties) {
@@ -552,7 +567,9 @@ export class DataExplorerAPI {
       const hybridOptions: WeaviateHybridQueryOptions = {
         ...vectorOptions,
         alpha: vectorSearch.alpha ?? 0.5, // 0 = pure BM25, 1 = pure vector
-        returnMetadata: ['score', 'distance', 'certainty', 'explainScore'],
+        returnMetadata: queryProfile
+          ? (['all', 'queryProfile'] as unknown as WeaviateQueryOptions['returnMetadata'])
+          : ['score', 'distance', 'certainty', 'explainScore'],
       };
 
       // Add fusion type if specified (default: rankedFusion)

--- a/src/data-explorer/extension/DataExplorerPanel.ts
+++ b/src/data-explorer/extension/DataExplorerPanel.ts
@@ -431,6 +431,7 @@ export class DataExplorerPanel {
         where: message.where, // Pass filter conditions to API
         matchMode: message.matchMode, // Pass AND/OR logic to API
         vectorSearch: message.vectorSearch, // Pass vector search params to API
+        queryProfile: message.queryProfile, // Pass query profiling flag to API
       });
 
       this.postMessage({
@@ -438,6 +439,7 @@ export class DataExplorerPanel {
         objects: result.objects,
         total: result.total,
         unfilteredTotal: result.unfilteredTotal,
+        queryProfile: result.queryProfile,
         requestId: message.requestId, // Echo back request ID
       });
     } catch (error) {

--- a/src/data-explorer/extension/__tests__/DataExplorerAPI.vector.test.ts
+++ b/src/data-explorer/extension/__tests__/DataExplorerAPI.vector.test.ts
@@ -1021,4 +1021,158 @@ describe('DataExplorerAPI - Vector Search', () => {
       expect(result.objects[0].metadata?.lastUpdateTime).toBe('2024-01-02T00:00:00.000Z');
     });
   });
+
+  describe('Query Profiling', () => {
+    const mockQueryProfile = {
+      shards: [
+        {
+          name: 'shard-1',
+          node: 'node-0',
+          searches: {
+            vector: {
+              details: {
+                total_took: '48.2ms',
+                vector_search_took: '8.4ms',
+                objects_took: '36.8ms',
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    function enableProfileOnMock() {
+      // Override mock to return queryProfile in the response
+      const createProfiledResult = () =>
+        Promise.resolve({
+          objects: mockObjects,
+          queryProfile: mockQueryProfile,
+        });
+
+      (mockCollection.query.nearText as jest.Mock).mockImplementation((text, options) => {
+        queryMethodCalls.push({ method: 'nearText', args: [text, options] });
+        return createProfiledResult();
+      });
+      (mockCollection.query.nearVector as jest.Mock).mockImplementation((vector, options) => {
+        queryMethodCalls.push({ method: 'nearVector', args: [vector, options] });
+        return createProfiledResult();
+      });
+      (mockCollection.query.nearObject as jest.Mock).mockImplementation((objectId, options) => {
+        queryMethodCalls.push({ method: 'nearObject', args: [objectId, options] });
+        return createProfiledResult();
+      });
+      (mockCollection.query.hybrid as jest.Mock).mockImplementation((text, options) => {
+        queryMethodCalls.push({ method: 'hybrid', args: [text, options] });
+        return createProfiledResult();
+      });
+      (mockCollection.query.fetchObjects as jest.Mock).mockImplementation((options) => {
+        queryMethodCalls.push({ method: 'fetchObjects', args: [options] });
+        return createProfiledResult();
+      });
+    }
+
+    test('nearText passes returnMetadata with queryProfile when enabled', async () => {
+      enableProfileOnMock();
+
+      await api.fetchObjects({
+        collectionName: 'Article',
+        limit: 10,
+        offset: 0,
+        vectorSearch: { type: 'nearText', text: 'test' },
+        queryProfile: true,
+      });
+
+      const call = queryMethodCalls.find((c) => c.method === 'nearText');
+      expect(call).toBeDefined();
+      expect(call!.args[1].returnMetadata).toEqual(['all', 'queryProfile']);
+    });
+
+    test('nearVector passes returnMetadata with queryProfile when enabled', async () => {
+      enableProfileOnMock();
+
+      await api.fetchObjects({
+        collectionName: 'Article',
+        limit: 10,
+        offset: 0,
+        vectorSearch: { type: 'nearVector', vector: [0.1, 0.2, 0.3] },
+        queryProfile: true,
+      });
+
+      const call = queryMethodCalls.find((c) => c.method === 'nearVector');
+      expect(call).toBeDefined();
+      expect(call!.args[1].returnMetadata).toEqual(['all', 'queryProfile']);
+    });
+
+    test('hybrid passes returnMetadata with queryProfile when enabled', async () => {
+      enableProfileOnMock();
+
+      await api.fetchObjects({
+        collectionName: 'Article',
+        limit: 10,
+        offset: 0,
+        vectorSearch: { type: 'hybrid', text: 'test', alpha: 0.5 },
+        queryProfile: true,
+      });
+
+      const call = queryMethodCalls.find((c) => c.method === 'hybrid');
+      expect(call).toBeDefined();
+      expect(call!.args[1].returnMetadata).toEqual(['all', 'queryProfile']);
+    });
+
+    test('fetchObjects (boolean) passes returnMetadata with queryProfile when enabled', async () => {
+      enableProfileOnMock();
+
+      await api.fetchObjects({
+        collectionName: 'Article',
+        limit: 10,
+        offset: 0,
+        queryProfile: true,
+      });
+
+      const call = queryMethodCalls.find((c) => c.method === 'fetchObjects');
+      expect(call).toBeDefined();
+      expect(call!.args[0].returnMetadata).toEqual(['all', 'queryProfile']);
+    });
+
+    test('queryProfile is extracted from response and returned', async () => {
+      enableProfileOnMock();
+
+      const result = await api.fetchObjects({
+        collectionName: 'Article',
+        limit: 10,
+        offset: 0,
+        vectorSearch: { type: 'nearText', text: 'test' },
+        queryProfile: true,
+      });
+
+      expect(result.queryProfile).toEqual(mockQueryProfile);
+      expect(result.queryProfile!.shards).toHaveLength(1);
+      expect(result.queryProfile!.shards[0].searches.vector).toBeDefined();
+    });
+
+    test('queryProfile is undefined when not requested', async () => {
+      const result = await api.fetchObjects({
+        collectionName: 'Article',
+        limit: 10,
+        offset: 0,
+        vectorSearch: { type: 'nearText', text: 'test' },
+      });
+
+      expect(result.queryProfile).toBeUndefined();
+    });
+
+    test('returnMetadata does not include queryProfile when disabled', async () => {
+      await api.fetchObjects({
+        collectionName: 'Article',
+        limit: 10,
+        offset: 0,
+        vectorSearch: { type: 'nearText', text: 'test' },
+        queryProfile: false,
+      });
+
+      const call = queryMethodCalls.find((c) => c.method === 'nearText');
+      expect(call).toBeDefined();
+      expect(call!.args[1].returnMetadata).not.toEqual(['all', 'queryProfile']);
+    });
+  });
 });

--- a/src/data-explorer/types/index.ts
+++ b/src/data-explorer/types/index.ts
@@ -196,6 +196,24 @@ export interface FilterCondition {
 // Filter match mode for combining filters
 export type FilterMatchMode = 'AND' | 'OR';
 
+// =====================================================
+// Query Profiling Types (Weaviate ≥ 1.36.9)
+// =====================================================
+
+export interface SearchProfile {
+  details: Record<string, string>;
+}
+
+export interface ShardProfile {
+  name: string;
+  node: string;
+  searches: Record<string, SearchProfile>;
+}
+
+export interface QueryProfile {
+  shards: ShardProfile[];
+}
+
 // Vector search types for Phase 3
 export type VectorSearchType = 'none' | 'nearText' | 'nearVector' | 'nearObject' | 'hybrid';
 
@@ -249,6 +267,7 @@ export interface FetchObjectsParams {
   where?: FilterCondition[]; // Phase 2: Filter support
   matchMode?: FilterMatchMode; // Phase 2: AND/OR logic
   vectorSearch?: VectorSearchParams; // Phase 3: Vector search support
+  queryProfile?: boolean; // Query profiling (Weaviate ≥ 1.36.9)
 }
 
 // Fetch response type
@@ -256,6 +275,7 @@ export interface FetchObjectsResponse {
   objects: WeaviateObject[];
   total: number;
   unfilteredTotal?: number; // Total count without filters (only set when filters are active)
+  queryProfile?: QueryProfile; // Query profiling data (when requested)
 }
 
 // Message types for extension <-> webview communication
@@ -315,6 +335,8 @@ export interface ExtensionMessage {
   isMultiTenant?: boolean;
   // Server metadata
   serverVersion?: string;
+  // Query profiling
+  queryProfile?: QueryProfile;
   // Phase 5: Aggregations and Export
   aggregations?: AggregationResult;
   exportResult?: ExportResult;
@@ -341,6 +363,8 @@ export interface WebviewMessage {
   requestId?: string; // For tracking and cancelling requests
   // Multi-tenancy
   tenant?: string;
+  // Query profiling
+  queryProfile?: boolean;
   // Phase 5: Aggregations and Export
   aggregationParams?: AggregationParams;
   exportParams?: ExportParams;

--- a/src/data-explorer/types/weaviate.ts
+++ b/src/data-explorer/types/weaviate.ts
@@ -19,9 +19,20 @@ export type WeaviateMetadataField =
   | 'explainScore';
 
 /**
+ * Extended metadata selection that includes query profiling
+ * 'queryProfile' must be explicitly requested and is not included in 'all'
+ */
+export type WeaviateMetadataSelection = WeaviateMetadataField | 'all' | 'queryProfile';
+
+/**
  * Array of metadata fields to return in query results
  */
 export type WeaviateQueryMetadata = WeaviateMetadataField[];
+
+/**
+ * Extended metadata array that supports query profiling
+ */
+export type WeaviateExtendedQueryMetadata = WeaviateMetadataSelection[];
 
 /**
  * Weaviate filter object
@@ -124,6 +135,7 @@ export interface WeaviateRawObject {
  */
 export interface WeaviateQueryResult {
   objects: WeaviateRawObject[];
+  queryProfile?: import('../types').QueryProfile;
 }
 
 /**

--- a/src/data-explorer/webview/components/VectorSearch/QueryProfilePanel.css
+++ b/src/data-explorer/webview/components/VectorSearch/QueryProfilePanel.css
@@ -1,0 +1,282 @@
+/* QueryProfilePanel - Query profiling visualization styles */
+
+.qp-panel {
+  border: 1px solid var(--vscode-panel-border, #444);
+  border-radius: 4px;
+  margin-top: 12px;
+  overflow: hidden;
+  background: var(--vscode-editor-background, #1e1e1e);
+}
+
+.qp-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: var(--vscode-sideBar-background, #252526);
+  border-bottom: 1px solid var(--vscode-panel-border, #444);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--vscode-foreground, #ccc);
+}
+
+.qp-panel-header .codicon {
+  color: var(--vscode-charts-green, #89d185);
+  font-size: 14px;
+}
+
+.qp-panel-title {
+  flex: 1;
+}
+
+/* Shard tabs */
+.qp-shard-tabs {
+  display: flex;
+  gap: 2px;
+}
+
+.qp-shard-tab {
+  background: transparent;
+  border: 1px solid var(--vscode-panel-border, #555);
+  border-radius: 3px;
+  color: var(--vscode-foreground, #ccc);
+  cursor: pointer;
+  font-size: 10px;
+  min-width: 20px;
+  padding: 1px 5px;
+  text-align: center;
+}
+
+.qp-shard-tab:hover {
+  background: var(--vscode-toolbar-hoverBackground, rgba(255, 255, 255, 0.1));
+}
+
+.qp-shard-tab.active {
+  background: var(--vscode-button-background, #0e639c);
+  border-color: var(--vscode-button-background, #0e639c);
+  color: var(--vscode-button-foreground, #fff);
+}
+
+/* Shard card */
+.qp-shard-card {
+  padding: 0;
+}
+
+.qp-shard-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground, #999);
+  border-bottom: 1px solid var(--vscode-panel-border, #333);
+}
+
+.qp-shard-header .codicon {
+  font-size: 12px;
+  margin-right: 3px;
+  vertical-align: -1px;
+}
+
+.qp-shard-name {
+  font-family: var(--vscode-editor-font-family, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.qp-shard-node {
+  margin-left: auto;
+}
+
+/* Search type sections */
+.qp-search-section {
+  border-bottom: 1px solid var(--vscode-panel-border, #333);
+}
+
+.qp-search-section:last-child {
+  border-bottom: none;
+}
+
+.qp-section-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 10px;
+  background: transparent;
+  border: none;
+  color: var(--vscode-foreground, #ccc);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+}
+
+.qp-section-header:hover {
+  background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.05));
+}
+
+.qp-section-header .codicon-chevron-down,
+.qp-section-header .codicon-chevron-right {
+  font-size: 12px;
+}
+
+.qp-section-label {
+  flex: 1;
+}
+
+.qp-section-total {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--vscode-descriptionForeground, #999);
+}
+
+.qp-section-body {
+  padding: 2px 0 8px;
+}
+
+/* Metric rows */
+.qp-metric-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 12px;
+  font-size: 11px;
+  min-height: 20px;
+}
+
+.qp-metric-row:hover {
+  background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.03));
+}
+
+.qp-metric-info {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 200px;
+  flex-shrink: 0;
+}
+
+.qp-metric-label {
+  color: var(--vscode-foreground, #ccc);
+  white-space: nowrap;
+}
+
+.qp-metric-value {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground, #aaa);
+  margin-left: 8px;
+  white-space: nowrap;
+}
+
+.qp-metric-static {
+  justify-content: space-between;
+}
+
+.qp-metric-static .qp-metric-label {
+  flex: 1;
+}
+
+/* Timing bar */
+.qp-metric-bar-track {
+  flex: 1;
+  height: 6px;
+  background: var(--vscode-editorWidget-background, #2a2a2a);
+  border-radius: 3px;
+  overflow: hidden;
+  min-width: 40px;
+}
+
+.qp-metric-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.qp-metric-bar-fill.bar-low {
+  background: var(--vscode-charts-green, #89d185);
+}
+
+.qp-metric-bar-fill.bar-medium {
+  background: var(--vscode-charts-yellow, #cca700);
+}
+
+.qp-metric-bar-fill.bar-high {
+  background: var(--vscode-charts-red, #f14c4c);
+}
+
+.qp-metric-pct {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 10px;
+  color: var(--vscode-descriptionForeground, #888);
+  min-width: 40px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* Badges for boolean values */
+.qp-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 0 6px;
+  border-radius: 3px;
+  text-transform: uppercase;
+}
+
+.qp-badge-ok {
+  background: rgba(137, 209, 133, 0.15);
+  color: var(--vscode-charts-green, #89d185);
+}
+
+.qp-badge-warn {
+  background: rgba(204, 167, 0, 0.15);
+  color: var(--vscode-charts-yellow, #cca700);
+}
+
+/* Empty state */
+.qp-empty {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  color: var(--vscode-descriptionForeground, #999);
+  font-size: 12px;
+  justify-content: center;
+}
+
+/* Profiling toggle in search parameters */
+.qp-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.qp-toggle-row input[type='checkbox'] {
+  accent-color: var(--vscode-button-background, #0e639c);
+}
+
+.qp-toggle-row label {
+  font-size: 11px;
+  color: var(--vscode-foreground, #ccc);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.qp-toggle-row .codicon {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground, #999);
+}
+
+.qp-toggle-hint {
+  font-size: 10px;
+  color: var(--vscode-descriptionForeground, #888);
+  margin-left: auto;
+}

--- a/src/data-explorer/webview/components/VectorSearch/QueryProfilePanel.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/QueryProfilePanel.tsx
@@ -1,0 +1,362 @@
+/**
+ * QueryProfilePanel - Visualizes query profiling data from Weaviate
+ * Shows per-shard timing breakdowns for vector, keyword, and object searches
+ * Requires Weaviate ≥ 1.36.9
+ */
+
+import React, { useState, useMemo } from 'react';
+import type { QueryProfile, ShardProfile, SearchProfile } from '../../../types';
+import './QueryProfilePanel.css';
+
+interface QueryProfilePanelProps {
+  profile: QueryProfile;
+}
+
+/** Parse a duration string like "48.2ms", "1.2s", "350µs" into milliseconds */
+export function parseDuration(value: string): number | null {
+  const match = value.match(/^([\d.]+)\s*(ms|s|µs|us|ns)$/);
+  if (!match) {
+    return null;
+  }
+  const num = parseFloat(match[1]);
+  if (isNaN(num)) {
+    return null;
+  }
+  switch (match[2]) {
+    case 's':
+      return num * 1000;
+    case 'ms':
+      return num;
+    case 'µs':
+    case 'us':
+      return num / 1000;
+    case 'ns':
+      return num / 1_000_000;
+    default:
+      return null;
+  }
+}
+
+/** Format milliseconds into a human-readable duration string */
+function formatMs(ms: number): string {
+  if (ms >= 1000) {
+    return `${(ms / 1000).toFixed(2)}s`;
+  }
+  if (ms >= 1) {
+    return `${ms.toFixed(1)}ms`;
+  }
+  if (ms >= 0.001) {
+    return `${(ms * 1000).toFixed(0)}µs`;
+  }
+  return `${(ms * 1_000_000).toFixed(0)}ns`;
+}
+
+/** Determine bar color based on proportion of total time */
+function getBarColorClass(proportion: number): string {
+  if (proportion > 0.66) {
+    return 'bar-high';
+  }
+  if (proportion > 0.33) {
+    return 'bar-medium';
+  }
+  return 'bar-low';
+}
+
+/** Known timing metric keys that should be rendered as bars */
+const TIMING_METRIC_KEYS = [
+  'total_took',
+  'vector_search_took',
+  'objects_took',
+  'filters_build_allow_list_took',
+  'knn_search_rescore_took',
+];
+
+/** Pattern for HNSW layer timing keys */
+const KNN_LAYER_PATTERN = /^knn_search_layer_(\d+)_took$/;
+
+/** Pattern for keyword timing keys */
+const KWD_PATTERN = /^kwd_/;
+
+interface MetricEntry {
+  key: string;
+  label: string;
+  rawValue: string;
+  ms: number | null;
+  isTiming: boolean;
+  indent: number;
+}
+
+/** Build a structured list of metrics from a search profile's details */
+function buildMetricEntries(details: Record<string, string>): MetricEntry[] {
+  const entries: MetricEntry[] = [];
+  const totalMs = parseDuration(details['total_took'] || '') ?? 0;
+
+  // Top-level timing metrics
+  for (const key of TIMING_METRIC_KEYS) {
+    if (details[key] === undefined) {
+      continue;
+    }
+    const ms = parseDuration(details[key]);
+    entries.push({
+      key,
+      label: formatMetricLabel(key),
+      rawValue: details[key],
+      ms,
+      isTiming: true,
+      indent: key === 'total_took' ? 0 : 1,
+    });
+  }
+
+  // HNSW layer metrics (nested under vector_search_took)
+  const layerKeys = Object.keys(details)
+    .filter((k) => KNN_LAYER_PATTERN.test(k))
+    .sort((a, b) => {
+      const layerA = parseInt(a.match(KNN_LAYER_PATTERN)![1], 10);
+      const layerB = parseInt(b.match(KNN_LAYER_PATTERN)![1], 10);
+      return layerA - layerB;
+    });
+
+  for (const key of layerKeys) {
+    const ms = parseDuration(details[key]);
+    entries.push({
+      key,
+      label: formatMetricLabel(key),
+      rawValue: details[key],
+      ms,
+      isTiming: true,
+      indent: 2,
+    });
+  }
+
+  // Keyword/BM25 metrics
+  const kwdKeys = Object.keys(details)
+    .filter((k) => KWD_PATTERN.test(k))
+    .sort();
+
+  for (const key of kwdKeys) {
+    const ms = parseDuration(details[key]);
+    entries.push({
+      key,
+      label: formatMetricLabel(key),
+      rawValue: details[key],
+      ms,
+      isTiming: ms !== null,
+      indent: 1,
+    });
+  }
+
+  // Non-timing metrics (counts, booleans)
+  const nonTimingKeys = Object.keys(details).filter(
+    (k) => !TIMING_METRIC_KEYS.includes(k) && !KNN_LAYER_PATTERN.test(k) && !KWD_PATTERN.test(k)
+  );
+
+  for (const key of nonTimingKeys) {
+    entries.push({
+      key,
+      label: formatMetricLabel(key),
+      rawValue: details[key],
+      ms: null,
+      isTiming: false,
+      indent: 1,
+    });
+  }
+
+  return entries;
+}
+
+/** Convert snake_case metric key to a readable label */
+function formatMetricLabel(key: string): string {
+  // Special cases
+  const specialLabels: Record<string, string> = {
+    total_took: 'Total',
+    vector_search_took: 'Vector Search',
+    objects_took: 'Object Hydration',
+    filters_build_allow_list_took: 'Filter Allow List',
+    filters_ids_matched: 'Filter IDs Matched',
+    knn_search_rescore_took: 'Rescore (decompression)',
+    hnsw_flat_search: 'Flat Search (brute-force)',
+  };
+
+  if (specialLabels[key]) {
+    return specialLabels[key];
+  }
+
+  // HNSW layer keys
+  const layerMatch = key.match(KNN_LAYER_PATTERN);
+  if (layerMatch) {
+    return `HNSW Layer ${layerMatch[1]}`;
+  }
+
+  // Generic: replace underscores with spaces, title-case
+  return key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Render a single shard's profile */
+function ShardProfileCard({ shard }: { shard: ShardProfile }) {
+  const searchTypes = Object.keys(shard.searches);
+
+  return (
+    <div className="qp-shard-card">
+      <div className="qp-shard-header">
+        <span className="qp-shard-name" title={shard.name}>
+          <span className="codicon codicon-database" aria-hidden="true"></span>
+          {shard.name.length > 16 ? `${shard.name.slice(0, 16)}…` : shard.name}
+        </span>
+        <span className="qp-shard-node">
+          <span className="codicon codicon-server" aria-hidden="true"></span>
+          {shard.node}
+        </span>
+      </div>
+
+      {searchTypes.map((searchType) => (
+        <SearchTypeSection
+          key={searchType}
+          searchType={searchType}
+          profile={shard.searches[searchType]}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Render a collapsible section for a search type (vector, keyword, object) */
+function SearchTypeSection({
+  searchType,
+  profile,
+}: {
+  searchType: string;
+  profile: SearchProfile;
+}) {
+  const [expanded, setExpanded] = useState(true);
+
+  const entries = useMemo(() => buildMetricEntries(profile.details), [profile.details]);
+  const totalMs = parseDuration(profile.details['total_took'] || '') ?? 0;
+
+  const icon =
+    searchType === 'vector'
+      ? 'symbol-variable'
+      : searchType === 'keyword'
+        ? 'symbol-keyword'
+        : 'symbol-object';
+  const label =
+    searchType === 'vector'
+      ? 'Vector Search'
+      : searchType === 'keyword'
+        ? 'Keyword / BM25'
+        : searchType.charAt(0).toUpperCase() + searchType.slice(1);
+
+  return (
+    <div className="qp-search-section">
+      <button
+        className="qp-section-header"
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+      >
+        <span
+          className={`codicon codicon-chevron-${expanded ? 'down' : 'right'}`}
+          aria-hidden="true"
+        ></span>
+        <span className={`codicon codicon-${icon}`} aria-hidden="true"></span>
+        <span className="qp-section-label">{label}</span>
+        {totalMs > 0 && <span className="qp-section-total">{formatMs(totalMs)}</span>}
+      </button>
+
+      {expanded && (
+        <div className="qp-section-body">
+          {entries.map((entry) => (
+            <MetricRow key={entry.key} entry={entry} totalMs={totalMs} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Render a single metric row with optional timing bar */
+function MetricRow({ entry, totalMs }: { entry: MetricEntry; totalMs: number }) {
+  const indentStyle = { paddingLeft: `${entry.indent * 16 + 8}px` };
+
+  if (!entry.isTiming || entry.ms === null) {
+    // Non-timing metric: show as label + value
+    const isBoolean = entry.rawValue === 'true' || entry.rawValue === 'false';
+    return (
+      <div className="qp-metric-row qp-metric-static" style={indentStyle}>
+        <span className="qp-metric-label">{entry.label}</span>
+        {isBoolean ? (
+          <span
+            className={`qp-badge ${entry.rawValue === 'true' ? 'qp-badge-warn' : 'qp-badge-ok'}`}
+          >
+            {entry.rawValue}
+          </span>
+        ) : (
+          <span className="qp-metric-value">{entry.rawValue}</span>
+        )}
+      </div>
+    );
+  }
+
+  // Timing metric: show bar
+  const proportion = totalMs > 0 ? entry.ms / totalMs : 0;
+  const barWidth = Math.max(2, Math.min(100, proportion * 100));
+  const colorClass = getBarColorClass(proportion);
+
+  return (
+    <div className="qp-metric-row" style={indentStyle}>
+      <div className="qp-metric-info">
+        <span className="qp-metric-label">{entry.label}</span>
+        <span className="qp-metric-value">{entry.rawValue}</span>
+      </div>
+      <div className="qp-metric-bar-track">
+        <div
+          className={`qp-metric-bar-fill ${colorClass}`}
+          style={{ width: `${barWidth}%` }}
+          title={`${(proportion * 100).toFixed(1)}% of total`}
+        />
+      </div>
+      <span className="qp-metric-pct">{(proportion * 100).toFixed(1)}%</span>
+    </div>
+  );
+}
+
+/** Main panel component */
+export function QueryProfilePanel({ profile }: QueryProfilePanelProps) {
+  const [activeShard, setActiveShard] = useState(0);
+
+  if (!profile.shards || profile.shards.length === 0) {
+    return (
+      <div className="qp-panel">
+        <div className="qp-empty">
+          <span className="codicon codicon-info" aria-hidden="true"></span>
+          No profiling data returned for this query.
+        </div>
+      </div>
+    );
+  }
+
+  const shard = profile.shards[Math.min(activeShard, profile.shards.length - 1)];
+
+  return (
+    <div className="qp-panel">
+      <div className="qp-panel-header">
+        <span className="codicon codicon-pulse" aria-hidden="true"></span>
+        <span className="qp-panel-title">Query Profile</span>
+        {profile.shards.length > 1 && (
+          <div className="qp-shard-tabs">
+            {profile.shards.map((s, i) => (
+              <button
+                key={s.name}
+                className={`qp-shard-tab ${i === activeShard ? 'active' : ''}`}
+                onClick={() => setActiveShard(i)}
+                title={`Shard: ${s.name} | Node: ${s.node}`}
+              >
+                {i + 1}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <ShardProfileCard shard={shard} />
+    </div>
+  );
+}

--- a/src/data-explorer/webview/components/VectorSearch/VectorSearchPanel.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/VectorSearchPanel.tsx
@@ -25,8 +25,13 @@ import { HybridSearchInput } from './HybridSearchInput';
 import { SearchResults } from './SearchResults';
 import { VectorOptionsDrawer } from './VectorOptionsDrawer';
 import { CopyAsCode } from './CopyAsCode';
+import { QueryProfilePanel } from './QueryProfilePanel';
 import { useNamedVectors } from '../../hooks/useNamedVectors';
-import { supportsMultiTargetNear, supportsMultiTargetHybrid } from '../../utils/versionCheck';
+import {
+  supportsMultiTargetNear,
+  supportsMultiTargetHybrid,
+  supportsQueryProfiling,
+} from '../../utils/versionCheck';
 import { validateMultiTargetConfig } from '../../utils/multiTargetBuilder';
 
 interface VectorSearchPanelProps {
@@ -59,6 +64,8 @@ export function VectorSearchPanel({
     selectedTargetVectors,
     joinStrategy,
     vectorWeights,
+    queryProfileEnabled,
+    queryProfileResult,
   } = state;
 
   // Get named vectors from schema
@@ -77,6 +84,15 @@ export function VectorSearchPanel({
     // For text, object, vector modes
     return supportsMultiTargetNear(serverVersion);
   }, [dataState.serverVersion, searchMode]);
+
+  // Check if query profiling is supported by the server
+  const queryProfilingSupported = useMemo(() => {
+    const serverVersion = dataState.serverVersion;
+    if (!serverVersion) {
+      return false;
+    }
+    return supportsQueryProfiling(serverVersion);
+  }, [dataState.serverVersion]);
 
   // Handle keyboard escape to close panel (only add listener when open)
   useEffect(() => {
@@ -545,6 +561,26 @@ export function VectorSearchPanel({
                   ))}
                 </select>
               </div>
+
+              {/* Query Profiling Toggle */}
+              {queryProfilingSupported && (
+                <div className="parameter-item">
+                  <div className="qp-toggle-row">
+                    <input
+                      type="checkbox"
+                      id="query-profile-toggle"
+                      checked={queryProfileEnabled}
+                      onChange={(e) => actions.setQueryProfileEnabled(e.target.checked)}
+                      disabled={isSearching}
+                    />
+                    <label htmlFor="query-profile-toggle">
+                      <span className="codicon codicon-pulse" aria-hidden="true"></span>
+                      Profile query
+                    </label>
+                    <span className="qp-toggle-hint">timing breakdown</span>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
 
@@ -612,6 +648,11 @@ export function VectorSearchPanel({
               hasSearched={hasSearched}
             />
           </div>
+
+          {/* Query Profile Results */}
+          {queryProfileEnabled && queryProfileResult && (
+            <QueryProfilePanel profile={queryProfileResult} />
+          )}
         </div>
       </div>
     </div>

--- a/src/data-explorer/webview/components/VectorSearch/__tests__/QueryProfilePanel.test.tsx
+++ b/src/data-explorer/webview/components/VectorSearch/__tests__/QueryProfilePanel.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryProfilePanel, parseDuration } from '../QueryProfilePanel';
+import type { QueryProfile } from '../../../../types';
+
+/**
+ * Test suite for QueryProfilePanel
+ *
+ * Tests cover:
+ * - Duration string parsing (ms, s, µs, ns)
+ * - Rendering with sample profile data
+ * - Shard tab navigation
+ * - Search type sections (vector, keyword, object)
+ * - Timing bar proportions
+ * - Non-timing metrics (counts, booleans)
+ * - Empty state
+ */
+
+describe('parseDuration', () => {
+  test('parses milliseconds', () => {
+    expect(parseDuration('48.2ms')).toBeCloseTo(48.2);
+    expect(parseDuration('0.3ms')).toBeCloseTo(0.3);
+    expect(parseDuration('100ms')).toBe(100);
+  });
+
+  test('parses seconds', () => {
+    expect(parseDuration('1.2s')).toBeCloseTo(1200);
+    expect(parseDuration('0.5s')).toBeCloseTo(500);
+  });
+
+  test('parses microseconds', () => {
+    expect(parseDuration('350µs')).toBeCloseTo(0.35);
+    expect(parseDuration('350us')).toBeCloseTo(0.35);
+  });
+
+  test('parses nanoseconds', () => {
+    expect(parseDuration('1500ns')).toBeCloseTo(0.0015);
+  });
+
+  test('returns null for non-duration strings', () => {
+    expect(parseDuration('512')).toBeNull();
+    expect(parseDuration('false')).toBeNull();
+    expect(parseDuration('')).toBeNull();
+    expect(parseDuration('abc')).toBeNull();
+  });
+
+  test('returns null for invalid numbers', () => {
+    expect(parseDuration('NaNms')).toBeNull();
+  });
+});
+
+const sampleProfile: QueryProfile = {
+  shards: [
+    {
+      name: '1a2b3c4dshard',
+      node: 'weaviate-0',
+      searches: {
+        vector: {
+          details: {
+            total_took: '48.2ms',
+            filters_build_allow_list_took: '2.1ms',
+            filters_ids_matched: '512',
+            vector_search_took: '8.4ms',
+            knn_search_layer_0_took: '7.9ms',
+            knn_search_rescore_took: '0.3ms',
+            hnsw_flat_search: 'false',
+            objects_took: '36.8ms',
+          },
+        },
+      },
+    },
+  ],
+};
+
+const hybridProfile: QueryProfile = {
+  shards: [
+    {
+      name: 'shard-a',
+      node: 'node-1',
+      searches: {
+        vector: {
+          details: {
+            total_took: '30ms',
+            vector_search_took: '20ms',
+            knn_search_layer_0_took: '18ms',
+            objects_took: '8ms',
+          },
+        },
+        keyword: {
+          details: {
+            total_took: '15ms',
+            kwd_3_term_time: '5ms',
+            kwd_4_bmw_time: '8ms',
+          },
+        },
+      },
+    },
+  ],
+};
+
+const multiShardProfile: QueryProfile = {
+  shards: [
+    {
+      name: 'shard-1',
+      node: 'node-0',
+      searches: {
+        object: {
+          details: { total_took: '5ms' },
+        },
+      },
+    },
+    {
+      name: 'shard-2',
+      node: 'node-1',
+      searches: {
+        object: {
+          details: { total_took: '3ms' },
+        },
+      },
+    },
+  ],
+};
+
+describe('QueryProfilePanel', () => {
+  test('renders empty state for no shards', () => {
+    render(<QueryProfilePanel profile={{ shards: [] }} />);
+    expect(screen.getByText(/no profiling data/i)).toBeTruthy();
+  });
+
+  test('renders vector search profile with timing bars', () => {
+    render(<QueryProfilePanel profile={sampleProfile} />);
+
+    // Panel header
+    expect(screen.getByText('Query Profile')).toBeTruthy();
+
+    // Shard info
+    expect(screen.getByText(/1a2b3c4dshard/)).toBeTruthy();
+    expect(screen.getByText('weaviate-0')).toBeTruthy();
+
+    // Search type section
+    const sectionLabels = screen.getAllByText('Vector Search');
+    expect(sectionLabels.length).toBeGreaterThanOrEqual(1);
+
+    // Timing metrics (may appear in both section header and metric row)
+    expect(screen.getAllByText('Total').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('48.2ms').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Object Hydration')).toBeTruthy();
+    expect(screen.getAllByText('36.8ms').length).toBeGreaterThanOrEqual(1);
+
+    // Non-timing metric
+    expect(screen.getByText('Filter IDs Matched')).toBeTruthy();
+    expect(screen.getByText('512')).toBeTruthy();
+
+    // Boolean badge
+    expect(screen.getByText('false')).toBeTruthy();
+  });
+
+  test('renders hybrid profile with both vector and keyword sections', () => {
+    render(<QueryProfilePanel profile={hybridProfile} />);
+
+    expect(screen.getAllByText('Vector Search').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Keyword / BM25')).toBeTruthy();
+  });
+
+  test('renders shard tabs for multi-shard profiles', () => {
+    render(<QueryProfilePanel profile={multiShardProfile} />);
+
+    // Two shard tabs
+    const tabs = screen
+      .getAllByRole('button')
+      .filter((el) => el.className.includes('qp-shard-tab'));
+    expect(tabs.length).toBe(2);
+
+    // First shard shown by default
+    expect(screen.getByText('shard-1')).toBeTruthy();
+
+    // Click second tab
+    fireEvent.click(tabs[1]);
+    expect(screen.getByText('shard-2')).toBeTruthy();
+  });
+
+  test('collapses and expands search type sections', () => {
+    render(<QueryProfilePanel profile={sampleProfile} />);
+
+    // Section is expanded by default - metrics visible
+    expect(screen.getAllByText('Total').length).toBeGreaterThanOrEqual(1);
+
+    // Click section header to collapse
+    const sectionHeaders = screen.getAllByText('Vector Search');
+    const sectionHeader = sectionHeaders[0].closest('button');
+    expect(sectionHeader).toBeTruthy();
+    fireEvent.click(sectionHeader!);
+
+    // Metrics should be hidden after collapse
+    expect(screen.queryByText('Object Hydration')).toBeNull();
+  });
+
+  test('shows HNSW layer metrics', () => {
+    render(<QueryProfilePanel profile={sampleProfile} />);
+    expect(screen.getByText('HNSW Layer 0')).toBeTruthy();
+    expect(screen.getByText('7.9ms')).toBeTruthy();
+  });
+
+  test('shows rescore metric when compression is enabled', () => {
+    render(<QueryProfilePanel profile={sampleProfile} />);
+    expect(screen.getByText('Rescore (decompression)')).toBeTruthy();
+    expect(screen.getByText('0.3ms')).toBeTruthy();
+  });
+});

--- a/src/data-explorer/webview/components/VectorSearch/index.ts
+++ b/src/data-explorer/webview/components/VectorSearch/index.ts
@@ -25,3 +25,6 @@ export { JoinStrategySelector } from './JoinStrategySelector';
 export { WeightEditor } from './WeightEditor';
 export { MuveraBadge } from './MuveraBadge';
 export { CopyAsCode } from './CopyAsCode';
+
+// Query Profiling Components
+export { QueryProfilePanel } from './QueryProfilePanel';

--- a/src/data-explorer/webview/context/VectorSearchContext.tsx
+++ b/src/data-explorer/webview/context/VectorSearchContext.tsx
@@ -216,8 +216,6 @@ function vectorSearchReducer(
         isSearching: false,
         searchError: null,
         hasSearched: true,
-        // Clear stale profile result when new results arrive
-        // (profile result is set separately via SET_QUERY_PROFILE_RESULT)
       };
 
     case 'SET_SEARCHING':
@@ -225,6 +223,8 @@ function vectorSearchReducer(
         ...state,
         isSearching: action.isSearching,
         searchError: action.isSearching ? null : state.searchError,
+        // Clear stale profile when a new search begins
+        queryProfileResult: action.isSearching ? null : state.queryProfileResult,
       };
 
     case 'SET_SEARCH_ERROR':
@@ -232,6 +232,8 @@ function vectorSearchReducer(
         ...state,
         searchError: action.error,
         isSearching: false,
+        // A failed query must not display a previous query's profile
+        queryProfileResult: null,
       };
 
     case 'CLEAR_SEARCH':

--- a/src/data-explorer/webview/context/VectorSearchContext.tsx
+++ b/src/data-explorer/webview/context/VectorSearchContext.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { createContext, useContext, useReducer, useMemo, useCallback } from 'react';
-import type { WeaviateObject, JoinStrategy } from '../../types';
+import type { WeaviateObject, JoinStrategy, QueryProfile } from '../../types';
 
 // ============================================================================
 // Types
@@ -76,6 +76,9 @@ export interface VectorSearchContextState {
   vectorWeights: Record<string, number>;
   multiTargetActive: boolean;
   muveraFlagsByVector: Record<string, boolean>;
+  // Query profiling state
+  queryProfileEnabled: boolean;
+  queryProfileResult: QueryProfile | null;
 }
 
 // ============================================================================
@@ -100,7 +103,10 @@ type VectorSearchAction =
   | { type: 'SET_JOIN_STRATEGY'; strategy: JoinStrategy }
   | { type: 'SET_VECTOR_WEIGHT'; vectorName: string; weight: number }
   | { type: 'NORMALIZE_WEIGHTS' }
-  | { type: 'SET_MUVERA_FLAGS'; flags: Record<string, boolean> };
+  | { type: 'SET_MUVERA_FLAGS'; flags: Record<string, boolean> }
+  // Query profiling actions
+  | { type: 'SET_QUERY_PROFILE_ENABLED'; enabled: boolean }
+  | { type: 'SET_QUERY_PROFILE_RESULT'; result: QueryProfile | null };
 
 // ============================================================================
 // Initial State
@@ -139,6 +145,9 @@ const initialState: VectorSearchContextState = {
   vectorWeights: {},
   multiTargetActive: false,
   muveraFlagsByVector: {},
+  // Query profiling state
+  queryProfileEnabled: false,
+  queryProfileResult: null,
 };
 
 // ============================================================================
@@ -207,6 +216,8 @@ function vectorSearchReducer(
         isSearching: false,
         searchError: null,
         hasSearched: true,
+        // Clear stale profile result when new results arrive
+        // (profile result is set separately via SET_QUERY_PROFILE_RESULT)
       };
 
     case 'SET_SEARCHING':
@@ -231,6 +242,7 @@ function vectorSearchReducer(
         searchError: null,
         isSearching: false,
         hasSearched: false,
+        queryProfileResult: null,
       };
 
     case 'FIND_SIMILAR':
@@ -304,6 +316,20 @@ function vectorSearchReducer(
         muveraFlagsByVector: action.flags,
       };
 
+    case 'SET_QUERY_PROFILE_ENABLED':
+      return {
+        ...state,
+        queryProfileEnabled: action.enabled,
+        // Clear previous profile result when toggling
+        queryProfileResult: action.enabled ? state.queryProfileResult : null,
+      };
+
+    case 'SET_QUERY_PROFILE_RESULT':
+      return {
+        ...state,
+        queryProfileResult: action.result,
+      };
+
     default:
       return state;
   }
@@ -332,6 +358,9 @@ export interface VectorSearchContextActions {
   setVectorWeight: (vectorName: string, weight: number) => void;
   normalizeWeights: () => void;
   setMuveraFlags: (flags: Record<string, boolean>) => void;
+  // Query profiling actions
+  setQueryProfileEnabled: (enabled: boolean) => void;
+  setQueryProfileResult: (result: QueryProfile | null) => void;
 }
 
 // ============================================================================
@@ -426,6 +455,15 @@ export function VectorSearchProvider({ children }: VectorSearchProviderProps) {
 
       setMuveraFlags: (flags: Record<string, boolean>) => {
         dispatch({ type: 'SET_MUVERA_FLAGS', flags });
+      },
+
+      // Query profiling actions
+      setQueryProfileEnabled: (enabled: boolean) => {
+        dispatch({ type: 'SET_QUERY_PROFILE_ENABLED', enabled });
+      },
+
+      setQueryProfileResult: (result: QueryProfile | null) => {
+        dispatch({ type: 'SET_QUERY_PROFILE_RESULT', result });
       },
     }),
     []

--- a/src/data-explorer/webview/context/__tests__/VectorSearchContext.test.tsx
+++ b/src/data-explorer/webview/context/__tests__/VectorSearchContext.test.tsx
@@ -1030,4 +1030,136 @@ describe('VectorSearchContext', () => {
       expect(result.current.state.hasSearched).toBe(true);
     });
   });
+
+  describe('Query Profiling', () => {
+    test('query profiling is disabled by default', () => {
+      const { result } = renderHook(() => useVectorSearchContext(), { wrapper });
+
+      expect(result.current.state.queryProfileEnabled).toBe(false);
+      expect(result.current.state.queryProfileResult).toBeNull();
+    });
+
+    test('enables query profiling', () => {
+      const { result } = renderHook(() => useVectorSearchContext(), { wrapper });
+
+      act(() => {
+        result.current.actions.setQueryProfileEnabled(true);
+      });
+
+      expect(result.current.state.queryProfileEnabled).toBe(true);
+    });
+
+    test('disables query profiling and clears result', () => {
+      const { result } = renderHook(() => useVectorSearchContext(), { wrapper });
+
+      const mockProfile = {
+        shards: [
+          {
+            name: 'shard-1',
+            node: 'node-0',
+            searches: {
+              vector: { details: { total_took: '10ms' } },
+            },
+          },
+        ],
+      };
+
+      act(() => {
+        result.current.actions.setQueryProfileEnabled(true);
+        result.current.actions.setQueryProfileResult(mockProfile);
+      });
+
+      expect(result.current.state.queryProfileResult).toEqual(mockProfile);
+
+      act(() => {
+        result.current.actions.setQueryProfileEnabled(false);
+      });
+
+      expect(result.current.state.queryProfileEnabled).toBe(false);
+      expect(result.current.state.queryProfileResult).toBeNull();
+    });
+
+    test('stores query profile result', () => {
+      const { result } = renderHook(() => useVectorSearchContext(), { wrapper });
+
+      const mockProfile = {
+        shards: [
+          {
+            name: 'shard-1',
+            node: 'node-0',
+            searches: {
+              vector: {
+                details: {
+                  total_took: '48.2ms',
+                  vector_search_took: '8.4ms',
+                  objects_took: '36.8ms',
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      act(() => {
+        result.current.actions.setQueryProfileResult(mockProfile);
+      });
+
+      expect(result.current.state.queryProfileResult).toEqual(mockProfile);
+      expect(result.current.state.queryProfileResult!.shards).toHaveLength(1);
+      expect(result.current.state.queryProfileResult!.shards[0].searches.vector).toBeDefined();
+    });
+
+    test('clears query profile result on clearSearch', () => {
+      const { result } = renderHook(() => useVectorSearchContext(), { wrapper });
+
+      const mockProfile = {
+        shards: [
+          {
+            name: 'shard-1',
+            node: 'node-0',
+            searches: { vector: { details: { total_took: '5ms' } } },
+          },
+        ],
+      };
+
+      act(() => {
+        result.current.actions.setQueryProfileEnabled(true);
+        result.current.actions.setQueryProfileResult(mockProfile);
+      });
+
+      expect(result.current.state.queryProfileResult).toEqual(mockProfile);
+
+      act(() => {
+        result.current.actions.clearSearch();
+      });
+
+      expect(result.current.state.queryProfileResult).toBeNull();
+    });
+
+    test('resets query profiling state on collection change', () => {
+      const { result } = renderHook(() => useVectorSearchContext(), { wrapper });
+
+      const mockProfile = {
+        shards: [
+          {
+            name: 'shard-1',
+            node: 'node-0',
+            searches: { vector: { details: { total_took: '5ms' } } },
+          },
+        ],
+      };
+
+      act(() => {
+        result.current.actions.setQueryProfileEnabled(true);
+        result.current.actions.setQueryProfileResult(mockProfile);
+      });
+
+      act(() => {
+        result.current.actions.resetForCollectionChange();
+      });
+
+      expect(result.current.state.queryProfileEnabled).toBe(false);
+      expect(result.current.state.queryProfileResult).toBeNull();
+    });
+  });
 });

--- a/src/data-explorer/webview/context/__tests__/VectorSearchContext.test.tsx
+++ b/src/data-explorer/webview/context/__tests__/VectorSearchContext.test.tsx
@@ -1161,5 +1161,104 @@ describe('VectorSearchContext', () => {
       expect(result.current.state.queryProfileEnabled).toBe(false);
       expect(result.current.state.queryProfileResult).toBeNull();
     });
+
+    test('starting a new search clears the previous profile', () => {
+      const { result } = renderHook(() => useVectorSearchContext(), { wrapper });
+
+      const profileA = {
+        shards: [
+          {
+            name: 'shard-a',
+            node: 'node-0',
+            searches: { vector: { details: { total_took: '10ms' } } },
+          },
+        ],
+      };
+
+      // Simulate: search A completes with profile
+      act(() => {
+        result.current.actions.setQueryProfileEnabled(true);
+        result.current.actions.setQueryProfileResult(profileA);
+        result.current.actions.setSearchResults([]);
+      });
+
+      expect(result.current.state.queryProfileResult).toEqual(profileA);
+
+      // Simulate: search B starts
+      act(() => {
+        result.current.actions.setSearching(true);
+      });
+
+      // Profile A must be gone while B runs
+      expect(result.current.state.queryProfileResult).toBeNull();
+      expect(result.current.state.isSearching).toBe(true);
+    });
+
+    test('search error clears any retained profile', () => {
+      const { result } = renderHook(() => useVectorSearchContext(), { wrapper });
+
+      const profileA = {
+        shards: [
+          {
+            name: 'shard-a',
+            node: 'node-0',
+            searches: { vector: { details: { total_took: '10ms' } } },
+          },
+        ],
+      };
+
+      act(() => {
+        result.current.actions.setQueryProfileEnabled(true);
+        result.current.actions.setQueryProfileResult(profileA);
+      });
+
+      expect(result.current.state.queryProfileResult).toEqual(profileA);
+
+      // Simulate: next search fails
+      act(() => {
+        result.current.actions.setSearching(true);
+      });
+      act(() => {
+        result.current.actions.setSearchError('Connection lost');
+      });
+
+      expect(result.current.state.queryProfileResult).toBeNull();
+      expect(result.current.state.searchError).toBe('Connection lost');
+    });
+
+    test('response without profile data sets result to null, not stale data', () => {
+      const { result } = renderHook(() => useVectorSearchContext(), { wrapper });
+
+      const profileA = {
+        shards: [
+          {
+            name: 'shard-a',
+            node: 'node-0',
+            searches: { vector: { details: { total_took: '10ms' } } },
+          },
+        ],
+      };
+
+      act(() => {
+        result.current.actions.setQueryProfileEnabled(true);
+        result.current.actions.setQueryProfileResult(profileA);
+      });
+
+      // Simulate: new search starts (clears profile)
+      act(() => {
+        result.current.actions.setSearching(true);
+      });
+
+      expect(result.current.state.queryProfileResult).toBeNull();
+
+      // Simulate: response arrives without profile (profiling disabled for this query)
+      act(() => {
+        result.current.actions.setQueryProfileResult(null);
+        result.current.actions.setSearchResults([]);
+      });
+
+      // Must remain null, not revert to profileA
+      expect(result.current.state.queryProfileResult).toBeNull();
+    });
   });
 });

--- a/src/data-explorer/webview/hooks/useVectorSearch.ts
+++ b/src/data-explorer/webview/hooks/useVectorSearch.ts
@@ -130,10 +130,8 @@ export function useVectorSearch() {
 
       searchActions.setSearchResults(results);
 
-      // Store query profile result if present
-      if (queryProfile) {
-        searchActions.setQueryProfileResult(queryProfile);
-      }
+      // Always set profile result (null clears any stale data from a previous query)
+      searchActions.setQueryProfileResult(queryProfile ?? null);
     },
     [searchActions]
   );

--- a/src/data-explorer/webview/hooks/useVectorSearch.ts
+++ b/src/data-explorer/webview/hooks/useVectorSearch.ts
@@ -16,6 +16,7 @@ import type {
   WeaviateObject,
   ExtensionMessage,
   WeaviateExplainScoreRaw,
+  QueryProfile,
 } from '../../types';
 
 const isDevelopment = process.env.NODE_ENV === 'development';
@@ -104,8 +105,8 @@ export function useVectorSearch() {
 
   // Handle vector search response
   const handleSearchResponse = useCallback(
-    (objects: WeaviateObject[]) => {
-      debugLog('Response received', { count: objects.length });
+    (objects: WeaviateObject[], queryProfile?: QueryProfile) => {
+      debugLog('Response received', { count: objects.length, hasProfile: !!queryProfile });
       // Transform objects to VectorSearchResult format
       const results: VectorSearchResult[] = objects.map((obj) => {
         // Parse explainScore for hybrid search results
@@ -128,6 +129,11 @@ export function useVectorSearch() {
       });
 
       searchActions.setSearchResults(results);
+
+      // Store query profile result if present
+      if (queryProfile) {
+        searchActions.setQueryProfileResult(queryProfile);
+      }
     },
     [searchActions]
   );
@@ -160,7 +166,7 @@ export function useVectorSearch() {
       switch (message.command) {
         case 'objectsLoaded':
           if (message.objects) {
-            handleSearchResponse(message.objects);
+            handleSearchResponse(message.objects, message.queryProfile);
           } else {
             // Empty results
             searchActions.setSearchResults([]);
@@ -340,6 +346,7 @@ export function useVectorSearch() {
       limit: searchParams.limit,
       offset: 0,
       vectorSearch: vectorSearchPayload,
+      queryProfile: searchState.queryProfileEnabled || undefined,
       requestId,
     } as WebviewMessage & { vectorSearch: unknown });
   }, [searchState, searchActions, dataState.collectionName, postMessage]);

--- a/src/data-explorer/webview/utils/__tests__/versionCheck.test.ts
+++ b/src/data-explorer/webview/utils/__tests__/versionCheck.test.ts
@@ -1,0 +1,85 @@
+import {
+  parseVersion,
+  compareVersions,
+  isVersionAtLeast,
+  supportsQueryProfiling,
+  supportsMultiTargetNear,
+  supportsMultiTargetHybrid,
+  supportsMUVERA,
+} from '../versionCheck';
+
+describe('versionCheck', () => {
+  describe('parseVersion', () => {
+    test('parses standard version', () => {
+      expect(parseVersion('1.36.9')).toEqual([1, 36, 9]);
+    });
+
+    test('parses version with v prefix', () => {
+      expect(parseVersion('v1.37.0')).toEqual([1, 37, 0]);
+    });
+
+    test('parses version with pre-release suffix', () => {
+      expect(parseVersion('1.38.0-rc1')).toEqual([1, 38, 0]);
+    });
+
+    test('throws for invalid version', () => {
+      expect(() => parseVersion('invalid')).toThrow();
+      expect(() => parseVersion('')).toThrow();
+    });
+  });
+
+  describe('compareVersions', () => {
+    test('equal versions', () => {
+      expect(compareVersions([1, 36, 9], [1, 36, 9])).toBe(0);
+    });
+
+    test('less than', () => {
+      expect(compareVersions([1, 36, 8], [1, 36, 9])).toBe(-1);
+      expect(compareVersions([1, 35, 0], [1, 36, 0])).toBe(-1);
+    });
+
+    test('greater than', () => {
+      expect(compareVersions([1, 37, 0], [1, 36, 9])).toBe(1);
+      expect(compareVersions([2, 0, 0], [1, 99, 99])).toBe(1);
+    });
+  });
+
+  describe('supportsQueryProfiling', () => {
+    test('returns true for 1.36.9', () => {
+      expect(supportsQueryProfiling('1.36.9')).toBe(true);
+    });
+
+    test('returns true for versions above 1.36.9', () => {
+      expect(supportsQueryProfiling('1.37.0')).toBe(true);
+      expect(supportsQueryProfiling('1.38.0')).toBe(true);
+      expect(supportsQueryProfiling('2.0.0')).toBe(true);
+    });
+
+    test('returns false for versions below 1.36.9', () => {
+      expect(supportsQueryProfiling('1.36.8')).toBe(false);
+      expect(supportsQueryProfiling('1.35.0')).toBe(false);
+      expect(supportsQueryProfiling('1.30.0')).toBe(false);
+    });
+
+    test('returns false for invalid version', () => {
+      expect(supportsQueryProfiling('invalid')).toBe(false);
+    });
+  });
+
+  describe('existing version checks still work', () => {
+    test('supportsMultiTargetNear', () => {
+      expect(supportsMultiTargetNear('1.26.0')).toBe(true);
+      expect(supportsMultiTargetNear('1.25.0')).toBe(false);
+    });
+
+    test('supportsMultiTargetHybrid', () => {
+      expect(supportsMultiTargetHybrid('1.27.0')).toBe(true);
+      expect(supportsMultiTargetHybrid('1.26.0')).toBe(false);
+    });
+
+    test('supportsMUVERA', () => {
+      expect(supportsMUVERA('1.31.0')).toBe(true);
+      expect(supportsMUVERA('1.30.0')).toBe(false);
+    });
+  });
+});

--- a/src/data-explorer/webview/utils/versionCheck.ts
+++ b/src/data-explorer/webview/utils/versionCheck.ts
@@ -7,6 +7,7 @@
 export const MULTI_TARGET_NEAR_MIN = '1.26.0';
 export const MULTI_TARGET_HYBRID_MIN = '1.27.0';
 export const MUVERA_MIN = '1.31.0';
+export const QUERY_PROFILING_MIN = '1.36.9';
 
 /**
  * Parse a semantic version string into [major, minor, patch]
@@ -91,4 +92,12 @@ export function supportsMultiTargetHybrid(serverVersion: string): boolean {
  */
 export function supportsMUVERA(serverVersion: string): boolean {
   return isVersionAtLeast(serverVersion, 1, 31, 0);
+}
+
+/**
+ * Check if query profiling is supported
+ * Introduced in Weaviate v1.36.9, GA in v1.38
+ */
+export function supportsQueryProfiling(serverVersion: string): boolean {
+  return isVersionAtLeast(serverVersion, 1, 36, 9);
 }


### PR DESCRIPTION
## Summary

Adds support for Weaviate's [query profiling](https://weaviate.io/blog/query-profiling) API in the Data Explorer's Vector Search panel. When enabled, every search returns an inline per-shard timing breakdown visualized as an interactive waterfall panel.

Requires **Weaviate >= 1.36.9** (toggle is version-gated and only appears for compatible servers).

## What is new

### Query Profiling UI
- **"Profile query" toggle** in Vector Search > Search Parameters
- **QueryProfilePanel** below search results with:
  - Per-shard tabs (multi-shard collections) with node attribution
  - Collapsible search-type sections (Vector Search, Keyword/BM25, Object)
  - Color-coded timing waterfall bars: green < 33% | yellow 33-66% | red > 66%
  - HNSW per-layer breakdown, rescore timing, filter stats, flat-search badges
  - BM25 term/BMW scoring metrics for keyword searches

### Dependency upgrade
- `weaviate-client` v3.11.0 to **v3.14.0** (adds `returnMetadata: ['all', 'queryProfile']` API from [typescript-client PR #416](https://github.com/weaviate/typescript-client/pull/416))

## Files changed

| Area | Files |
|---|---|
| **Types** | `types/index.ts` (QueryProfile, ShardProfile, SearchProfile), `types/weaviate.ts` (metadata selection) |
| **API layer** | `DataExplorerAPI.ts` (queryProfile flag to returnMetadata), `DataExplorerPanel.ts` (relay) |
| **State** | `VectorSearchContext.tsx` (enabled + result state, actions, reducer) |
| **Hook** | `useVectorSearch.ts` (send flag, extract profile from response) |
| **UI** | `QueryProfilePanel.tsx` + `.css` (new), `VectorSearchPanel.tsx` (toggle + mount) |
| **Version gate** | `versionCheck.ts` (`supportsQueryProfiling`, min 1.36.9) |
| **Tests** | `QueryProfilePanel.test.tsx` (10), `VectorSearchContext.test.tsx` (+6), `versionCheck.test.ts` (12) |
| **Docs** | `CHANGELOG.md`, `README.md`, `site/changelog.md`, `site/features/data-explorer.md`, `src/data-explorer/README.md` |

## Verification

- webpack extension + webview bundles compile successfully
- ESLint: 0 errors
- Full test suite: **67 suites, 1798 tests pass** (0 failures)
- 28 new tests covering duration parsing, rendering, state management, version gating

## How to test

1. Connect to a Weaviate >= 1.36.9 instance
2. Open Data Explorer > Vector Search (`Ctrl+K`)
3. Check **"Profile query"** in Search Parameters
4. Run any search (text, hybrid, vector, or object)
5. See the **Query Profile** panel below results with timing breakdown
